### PR TITLE
Detect itch.io CSpect hdfmonkey on Linux/macOS; move Open config button

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2233,7 +2233,8 @@ class MainWindow(QMainWindow):
         self._cspect_from_downloads = False
 
         # Full path to a bundled hdfmonkey executable discovered under
-        # downloads/cspect (Windows only). None means "use the PATH/'hdfmonkey'
+        # downloads/cspect (Windows/Linux/macOS — the itch.io CSpect package
+        # ships a build per platform). None means "use the PATH/'hdfmonkey'
         # default". execute_hdf_monkey and _hdfmonkey_binary_found prefer it.
         self._hdfmonkey_executable_path = None
         # Set True while the async downloads/cspect scan is in flight so the
@@ -2454,7 +2455,6 @@ class MainWindow(QMainWindow):
             self.cspect_vsync.setDisabled(True)
             self.cspect_joystick.setDisabled(True)
             self.cspect_frequency.setDisabled(True)
-            self.button_open_config_file.setDisabled(True)
 
         def set_all_buttons_enabled():
             self.imageinput.setDisabled(False)
@@ -2477,7 +2477,6 @@ class MainWindow(QMainWindow):
             self.cspect_vsync.setDisabled(False)
             self.cspect_joystick.setDisabled(False)
             self.cspect_frequency.setDisabled(False)
-            self.button_open_config_file.setDisabled(False)
 
         def enable_image_selection():
             self.imageinput.setDisabled(False)
@@ -4166,6 +4165,25 @@ class MainWindow(QMainWindow):
                 exec_process = subprocess.run(argv, shell=False, check=True,
                                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                               **subprocess_no_window_kwargs())
+
+            except PermissionError as ex:
+                    # On Linux/macOS the itch.io CSpect bundle ships hdfmonkey
+                    # without its executable bit set, so the OS refuses to launch
+                    # it (EACCES / "Permission denied"). Surface that in the
+                    # SD-card log window with the exact fix and full path, rather
+                    # than letting it bubble up as an opaque failure.
+                    exec_process = subprocess.CompletedProcess(args=[hdfmonkey_exe], returncode=-1)
+                    if silent:
+                        logging.debug(f"hdfmonkey {command_to_execute} permission denied (silent): {execution_cmd} - {ex}")
+                    else:
+                        logging.error(f"Permission denied running hdfmonkey: {execution_cmd} - {ex}")
+                        add_main_log_window(f"ERROR: Permission denied running hdfmonkey: {hdfmonkey_exe}")
+                        if hdfmonkey_needs_exec_bit():
+                            cmd = hdfmonkey_chmod_instruction(hdfmonkey_exe)
+                            add_main_log_window(
+                                "The hdfmonkey provided by the CSpect itch.io package is not "
+                                "executable. Make it executable by running:")
+                            add_main_log_window(f"    {cmd}")
 
             except (FileNotFoundError,subprocess.CalledProcessError) as ex:
                     # If hdfmonkey can't actually be located, offer to install it
@@ -8168,14 +8186,8 @@ class MainWindow(QMainWindow):
 
         self.horizontal6.addWidget(self.cspect_frequency)
 
-        self.button_open_config_file = QPushButton("Open config file", self)
-        self.button_open_config_file.setText("Open config file")
-        self.button_open_config_file.clicked.connect(open_cspect_configuration_file)
-        self.horizontal6.addWidget(self.button_open_config_file)
-
         # Hide all CSpect controls when the CSpect emulator was not found at
-        # startup (application directory or PATH). The MAME button and the
-        # general "Open config file" button are unaffected.
+        # startup (application directory or PATH). The MAME button is unaffected.
         if self._cspect_executable_path is None:
             for _cspect_widget in (
                 self.button_start_cspect,
@@ -19323,6 +19335,14 @@ class MainWindow(QMainWindow):
             lambda _i: _settings_nextsync_send_conflict_changed())
         grid_tab_Settings.addWidget(self.settings_nextsync_send_conflict_combo, 2, 1)
 
+        # "Open config file" — moved here from the SD-card tab. Opens hdfg.cfg in
+        # the system text editor so advanced users can hand-edit settings. Placed
+        # at the bottom of the Settings tab, left-aligned so it keeps its natural
+        # width rather than stretching across both columns.
+        self.button_open_config_file = QPushButton("Open config file", self)
+        self.button_open_config_file.clicked.connect(open_cspect_configuration_file)
+        grid_tab_Settings.addWidget(self.button_open_config_file, 28, 0, 1, 2, Qt.AlignLeft)
+
         grid_tab_Settings.setColumnStretch(2, 1)
         zxnextunite_Settings_tab.setLayout(grid_tab_Settings)
         zxnextunite_Settings_tab.tab_name_private = "Settings"
@@ -19823,6 +19843,37 @@ class MainWindow(QMainWindow):
             if success and self.settings_warn_image_nearly_full_checkbox.isChecked():
                 _warn_if_image_nearly_full(self.right_disk_image_path)
 
+        def _notify_bundled_hdfmonkey(hdfmonkey_path):
+            """When a bundled itch.io hdfmonkey is adopted on Linux/macOS, warn
+            the user it must be made executable first — the freshly extracted
+            binary carries no executable bit, so running it as-is yields a
+            'Permission denied'. Logs the exact command (with full path) to the
+            SD-card log window and shows a toast. No-op on Windows, and skipped
+            once the user has already made the binary executable (so it does not
+            nag on every launch)."""
+            if not hdfmonkey_needs_exec_bit():
+                return
+            try:
+                if os.access(hdfmonkey_path, os.X_OK):
+                    return  # already executable — nothing to warn about
+            except Exception:
+                pass
+            cmd = hdfmonkey_chmod_instruction(hdfmonkey_path)
+            add_main_log_window(
+                "NOTE: The hdfmonkey bundled with the CSpect itch.io package is "
+                "not executable yet. If you get a 'Permission denied' error, "
+                "make it executable by running:")
+            add_main_log_window(f"    {cmd}")
+            self._show_toast(
+                "ℹ  Make hdfmonkey executable",
+                "The hdfmonkey bundled with the CSpect itch.io package needs its "
+                "executable bit set before it can run, otherwise you will get a "
+                "'Permission denied' error.\r\n\r\nRun this command in a "
+                f"terminal:\r\n{cmd}",
+                variant="yellow",
+                duration_ms=15000,
+            )
+
         _is_windows = platform.system() == "Windows"
         _hdfmonkey_present = is_hdfmonkey_present()
         _startup_load_started = False
@@ -19843,12 +19894,14 @@ class MainWindow(QMainWindow):
         # walk can be slow. The emulator-detection toast waits for the result;
         # when nothing needs scanning it fires on a short timer as before.
         _need_cspect = self._cspect_executable_path is None
-        _need_hdfmonkey = _is_windows and not _hdfmonkey_present
+        # hdfmonkey may be bundled with the itch.io CSpect package on every
+        # platform (Windows/Linux/macOS), so scan for it whenever it is missing.
+        _need_hdfmonkey = not _hdfmonkey_present
 
         # When CSpect was already found (manual install on PATH or the
-        # application directory) but hdfmonkey is still missing, CSpect ships
-        # hdfmonkey.exe alongside itself under hdfmonkey\windows-64 — pick that
-        # up directly. This is a couple of os.path.isfile checks, so it runs
+        # application directory) but hdfmonkey is still missing, CSpect ships an
+        # hdfmonkey build alongside itself under hdfmonkey/<platform>/ — pick
+        # that up directly. This is a couple of os.path.isfile checks, so it runs
         # synchronously here and saves the slower itch.io downloads scan below.
         if _need_hdfmonkey and self._cspect_executable_path:
             _near_hdfmonkey = find_hdfmonkey_near_cspect(self._cspect_executable_path)
@@ -19859,6 +19912,8 @@ class MainWindow(QMainWindow):
                 self.download_and_install_hdfmonkey_button.setVisible(False)
                 self.button_new_folder.setVisible(True)
                 self.button_delete_files.setVisible(True)
+                # On Linux/macOS the bundled binary needs +x before it will run.
+                _notify_bundled_hdfmonkey(_near_hdfmonkey)
                 if not _startup_load_started:
                     load_image(_warn_after_startup_load)
                     _startup_load_started = True
@@ -19889,6 +19944,8 @@ class MainWindow(QMainWindow):
                 self.download_and_install_hdfmonkey_button.setVisible(False)
                 self.button_new_folder.setVisible(True)
                 self.button_delete_files.setVisible(True)
+                # On Linux/macOS the bundled binary needs +x before it will run.
+                _notify_bundled_hdfmonkey(hdfmonkey_path)
                 # Load the image now if startup couldn't (hdfmonkey was missing).
                 if not _startup_load_started:
                     load_image(_warn_after_startup_load)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -547,9 +547,58 @@ HDFMONKEY_EXECUTABLE = "hdfmonkey"
 DOWNLOADS_CSPECT_DIRNAME = os.path.join("downloads", "itchio", "mdf200", "cspect")
 
 
+def hdfmonkey_bundle_subpaths():
+    """Return candidate ``(relative_subpath, exe_filename)`` pairs, in priority
+    order, where the itch.io CSpect bundle ships an hdfmonkey build runnable on
+    the *current* platform.
+
+    The itch.io CSpect package carries hdfmonkey builds for every platform side
+    by side under ``hdfmonkey/<platform>/``:
+
+        hdfmonkey/windows-64/hdfmonkey.exe   (Windows)
+        hdfmonkey/linux-musl/hdfmonkey       (Linux)
+        hdfmonkey/macos-intel/hdfmonkey      (macOS, Intel)
+        hdfmonkey/macos-mn/hdfmonkey         (macOS, Apple Silicon / "MN")
+
+    Because the Linux and both macOS builds all share the bare file name
+    ``hdfmonkey``, callers must match the full platform-specific *sub-path*
+    rather than the file name — otherwise a binary built for another OS could be
+    handed back. Returns an empty list on unrecognised platforms.
+    """
+    system = platform.system()
+    if system == "Windows":
+        exe = HDFMONKEY_EXECUTABLE + ".exe"
+        return [(os.path.join("hdfmonkey", "windows-64", exe), exe)]
+    exe = HDFMONKEY_EXECUTABLE
+    if system == "Linux":
+        return [(os.path.join("hdfmonkey", "linux-musl", exe), exe)]
+    if system == "Darwin":
+        machine = (platform.machine() or "").lower()
+        # Prefer the build native to this Mac; fall back to the other. Apple
+        # Silicon ("MN") can run the Intel binary through Rosetta 2, but an Intel
+        # Mac can never run the arm64 build, so order accordingly.
+        dirs = (["macos-mn", "macos-intel"]
+                if machine in ("arm64", "aarch64")
+                else ["macos-intel", "macos-mn"])
+        return [(os.path.join("hdfmonkey", d, exe), exe) for d in dirs]
+    return []
+
+
+def hdfmonkey_needs_exec_bit():
+    """True on Linux/macOS, where a freshly extracted itch.io hdfmonkey binary
+    has no executable permission bit and must be ``chmod +x`` before it runs."""
+    return platform.system() in ("Linux", "Darwin")
+
+
+def hdfmonkey_chmod_instruction(hdfmonkey_path):
+    """The exact shell command the user must run to make a bundled itch.io
+    hdfmonkey executable. The path is quoted so spaces are handled."""
+    return f'sudo chmod +x "{hdfmonkey_path}"'
+
+
 def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonkey=True):
-    """Recursively search ``<base_dir>/downloads/cspect`` for a CSpect.exe and,
-    on Windows only, a bundled hdfmonkey executable.
+    """Recursively search ``<base_dir>/downloads/cspect`` for a CSpect.exe and a
+    bundled hdfmonkey executable built for the current platform.
 
     Returns ``(cspect_path, hdfmonkey_path)`` where each element is the full path
     to the first matching executable found, or ``None`` if not found / not
@@ -557,63 +606,84 @@ def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonk
     application directory or on PATH — itch.io CSpect installs land under
     ``downloads/cspect`` (optionally in a per-version sub-folder).
 
-    The hdfmonkey search is Windows-only: on Linux/macOS hdfmonkey is installed
-    manually via ``make`` and is not shipped with CSpect, so ``scan_for_hdfmonkey``
-    is ignored there. The walk is potentially slow (many files), so callers run
-    it on a background thread.
+    The hdfmonkey search now covers Windows, Linux and macOS (Intel + Apple
+    Silicon): the itch.io CSpect package ships an hdfmonkey build for each of
+    these under ``hdfmonkey/<platform>/`` (see ``hdfmonkey_bundle_subpaths``).
+    The walk is potentially slow (many files), so callers run it on a background
+    thread.
     """
     search_root = os.path.join(base_dir, DOWNLOADS_CSPECT_DIRNAME)
     if not os.path.isdir(search_root):
         return (None, None)
 
-    is_windows = platform.system() == "Windows"
     want_cspect = bool(scan_for_cspect)
-    want_hdfmonkey = bool(scan_for_hdfmonkey) and is_windows
+    want_hdfmonkey = bool(scan_for_hdfmonkey)
 
     cspect_target = (CSPECT_EXECUTABLE_NAME + ".exe").lower()
-    # hdfmonkey discovery is Windows-only (see want_hdfmonkey above), so only
-    # accept the Windows executable. CSpect bundles ship hdfmonkey for several
-    # platforms side by side (e.g. hdfmonkey/linux-musl/hdfmonkey alongside
-    # hdfmonkey/windows-64/hdfmonkey.exe); matching the extension-less Linux
-    # binary would hand back an ELF that cannot run on Windows.
-    hdf_target = (HDFMONKEY_EXECUTABLE + ".exe").lower()
+    # Platform-specific bundle locations for hdfmonkey, in priority order. We
+    # match the full sub-path (e.g. .../hdfmonkey/linux-musl/hdfmonkey) rather
+    # than the bare file name: on Linux/macOS the bundle ships several same-named
+    # "hdfmonkey" binaries (one per platform) and only the one under the matching
+    # platform folder can actually run here.
+    hdf_candidates = hdfmonkey_bundle_subpaths() if want_hdfmonkey else []
+    want_hdfmonkey = want_hdfmonkey and bool(hdf_candidates)
+    # (path-suffix, priority rank) pairs; a leading separator anchors the match
+    # to whole path components.
+    hdf_suffixes = [(os.sep + sp.lower(), rank)
+                    for rank, (sp, _exe) in enumerate(hdf_candidates)]
 
     cspect_path = None
     hdfmonkey_path = None
+    hdf_best_rank = None  # priority rank of the best hdfmonkey match so far
     for dirpath, _dirnames, filenames in os.walk(search_root):
         for filename in filenames:
             low = filename.lower()
             if want_cspect and cspect_path is None and low == cspect_target:
                 cspect_path = os.path.join(dirpath, filename)
-            elif want_hdfmonkey and hdfmonkey_path is None and low == hdf_target:
-                hdfmonkey_path = os.path.join(dirpath, filename)
-        if (not want_cspect or cspect_path is not None) and \
-           (not want_hdfmonkey or hdfmonkey_path is not None):
+                continue
+            # Keep looking for hdfmonkey until the top-priority (rank 0) build is
+            # found, so a native build wins over a lower-priority fallback.
+            if want_hdfmonkey and (hdf_best_rank is None or hdf_best_rank > 0):
+                full = os.path.join(dirpath, filename)
+                full_low = full.lower()
+                for suffix, rank in hdf_suffixes:
+                    if full_low.endswith(suffix) and \
+                       (hdf_best_rank is None or rank < hdf_best_rank):
+                        hdfmonkey_path = full
+                        hdf_best_rank = rank
+                        break
+        cspect_done = (not want_cspect) or cspect_path is not None
+        hdf_done = (not want_hdfmonkey) or hdf_best_rank == 0
+        if cspect_done and hdf_done:
             break  # everything we were asked to find has been located
     return (cspect_path, hdfmonkey_path)
 
 
 def find_hdfmonkey_near_cspect(cspect_path):
-    """On Windows, locate an ``hdfmonkey.exe`` shipped alongside a manually
-    installed CSpect.
+    """Locate an hdfmonkey executable shipped alongside a manually installed
+    CSpect, for the current platform.
 
-    CSpect distributions bundle the Windows hdfmonkey build under
-    ``hdfmonkey\\windows-64\\hdfmonkey.exe`` next to ``CSpect.exe`` (and a copy
-    is sometimes placed directly beside it). So when CSpect was found on PATH or
-    in the application directory but hdfmonkey is otherwise missing, this picks
-    up that bundled copy without needing the itch.io downloads scan.
+    CSpect distributions bundle hdfmonkey under
+    ``hdfmonkey/<platform>/hdfmonkey[.exe]`` next to the CSpect executable (and a
+    copy is sometimes placed directly beside it). So when CSpect was found on
+    PATH or in the application directory but hdfmonkey is otherwise missing, this
+    picks up that bundled copy without needing the itch.io downloads scan. The
+    platform-specific sub-folders (windows-64 / linux-musl / macos-intel /
+    macos-mn) come from ``hdfmonkey_bundle_subpaths``.
 
-    Returns the full path to the executable, or ``None`` when not on Windows,
-    when ``cspect_path`` is falsy, or when no copy is found.
+    Returns the full path to the executable, or ``None`` when ``cspect_path`` is
+    falsy or when no copy is found for this platform.
     """
-    if not cspect_path or platform.system() != "Windows":
+    if not cspect_path:
         return None
     cspect_dir = os.path.dirname(os.path.abspath(cspect_path))
-    exe = HDFMONKEY_EXECUTABLE + ".exe"
-    for candidate in (
-        os.path.join(cspect_dir, "hdfmonkey", "windows-64", exe),
-        os.path.join(cspect_dir, exe),
-    ):
+    # Platform-specific bundle locations first (in priority order)...
+    candidates = [os.path.join(cspect_dir, subpath)
+                  for subpath, _exe in hdfmonkey_bundle_subpaths()]
+    # ...then the binary dropped directly beside CSpect (some manual installs).
+    exe = HDFMONKEY_EXECUTABLE + (".exe" if platform.system() == "Windows" else "")
+    candidates.append(os.path.join(cspect_dir, exe))
+    for candidate in candidates:
         if os.path.isfile(candidate):
             return candidate
     return None


### PR DESCRIPTION
Extend bundled-hdfmonkey detection (from the itch.io CSpect package) beyond Windows to Linux and macOS (Intel + Apple Silicon):

- Add hdfmonkey_bundle_subpaths(): per-platform bundle locations (windows-64 / linux-musl / macos-intel / macos-mn), preferring the native macOS build with an Intel fallback for Apple Silicon.
- find_emulators_in_downloads() and find_hdfmonkey_near_cspect() now match the full platform sub-path instead of the bare filename, so a binary built for another OS is never picked up; scanning is no longer Windows-only.
- On Linux/macOS, warn the user (log window + toast) that the extracted binary needs "sudo chmod +x <full path>"; the toast self-silences once the file is executable.
- execute_hdf_monkey() now catches PermissionError (EACCES) and logs the Permission denied error plus the chmod fix with the full path.

Also move the "Open config file" button from the SD Card Utility tab to the bottom of the Settings tab.