### PR TITLE
Fix SyntaxError: escape backslash in C:\upx docstring build command

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -51,7 +51,7 @@
     To update embedded images use: pyside6-rcc rc_backgrounds.qrc -o rc_backgrounds.py
 
     pip install pyinstaller
-    pyinstaller --onefile --windowed --upx-dir C:\upx --collect-all itch_dl --collect-all bs4 zx-next-unite.py
+    pyinstaller --onefile --windowed --upx-dir C:\\upx --collect-all itch_dl --collect-all bs4 zx-next-unite.py
     pyinstaller --onefile --windowed --upx-dir C:\\upx zx-next-unite.py
     pyinstaller --onefile --windowed --noupx zx-next-unite.py
 """


### PR DESCRIPTION
The packaging command added to the module docstring used a single backslash (C:\upx). Inside a regular triple-quoted docstring, \u starts a Unicode escape, so Python raised "truncated \uXXXX escape" and the app would not start. Escape it (C:\upx) to match the existing upx-dir line below it.