### PR TITLE
Auto-fix exec bit on bundled Linux/macOS hdfmonkey

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -4155,6 +4155,12 @@ class MainWindow(QMainWindow):
             # (Windows only); otherwise fall back to the PATH/"hdfmonkey" default.
             hdfmonkey_exe = getattr(self, "_hdfmonkey_executable_path", None) or HDFMONKEY_EXECUTABLE
             execution_cmd = f'{hdfmonkey_exe} {command_to_execute} {image_path} {additional_args}'
+            # On Linux/macOS the itch.io CSpect bundle ships hdfmonkey without
+            # its executable bit set, so the OS would refuse to launch it
+            # (EACCES). Add the bit ourselves (the binary is in the user's own
+            # downloads dir, no sudo needed) so it runs like a manually compiled
+            # build. No-op on Windows / for the bare "hdfmonkey" PATH default.
+            ensure_hdfmonkey_executable(hdfmonkey_exe)
             try:
                 img = image_path.strip('"')
                 argv = [hdfmonkey_exe, command_to_execute, img]
@@ -4168,11 +4174,11 @@ class MainWindow(QMainWindow):
                                               **subprocess_no_window_kwargs())
 
             except PermissionError as ex:
-                    # On Linux/macOS the itch.io CSpect bundle ships hdfmonkey
-                    # without its executable bit set, so the OS refuses to launch
-                    # it (EACCES / "Permission denied"). Surface that in the
-                    # SD-card log window with the exact fix and full path, rather
-                    # than letting it bubble up as an opaque failure.
+                    # The proactive chmod above couldn't make the bundled
+                    # hdfmonkey executable (e.g. read-only filesystem or a file
+                    # the user doesn't own). Surface that in the SD-card log
+                    # window with the exact fix and full path, rather than
+                    # letting it bubble up as an opaque failure.
                     exec_process = subprocess.CompletedProcess(args=[hdfmonkey_exe], returncode=-1)
                     if silent:
                         logging.debug(f"hdfmonkey {command_to_execute} permission denied (silent): {execution_cmd} - {ex}")

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -596,6 +596,32 @@ def hdfmonkey_chmod_instruction(hdfmonkey_path):
     return f'sudo chmod +x "{hdfmonkey_path}"'
 
 
+def ensure_hdfmonkey_executable(hdfmonkey_path):
+    """On Linux/macOS, make a bundled hdfmonkey binary executable if it isn't
+    already, so it launches like a manually compiled build instead of failing
+    with EACCES ("Permission denied").
+
+    The itch.io CSpect package ships the Linux/macOS hdfmonkey without its
+    executable permission bit. The binary lives under the user's own downloads
+    directory, so a plain ``os.chmod`` (no sudo) is enough to add the bits.
+
+    Returns True if the file is (now) executable, False on any failure. No-op
+    that returns True on Windows; returns False for the bare ``hdfmonkey`` PATH
+    default (not a real file) so callers don't assume a fix was applied."""
+    if not hdfmonkey_needs_exec_bit():
+        return True
+    if not hdfmonkey_path or not os.path.isfile(hdfmonkey_path):
+        return False
+    try:
+        mode = os.stat(hdfmonkey_path).st_mode
+        if mode & 0o111:
+            return True  # already executable
+        os.chmod(hdfmonkey_path, mode | 0o111)
+        return True
+    except OSError:
+        return False
+
+
 def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonkey=True):
     """Recursively search ``<base_dir>/downloads/cspect`` for a CSpect.exe and a
     bundled hdfmonkey executable built for the current platform.


### PR DESCRIPTION
The itch.io CSpect package ships the Linux/macOS hdfmonkey binary without its executable permission bit, so the app failed to launch it with EACCES ("Permission denied") and could only list/read disk images after the user manually ran `chmod +x`. A self-compiled hdfmonkey worked because it lands executable.

Add ensure_hdfmonkey_executable() in zxnu_config.py and call it before every hdfmonkey invocation in execute_hdf_monkey(). It adds the exec bits via a plain os.chmod (no sudo needed — the binary lives in the user's own downloads dir). No-op on Windows and for the bare "hdfmonkey" PATH default. The existing PermissionError handler stays as a fallback for the read-only / not-owned case.