### PR TITLE
SD Card: default CSpect screen size to X3 + fix bundled itch.io -mmc path

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -3234,12 +3234,22 @@ class MainWindow(QMainWindow):
                 cspect_exe = getattr(self, "_cspect_executable_path", None)
                 use_bundled = (getattr(self, "_cspect_from_downloads", False)
                                and cspect_exe and os.path.isfile(cspect_exe))
+                # The image path may be stored with surrounding quotes (kept so
+                # spaces survive the shell). Strip them before any os.path work:
+                # os.path.abspath() on a string starting with '"' treats it as a
+                # relative path and prepends the cwd, yielding a bogus value like
+                # <cwd>\"C:\temp\img". Re-quote only the final path below.
+                img_path = (self.right_disk_image_path or "").strip().strip('"')
                 if use_bundled:
+                    # CSpect runs from its own folder so its Next ROMs resolve;
+                    # the working dir then differs from the app dir, so the image
+                    # path must be absolute.
                     cspect_cwd = os.path.dirname(cspect_exe)
-                    mmc_path = os.path.abspath(self.right_disk_image_path) if self.right_disk_image_path else self.right_disk_image_path
+                    if img_path:
+                        img_path = os.path.abspath(img_path)
                 else:
                     cspect_cwd = None
-                    mmc_path = self.right_disk_image_path
+                mmc_path = f'"{img_path}"' if img_path else img_path
 
                 cspect_arguments += " -mmc=" + mmc_path + " "
 


### PR DESCRIPTION
## What changed

Two SD Card Utility / CSpect launch fixes:

1. **Default CSpect screen size to X3 on first run.** With no `hdfg.cfg` present, the screen-size combo kept its natural index-0 default ("Screen Size X1"). It now defaults to "Screen Size X3" at combo creation (set before the `currentIndexChanged` signal is connected, so it doesn't trigger a spurious config save). A saved configuration still overrides it in `load_configuration_file()`, and the index is looked up from `CSPECT_SCREEN_SIZES` by label so it survives any reordering of that table.

2. **Fix bogus `-mmc` path when launching a bundled itch.io CSpect.** The disk-image path is stored with surrounding quotes (so spaces survive the shell). For a bundled itch.io CSpect — which is launched from its own folder so its Next ROMs resolve — the quoted path was passed straight to `os.path.abspath()`. A string starting with `"` is treated as relative, so `abspath` prepended the current working directory, producing e.g.:

   ```
   -mmc=C:\Users\...\dist\ho\"C:\temp\cspect-next-8gb.img"
   ```

   The fix strips the surrounding quotes before any `os.path` manipulation, makes the path absolute (bundled case only), then re-quotes the final value:

   ```
   -mmc="C:\temp\cspect-next-8gb.img"
   ```

## Why

- New users got a tiny X1 window by default; X3 is a far more usable first-run size.
- The `-mmc` bug made CSpect fail to mount the selected image whenever CSpect came from an itch.io install (the common path for new users), since the generated path was invalid.

## Reviewer notes

- The non-bundled launch path is now always quoted too — harmless for paths without spaces, and correct for paths that contain them.
- Both changes are confined to `zx-next-unite.py`; no behavior change for users who already have a saved config (their stored screen size is still honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)