### PR TITLE
itch.io gallery: show "Installed" badge on locally-downloaded items

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -16861,6 +16861,37 @@ class MainWindow(QMainWindow):
                 pass
             return d
 
+        # Cache of normalised install-folder names, so the gallery can flag
+        # every locally-downloaded cell without re-walking the downloads tree
+        # per item. Invalidated (set to None) whenever an install/uninstall
+        # changes what's on disk; rebuilt lazily on the next lookup.
+        self._itchio_installed_names_cache = None
+
+        def _itchio_installed_names():
+            if self._itchio_installed_names_cache is None:
+                try:
+                    self._itchio_installed_names_cache = (
+                        zxnu_itchio.installed_dir_names(_itchio_downloads_dir()))
+                except Exception:
+                    self._itchio_installed_names_cache = set()
+            return self._itchio_installed_names_cache
+
+        def _itchio_is_installed(entry):
+            try:
+                return zxnu_itchio.entry_installed(entry, _itchio_installed_names())
+            except Exception:
+                return False
+
+        def _itchio_mark_local_state_changed():
+            """Forget the cached install scan and re-flag the gallery cells so
+            the 'Installed' badges reflect a fresh install/uninstall."""
+            self._itchio_installed_names_cache = None
+            try:
+                self.itchio_gallery_view.refresh_installed_overlays()
+            except Exception:
+                pass
+        self._itchio_mark_local_state_changed = _itchio_mark_local_state_changed
+
         if zxnu_itchio.itchdl_available()[0]:
             zxnextunite_itchio_tab = QWidget(wid_inner.tab)
             zxnextunite_itchio_tab.setAttribute(Qt.WA_TranslucentBackground)
@@ -17044,6 +17075,7 @@ class MainWindow(QMainWindow):
                 info_getter=_itchio_info_getter,
                 source_label_getter=lambda _e: "itch.io",
                 source_overlay_anchor="bottomleft",
+                installed_getter=_itchio_is_installed,
                 is_favorite_cb=lambda e: self._fav_is({**e, "_fav_source": "itchio"}),
                 toggle_favorite_cb=lambda e: self._fav_toggle({**e, "_fav_source": "itchio"}),
             )
@@ -17107,6 +17139,9 @@ class MainWindow(QMainWindow):
             def _itchio_populate(entries):
                 """Render results into both the gallery and the table views."""
                 self._itchio_last_entries = list(entries)
+                # Re-scan local installs so the "Installed" badges are accurate
+                # for this fresh batch (cheap: one bounded walk, then cached).
+                self._itchio_installed_names_cache = None
                 self.itchio_gallery_view.populate(entries)
                 _itchio_fill_table(entries)
             self._itchio_populate = _itchio_populate
@@ -17463,6 +17498,7 @@ class MainWindow(QMainWindow):
                         # Post-install setup: extract any bundled .zip (CSpect
                         # builds and similar ship as archives under ``files``).
                         if ok:
+                            _itchio_mark_local_state_changed()
                             _itchio_run_setup_extract(_e)
                     def _err(e, _v=_viewer):
                         _itchio_set_status(f"Install failed: {e}")
@@ -17507,6 +17543,7 @@ class MainWindow(QMainWindow):
                         except RuntimeError: pass
                         _itchio_set_status(f"Uninstalled “{title}”.")
                         _itchio_refresh_install_buttons(_v, False)
+                        _itchio_mark_local_state_changed()
                         try:
                             _v.refresh_meta(
                                 title, base_rows + [("Status:", _status_text(False))])

--- a/zxnu_gallery.py
+++ b/zxnu_gallery.py
@@ -43,7 +43,8 @@ class GalleryCell(QFrame):
                  tags=None, parent=None,
                  is_favorite_cb=None, toggle_favorite_cb=None,
                  source_label_getter=None,
-                 source_overlay_anchor="topleft"):
+                 source_overlay_anchor="topleft",
+                 installed_getter=None):
         super().__init__(parent)
         if tooltip_text:
             self.setToolTip(tooltip_text)
@@ -56,6 +57,10 @@ class GalleryCell(QFrame):
         self._toggle_favorite_cb = toggle_favorite_cb
         self._source_label_getter = source_label_getter
         self._source_overlay_anchor = source_overlay_anchor or "topleft"
+        # Optional callable(entry) -> bool. When it returns True a green
+        # "Installed" badge is shown at the bottom-left of the thumbnail (used
+        # by the itch.io gallery to flag locally-downloaded packages).
+        self._installed_getter = installed_getter
         self._screenshots = []        # list of URL strings (or dicts {"url": ...})
         self._shot_cache  = {}        # url -> QPixmap
         self._shot_index  = 0
@@ -145,6 +150,17 @@ class GalleryCell(QFrame):
         self._source_overlay.setTextFormat(Qt.RichText)
         self._source_overlay.setStyleSheet("background: transparent;")
         self._source_overlay.setVisible(False)
+
+        # "Installed" badge (bottom-left of thumbnail).  Flags items that are
+        # already downloaded locally (itch.io gallery).  Hidden unless an
+        # installed_getter is wired and reports True for this entry.
+        self._installed_overlay = QLabel(self._thumb_lbl)
+        self._installed_overlay.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self._installed_overlay.setAlignment(Qt.AlignBottom | Qt.AlignLeft)
+        self._installed_overlay.setTextFormat(Qt.RichText)
+        self._installed_overlay.setStyleSheet("background: transparent;")
+        self._installed_overlay.setVisible(False)
+        self._refresh_installed_overlay()
         self._refresh_source_overlay()
         self._refresh_heart()
 
@@ -344,6 +360,11 @@ class GalleryCell(QFrame):
         if anchor == "bottomleft":
             x = pad
             y = self._thumb_lbl.height() - h - pad
+            # Stack above the "Installed" badge (which also hugs bottom-left)
+            # so the two chips don't overlap.
+            inst = getattr(self, "_installed_overlay", None)
+            if inst is not None and inst.isVisible():
+                y -= inst.sizeHint().height() + 2
         elif anchor == "bottomright":
             # Sit to the left of the heart button (which is anchored bottom-
             # right) if one is shown, otherwise hug the right edge.
@@ -358,6 +379,53 @@ class GalleryCell(QFrame):
             y = pad
         ov.setGeometry(x, y, w, h)
         ov.raise_()
+
+    def _refresh_installed_overlay(self):
+        ov = getattr(self, "_installed_overlay", None)
+        if ov is None:
+            return
+        getter = self._installed_getter
+        installed = False
+        if getter is not None:
+            try:
+                installed = bool(getter(self._entry))
+            except Exception:
+                installed = False
+        if not installed:
+            ov.setVisible(False)
+            ov.setText("")
+            self._position_source_overlay()
+            return
+        chip_css = (
+            "background:#1f5c2e;color:#c8ffd4;border:1px solid #3da35a;"
+            "border-radius:3px;padding:1px 6px;margin:1px 2px;"
+            "font-size:9pt;font-weight:600;"
+        )
+        ov.setText(f"<div style='text-align:left;'>"
+                   f"<span style='{chip_css}'>Installed</span></div>")
+        ov.setVisible(True)
+        self._position_installed_overlay()
+        # Keep the bottom-left source chip stacked above this badge.
+        self._position_source_overlay()
+
+    def _position_installed_overlay(self):
+        ov = getattr(self, "_installed_overlay", None)
+        if ov is None or not ov.isVisible():
+            return
+        pad = 4
+        ov.adjustSize()
+        w = min(ov.width(), max(40, self._thumb_lbl.width() - 2 * pad))
+        h = ov.sizeHint().height()
+        x = pad
+        y = self._thumb_lbl.height() - h - pad
+        ov.setGeometry(x, y, w, h)
+        ov.raise_()
+
+    def refresh_installed(self):
+        """Re-evaluate the installed_getter and show/hide the 'Installed'
+        badge.  Called by the parent view after an install/uninstall so the
+        gallery reflects the new local state without a full re-populate."""
+        self._refresh_installed_overlay()
 
     def _refresh_heart(self):
         btn = getattr(self, "_heart_btn", None)
@@ -541,6 +609,7 @@ class GalleryCell(QFrame):
         if cur is not None:
             self._apply_pixmap(cur)
         self._position_tag_overlay()
+        self._position_installed_overlay()
         self._position_source_overlay()
         self._position_heart()
         super().resizeEvent(ev)
@@ -860,6 +929,7 @@ class GalleryCell(QFrame):
         except Exception:
             pass
         self._position_tag_overlay()
+        self._position_installed_overlay()
         self._position_source_overlay()
         self._position_heart()
 
@@ -884,6 +954,7 @@ class GalleryCell(QFrame):
         self._thumb_lbl.setPixmap(scaled)
         self._thumb_lbl.setText("")
         self._position_tag_overlay()
+        self._position_installed_overlay()
         self._position_source_overlay()
         self._position_heart()
         # A pixmap was successfully applied: mark the cell loaded so the
@@ -931,7 +1002,7 @@ class GalleryView(QWidget):
                  is_favorite_cb=None, toggle_favorite_cb=None,
                  source_label_getter=None, tooltip_getter=None,
                  cols_getter=None, img_size_getter=None, parent=None,
-                 source_overlay_anchor="topleft"):
+                 source_overlay_anchor="topleft", installed_getter=None):
         super().__init__(parent)
         self._rows_per_page_getter = rows_per_page_getter
         self._anim_mode_getter     = anim_mode_getter
@@ -948,6 +1019,7 @@ class GalleryView(QWidget):
         self._toggle_favorite_cb   = toggle_favorite_cb
         self._source_label_getter  = source_label_getter
         self._source_overlay_anchor = source_overlay_anchor or "topleft"
+        self._installed_getter      = installed_getter
         # Optional predicate(entry) -> bool returning True when the entry
         # is known to have at least one image at populate-time.  Entries
         # for which the predicate returns False are moved to the end of
@@ -1034,6 +1106,18 @@ class GalleryView(QWidget):
         for cell in self._cells:
             try:
                 cell.set_gif_fetch_cb(cb)
+            except Exception:
+                pass
+
+    def refresh_installed_overlays(self):
+        """Re-evaluate every visible cell's installed_getter so the 'Installed'
+        badge appears/disappears after an install or uninstall, without a full
+        re-populate.  No-op when no installed_getter is wired."""
+        if self._installed_getter is None:
+            return
+        for cell in self._cells:
+            try:
+                cell.refresh_installed()
             except Exception:
                 pass
 
@@ -1242,6 +1326,7 @@ class GalleryView(QWidget):
                 toggle_favorite_cb=self._toggle_favorite_cb,
                 source_label_getter=self._source_label_getter,
                 source_overlay_anchor=self._source_overlay_anchor,
+                installed_getter=self._installed_getter,
             )
             # Wire the gif fetcher before the cell's deferred initial fetch
             # runs so .gif thumbnails take the QMovie animation path.

--- a/zxnu_itchio.py
+++ b/zxnu_itchio.py
@@ -497,6 +497,46 @@ def installed_status(game, dest_dir):
     return installed_path(game, dest_dir) is not None
 
 
+def installed_dir_names(dest_dir):
+    """Return the set of normalised directory names found under *dest_dir*
+    (same depth-limited walk and normalisation as :func:`installed_path`).
+
+    Computed once and matched against many games with :func:`entry_installed`,
+    this lets a gallery flag every installed cell without re-walking the
+    downloads tree per item."""
+    names = set()
+    if not dest_dir or not os.path.isdir(dest_dir):
+        return names
+    try:
+        for root, dirs, _files in os.walk(dest_dir):
+            depth = root[len(dest_dir):].count(os.sep)
+            if depth >= 3:
+                dirs[:] = []
+                continue
+            for d in dirs:
+                names.add(re.sub(r"[^a-z0-9]+", "-", d.lower()).strip("-"))
+    except Exception:
+        return names
+    return names
+
+
+def entry_installed(game, dir_names):
+    """True when *game* matches one of the pre-scanned *dir_names* (from
+    :func:`installed_dir_names`). Mirrors :func:`installed_path`'s slug/title
+    matching, but against a cached name set instead of a fresh disk walk."""
+    if not dir_names:
+        return False
+    slug = _game_slug(game).lower()
+    title = re.sub(r"[^a-z0-9]+", "-", ((game or {}).get("title") or "").lower()).strip("-")
+    wanted = {s for s in (slug, title) if s}
+    if not wanted:
+        return False
+    for norm in dir_names:
+        if norm in wanted or any(w and w in norm for w in wanted):
+            return True
+    return False
+
+
 # ── post-install zip extraction ────────────────────────────────────────────
 #
 # itch-dl lays a downloaded item's payload out under a ``files`` directory. Some


### PR DESCRIPTION
- Add a green "Installed" overlay at the bottom-left of itch.io gallery thumbnails for packages already downloaded locally, stacking the existing "itch.io" source chip above it so they don't overlap.
- GalleryCell/GalleryView gain an installed_getter and refresh_installed hooks so badges update after an install/uninstall without a re-populate.
- zxnu_itchio: installed_dir_names() + entry_installed() give a cached scan so every cell is flagged from one bounded downloads walk, not per item.