### PR TITLE
Gallery: add "None" animation mode and fix item-viewer/thumbnail blin…

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -1034,10 +1034,15 @@ def zxdb_parse_game_detail(payload) -> dict:
         if not u:
             return ""
         if u.startswith("/"):
-            # ZXInfo serves screen/asset paths under https://zxinfo.dk/media.
-            # The older spectrumcomputing.co.uk host returns 404 for these
-            # relative paths (e.g. /zxscreens/0037705/0037705-load-1.png).
-            return "https://zxinfo.dk/media" + u
+            # ZXInfo hosts its own *rendered* screen images (/zxscreens/…) under
+            # https://zxinfo.dk/media, but the raw archive paths it references
+            # for screen dumps (.scr) and downloads — /pub/… and /zxdb/… — are
+            # NOT on zxinfo.dk/media (they 404 there); they live on the
+            # spectrumcomputing.co.uk mirror. Route each to the host that serves
+            # it, otherwise e.g. a .scr loading screen never renders.
+            if u.lower().startswith("/zxscreens/"):
+                return "https://zxinfo.dk/media" + u
+            return "https://spectrumcomputing.co.uk" + u
         return u
 
     # Gather candidate "asset" lists from top-level AND from each release.
@@ -1080,19 +1085,54 @@ def zxdb_parse_game_detail(payload) -> dict:
             if url in seen_urls:
                 continue
             # Deduplicate the same screen offered in multiple formats (e.g. a
-            # PNG screenshot plus its raw .scr screen dump). Key on the base
-            # filename without extension; keep the web-renderable raster
-            # version (.png/.gif/.jpg…) over a .scr that the viewer cannot
-            # display.
+            # PNG screenshot, an animated GIF and its raw .scr screen dump). Key
+            # on the base filename without extension and keep the best format.
+            #
+            # Preference (lower = better): static web raster (.png/.jpg/.bmp) is
+            # ideal; then the native .scr screen dump (the viewer decodes it
+            # crisply); then .gif LAST — a ZX loading screen offered as a GIF is
+            # usually animated (the FLASH effect), so its static .scr twin is
+            # preferred over a flickering GIF.
+            def _fmt_priority(e):
+                e = (e or "").lower()
+                if e in (".png", ".jpg", ".jpeg", ".bmp"):
+                    return 0
+                if e == ".scr":
+                    return 1
+                if e == ".gif":
+                    return 2
+                return 3
             base = os.path.basename(ulow)
             stem, ext = os.path.splitext(base)
-            prev_idx = seen_stems.get(stem)
+            # Dedup key = (screen kind, normalised stem). Including the kind
+            # stops two *different* screens that happen to share a base name
+            # (e.g. a "Running" GIF and a "Loading" SCR both named
+            # "BattleShips_2") from being merged. Normalising the stem — dropping
+            # a trailing -load/-run/… qualifier — lets the *same* screen offered
+            # under slightly different names ("BattleShips_2-load.gif" vs
+            # "BattleShips_2.scr") collapse into a single entry, so its best
+            # format wins instead of both appearing.
+            def _screen_kind(tt):
+                tt = (tt or "").lower()
+                if "load" in tt:  return "loading"
+                if "run" in tt:   return "running"
+                if "inlay" in tt or "cover" in tt or "box" in tt: return "inlay"
+                if "map" in tt:   return "map"
+                return "screen"
+            def _norm_stem(s):
+                s = s.lower()
+                for suff in ("-loading", "-running", "-load", "-run", "-screen",
+                             "_loading", "_running", "_load", "_run"):
+                    if s.endswith(suff):
+                        return s[:-len(suff)]
+                return s
+            key = (_screen_kind(t), _norm_stem(stem))
+            prev_idx = seen_stems.get(key)
             if prev_idx is not None:
                 prev_url = detail["screenshots"][prev_idx]["url"]
-                prev_is_web = any(prev_url.lower().endswith(e) for e in web_image_exts)
-                cur_is_web = ext in web_image_exts
-                if cur_is_web and not prev_is_web:
-                    # Replace the non-web entry with this web-renderable one.
+                prev_ext = os.path.splitext(prev_url.lower())[1]
+                if _fmt_priority(ext) < _fmt_priority(prev_ext):
+                    # This format is better than the one we already kept.
                     seen_urls.discard(prev_url)
                     seen_urls.add(url)
                     detail["screenshots"][prev_idx] = {
@@ -1101,17 +1141,19 @@ def zxdb_parse_game_detail(payload) -> dict:
                     }
                 continue
             seen_urls.add(url)
-            seen_stems[stem] = len(detail["screenshots"])
+            seen_stems[key] = len(detail["screenshots"])
             detail["screenshots"].append({
                 "url":  url,
                 "type": str(a.get("type") or ""),
             })
 
-    # Prefer a "running" or "loading" screen as the very first frame.
+    # Prefer the "loading" splash screen as the very first frame (it is the
+    # iconic title artwork), then the in-game "running" screen, then any other
+    # screen. This first frame is also used as the gallery thumbnail below.
     def _shot_priority(s):
         t = (s.get("type") or "").lower()
-        if "running" in t:   return 0
-        if "loading" in t:   return 1
+        if "loading" in t:   return 0
+        if "running" in t:   return 1
         if "screen"  in t:   return 2
         return 3
     detail["screenshots"].sort(key=_shot_priority)
@@ -1926,9 +1968,24 @@ def _qimage_from_data(data) -> QImage:
     return img
 
 
-def getit_run_in_thread(fn, on_result, on_error):
+# Bounds how many *gated* (gallery thumbnail/asset) fetches do their HTTP +
+# image-decode work at once. A full gallery page can kick off dozens of cells;
+# without this cap they would all run simultaneously, starving the UI thread
+# (Python GIL) and flooding the remote servers — the Unite! Latest/Random hang.
+# Threads are still daemon (so app exit never blocks on an in-flight fetch); the
+# semaphore just throttles concurrent work to GALLERY_THUMB_FETCH_WORKERS.
+_THUMB_FETCH_SEM = threading.Semaphore(max(1, int(GALLERY_THUMB_FETCH_WORKERS)))
+
+
+def getit_run_in_thread(fn, on_result, on_error, gated=False):
     """Run *fn* in a daemon thread. Results are marshalled to the main thread
     via Qt queued signal connections, which are thread-safe.
+
+    When *gated* is True the thread waits on a shared bounded semaphore before
+    doing its work, so a page full of gallery cells can't run dozens of
+    concurrent fetch/decode operations at once (which hangs the UI). Leave it
+    False for user-driven one-off work (searches, library builds, installs)
+    that should start immediately.
 
     The WorkerSignals object is parented to the QApplication and kept alive in
     a module-level registry until *after* the main-thread slot has executed,
@@ -1990,7 +2047,19 @@ def getit_run_in_thread(fn, on_result, on_error):
             except RuntimeError:
                 pass
 
-    t = threading.Thread(target=_run, daemon=True)
+    target = _run
+    if gated:
+        # Throttle concurrent gallery fetch/decode work to the semaphore's
+        # permit count; the thread blocks here (cheaply) until a slot frees.
+        def _run_gated():
+            _THUMB_FETCH_SEM.acquire()
+            try:
+                _run()
+            finally:
+                _THUMB_FETCH_SEM.release()
+        target = _run_gated
+
+    t = threading.Thread(target=target, daemon=True)
     t.start()
     return t
 
@@ -2003,7 +2072,7 @@ def _gif_fetch_bytes(url, on_bytes):
     def _fn(_u=url):
         return _http_fetch_bytes_with_retry(_u, timeout=20)
     getit_run_in_thread(_fn, lambda data: on_bytes(data),
-                        lambda _e: on_bytes(None))
+                        lambda _e: on_bytes(None), gated=True)
 
 
 
@@ -2814,10 +2883,10 @@ class MainWindow(QMainWindow):
                 except Exception:
                     pass
 
-                # Gallery animation mode: "hover" (default) or "timer"
+                # Gallery animation mode: "hover" (default), "timer" or "none"
                 if SETTING_GALLERY_ANIM_MODE in configuration_dictionary and configuration_dictionary[SETTING_GALLERY_ANIM_MODE] != "":
                     val = configuration_dictionary[SETTING_GALLERY_ANIM_MODE].strip().lower()
-                    if val in ("hover", "timer"):
+                    if val in ("hover", "timer", "none"):
                         self._gallery_anim_mode = val
                         cb = getattr(self, "settings_gallery_anim_combo", None)
                         if cb is not None:
@@ -9091,7 +9160,7 @@ class MainWindow(QMainWindow):
                 _set(px, u)
             def _on_err(_err):
                 _make_placeholder()
-            getit_run_in_thread(_fn, _on_done, _on_err)
+            getit_run_in_thread(_fn, _on_done, _on_err, gated=True)
 
             # Lazily enrich the hover-info line with the entry date, which is
             # not part of the list endpoint. Author and category already come
@@ -9108,7 +9177,7 @@ class MainWindow(QMainWindow):
                     if _e.get("category"):parts.append(_e["category"])
                     _set(" · ".join(parts))
                 def _det_err(_e): pass
-                getit_run_in_thread(_det_fn, _det_ok, _det_err)
+                getit_run_in_thread(_det_fn, _det_ok, _det_err, gated=True)
 
         def _getit_extra_fetch(url, on_pixmap):
             # GetIt only exposes a single screenshot per entry; nothing to do.
@@ -9859,7 +9928,8 @@ class MainWindow(QMainWindow):
                 _ph_cat = (entry.get("category") or "").upper()
                 if _ph_cat:
                     _ph_label = _ph_cat[:6]
-            _mk = make_viewer or (lambda **kw: GalleryItemViewer(parent=self, **kw))
+            _mk = make_viewer or (lambda **kw: GalleryItemViewer(
+                parent=self, anim_mode_getter=lambda: self._gallery_anim_mode, **kw))
             viewer = _mk(
                 title=title,
                 info_rows=info_rows,
@@ -10528,7 +10598,7 @@ class MainWindow(QMainWindow):
         self.zxdb_results_table.setColumnWidth(3, 180)
         self.zxdb_results_table.setColumnWidth(4, 120)
 
-        self.zxdb_screenshot_label = QLabel()
+        self.zxdb_screenshot_label = _ScalingImageLabel()
         self.zxdb_screenshot_label.setFixedSize(256, 192)
         self.zxdb_screenshot_label.setAlignment(Qt.AlignCenter)
         self.zxdb_screenshot_label.setStyleSheet("background: #111; border: 1px solid #444;")
@@ -10658,7 +10728,7 @@ class MainWindow(QMainWindow):
                         px = QPixmap.fromImage(img) if (img is not None and not img.isNull()) else QPixmap()
                         if not px.isNull():
                             set_pixmap(px, u)
-                    getit_run_in_thread(_img_fn, _img_ok, lambda _e: None)
+                    getit_run_in_thread(_img_fn, _img_ok, lambda _e: None, gated=True)
                     return
                 # No real image: render a typed placeholder showing the
                 # primary download format (e.g. TAP, POK, PDF) so the cell
@@ -10671,7 +10741,7 @@ class MainWindow(QMainWindow):
                 pm = zxfmt_make_placeholder_pixmap(label, sub)
                 if not pm.isNull():
                     set_pixmap(pm, placeholder_url)
-            getit_run_in_thread(_fn, _on_ok, lambda _e: None)
+            getit_run_in_thread(_fn, _on_ok, lambda _e: None, gated=True)
 
         def _zxdb_extra_fetch(url, on_pixmap):
             if isinstance(url, str) and url.startswith("placeholder://"):
@@ -10934,7 +11004,7 @@ class MainWindow(QMainWindow):
         def zxdb_clear_detail():
             _zxdb_clear_detail_rows()
             self.zxdb_screenshot_label.setText("No preview")
-            self.zxdb_screenshot_label.setPixmap(QPixmap())
+            self.zxdb_screenshot_label.clear_image()
             self.zxdb_download_button.setEnabled(False)
             self._zxdb_selected_id = ""
             self._zxdb_selected_title = ""
@@ -11084,22 +11154,16 @@ class MainWindow(QMainWindow):
         def zxdb_set_pixmap(pm: QPixmap):
             if pm is None or pm.isNull():
                 self.zxdb_screenshot_label.setText("No preview")
-                self.zxdb_screenshot_label.setPixmap(QPixmap())
+                self.zxdb_screenshot_label.clear_image()
                 return
-            self.zxdb_screenshot_label.setPixmap(
-                pm.scaled(
-                    self.zxdb_screenshot_label.size(),
-                    Qt.KeepAspectRatio,
-                    Qt.SmoothTransformation,
-                )
-            )
+            # The label keeps the original and re-fits it to its own size on
+            # every resize, so the picture never stays stuck at the size it had
+            # when first shown (the "first .scr doesn't get rescaled" symptom).
+            self.zxdb_screenshot_label.set_image(pm)
             # If the fullscreen view is showing this pane's preview, refresh it too.
             if self._zxdb_stack.currentIndex() == 1:
                 self._zxdb_fullscreen_pixmap = pm
-                fs = self.zxdb_fullscreen_label.size()
-                self.zxdb_fullscreen_label.setPixmap(
-                    pm.scaled(fs, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-                )
+                self.zxdb_fullscreen_label.set_image(pm)
 
         def zxdb_update_nav_buttons():
             multi = len(self._zxdb_screenshots) > 1
@@ -11169,7 +11233,7 @@ class MainWindow(QMainWindow):
             self._zxdb_shot_index  = 0
             if not self._zxdb_screenshots:
                 self.zxdb_screenshot_label.setText("No preview")
-                self.zxdb_screenshot_label.setPixmap(QPixmap())
+                self.zxdb_screenshot_label.clear_image()
                 zxdb_update_nav_buttons()
                 return
             zxdb_show_shot_at(0)
@@ -11922,7 +11986,7 @@ class MainWindow(QMainWindow):
             self._zxdb_screenshots = []
             self._zxdb_shot_cache  = {}
             self._zxdb_shot_index  = 0
-            self.zxdb_screenshot_label.setPixmap(QPixmap())
+            self.zxdb_screenshot_label.clear_image()
 
         def _zxdb_load_game(eid: str, title_hint: str):
             self._zxdb_selected_id    = eid
@@ -12227,7 +12291,8 @@ class MainWindow(QMainWindow):
                 ("Machine:", entry.get("machine", "")),
                 ("Genre:",   entry.get("genre", "")),
             ]
-            _mk = make_viewer or (lambda **kw: GalleryItemViewer(parent=self, **kw))
+            _mk = make_viewer or (lambda **kw: GalleryItemViewer(
+                parent=self, anim_mode_getter=lambda: self._gallery_anim_mode, **kw))
             viewer = _mk(
                 title=title,
                 info_rows=info_rows_base,
@@ -13261,7 +13326,7 @@ class MainWindow(QMainWindow):
         zxdb_close_bar_widget.setLayout(zxdb_close_bar)
         zxdb_overlay_layout.addWidget(zxdb_close_bar_widget, 0)
 
-        self.zxdb_fullscreen_label = QLabel()
+        self.zxdb_fullscreen_label = _ScalingImageLabel()
         self.zxdb_fullscreen_label.setAlignment(Qt.AlignCenter)
         self.zxdb_fullscreen_label.setStyleSheet("background: #000;")
         self.zxdb_fullscreen_label.setCursor(Qt.PointingHandCursor)
@@ -13322,10 +13387,7 @@ class MainWindow(QMainWindow):
         def _zxdb_resize_fullscreen():
             px = self._zxdb_fullscreen_pixmap
             if px and not px.isNull():
-                sz = self.zxdb_fullscreen_label.size()
-                self.zxdb_fullscreen_label.setPixmap(
-                    px.scaled(sz, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-                )
+                self.zxdb_fullscreen_label.set_image(px)
             self._zxdb_reposition_fs_btns()
 
         zxdb_close_btn.clicked.connect(_zxdb_hide_fullscreen)
@@ -13487,7 +13549,7 @@ class MainWindow(QMainWindow):
         self.zxart_results_table.setColumnWidth(3, 180)
         self.zxart_results_table.setColumnWidth(4, 120)
 
-        self.zxart_screenshot_label = QLabel()
+        self.zxart_screenshot_label = _ScalingImageLabel()
         self.zxart_screenshot_label.setFixedSize(256, 192)
         self.zxart_screenshot_label.setAlignment(Qt.AlignCenter)
         self.zxart_screenshot_label.setStyleSheet("background: #111; border: 1px solid #444;")
@@ -13693,7 +13755,7 @@ class MainWindow(QMainWindow):
                                 _st(_gallery_extract_tags(_e))
                             except Exception:
                                 pass
-                        getit_run_in_thread(_rel_fn, _rel_ok, lambda _e: None)
+                        getit_run_in_thread(_rel_fn, _rel_ok, lambda _e: None, gated=True)
 
             if not urls:
                 # No real picture for this entry: render a typed placeholder
@@ -13743,7 +13805,7 @@ class MainWindow(QMainWindow):
                 px = QPixmap.fromImage(img) if (img is not None and not img.isNull()) else QPixmap()
                 if not px.isNull():
                     set_pixmap(px, u)
-            getit_run_in_thread(_img_fn, _img_ok, lambda _e: None)
+            getit_run_in_thread(_img_fn, _img_ok, lambda _e: None, gated=True)
 
         def _zxart_extra_fetch(url, on_pixmap):
             if isinstance(url, str) and url.startswith("placeholder://"):
@@ -14011,7 +14073,7 @@ class MainWindow(QMainWindow):
         def zxart_clear_detail():
             _zxart_clear_detail_rows()
             self.zxart_screenshot_label.setText("No preview")
-            self.zxart_screenshot_label.setPixmap(QPixmap())
+            self.zxart_screenshot_label.clear_image()
             self.zxart_download_button.setEnabled(False)
             self._zxart_selected_id = ""
             self._zxart_selected_title = ""
@@ -14282,21 +14344,15 @@ class MainWindow(QMainWindow):
         def zxart_set_pixmap(pm: QPixmap):
             if pm is None or pm.isNull():
                 self.zxart_screenshot_label.setText("No preview")
-                self.zxart_screenshot_label.setPixmap(QPixmap())
+                self.zxart_screenshot_label.clear_image()
                 return
-            self.zxart_screenshot_label.setPixmap(
-                pm.scaled(
-                    self.zxart_screenshot_label.size(),
-                    Qt.KeepAspectRatio,
-                    Qt.SmoothTransformation,
-                )
-            )
+            # The label keeps the original and re-fits it to its own size on
+            # every resize, so the picture never stays stuck at the size it had
+            # when first shown (the "first .scr doesn't get rescaled" symptom).
+            self.zxart_screenshot_label.set_image(pm)
             if self._zxart_stack.currentIndex() == 1:
                 self._zxart_fullscreen_pixmap = pm
-                fs = self.zxart_fullscreen_label.size()
-                self.zxart_fullscreen_label.setPixmap(
-                    pm.scaled(fs, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-                )
+                self.zxart_fullscreen_label.set_image(pm)
 
         def zxart_update_nav_buttons():
             multi = len(self._zxart_screenshots) > 1
@@ -14366,7 +14422,7 @@ class MainWindow(QMainWindow):
             self._zxart_shot_index  = 0
             if not self._zxart_screenshots:
                 self.zxart_screenshot_label.setText("No preview")
-                self.zxart_screenshot_label.setPixmap(QPixmap())
+                self.zxart_screenshot_label.clear_image()
                 zxart_update_nav_buttons()
                 return
             zxart_show_shot_at(0)
@@ -14996,7 +15052,7 @@ class MainWindow(QMainWindow):
             self._zxart_screenshots = []
             self._zxart_shot_cache  = {}
             self._zxart_shot_index  = 0
-            self.zxart_screenshot_label.setPixmap(QPixmap())
+            self.zxart_screenshot_label.clear_image()
 
         def _zxart_load_prod(pid: str, title_hint: str):
             """Load full production detail including releases."""
@@ -15311,7 +15367,8 @@ class MainWindow(QMainWindow):
                 ("Year:",   str(entry.get("year", "") or "")),
                 ("Type:",   entry.get("prodType", "") or entry.get("pic_type", "")),
             ]
-            _mk = make_viewer or (lambda **kw: GalleryItemViewer(parent=self, **kw))
+            _mk = make_viewer or (lambda **kw: GalleryItemViewer(
+                parent=self, anim_mode_getter=lambda: self._gallery_anim_mode, **kw))
             viewer = _mk(
                 title=title,
                 info_rows=info_rows_base,
@@ -16195,7 +16252,7 @@ class MainWindow(QMainWindow):
         zxart_close_bar_widget.setLayout(zxart_close_bar)
         zxart_overlay_layout.addWidget(zxart_close_bar_widget, 0)
 
-        self.zxart_fullscreen_label = QLabel()
+        self.zxart_fullscreen_label = _ScalingImageLabel()
         self.zxart_fullscreen_label.setAlignment(Qt.AlignCenter)
         self.zxart_fullscreen_label.setStyleSheet("background: #000;")
         self.zxart_fullscreen_label.setCursor(Qt.PointingHandCursor)
@@ -16256,10 +16313,7 @@ class MainWindow(QMainWindow):
         def _zxart_resize_fullscreen():
             px = self._zxart_fullscreen_pixmap
             if px and not px.isNull():
-                sz = self.zxart_fullscreen_label.size()
-                self.zxart_fullscreen_label.setPixmap(
-                    px.scaled(sz, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-                )
+                self.zxart_fullscreen_label.set_image(px)
             self._zxart_reposition_fs_btns()
 
         zxart_close_btn.clicked.connect(_zxart_hide_fullscreen)
@@ -17057,7 +17111,7 @@ class MainWindow(QMainWindow):
                         _set(px, u)
                 def _err(_e):
                     _placeholder()
-                getit_run_in_thread(_fn, _ok, _err)
+                getit_run_in_thread(_fn, _ok, _err, gated=True)
 
             def _itchio_title_getter(e):
                 return str(e.get("title") or e.get("id") or "")
@@ -17238,7 +17292,8 @@ class MainWindow(QMainWindow):
                 # opening an item never blocks the UI thread.
                 info_rows = base_rows + [("Status:", _status_text(None))]
 
-                _mk = make_viewer or (lambda **kw: GalleryItemViewer(parent=self, **kw))
+                _mk = make_viewer or (lambda **kw: GalleryItemViewer(
+                parent=self, anim_mode_getter=lambda: self._gallery_anim_mode, **kw))
                 viewer = _mk(
                     title=title,
                     info_rows=info_rows,
@@ -18050,7 +18105,16 @@ class MainWindow(QMainWindow):
             except Exception:
                 pass
 
-        def _allinone_repopulate():
+        # Latest / Random / multi-search fan out to several sources, each of
+        # which calls _allinone_repopulate as its results land. Rebuilding the
+        # aggregated gallery on every source completion re-spawned the whole
+        # page's thumbnail threads several times over (and re-ran the image-first
+        # re-sort), which hung the UI thread. While a bulk op is in progress we
+        # coalesce those requests into a single rebuild at the end.
+        self._allinone_bulk_active = False
+        self._allinone_repopulate_pending = False
+
+        def _allinone_repopulate_now():
             try:
                 entries = _allinone_collect()
                 # Cache the full merged list so prev/next can re-slice without
@@ -18090,7 +18154,30 @@ class MainWindow(QMainWindow):
             except Exception:
                 pass
 
+        def _allinone_repopulate():
+            # Defer while a bulk fan-out is active; _allinone_end_bulk() flushes
+            # one rebuild once every source has reported back.
+            if getattr(self, "_allinone_bulk_active", False):
+                self._allinone_repopulate_pending = True
+                return
+            _allinone_repopulate_now()
+
+        def _allinone_begin_bulk():
+            # Reset state at the start of each bulk op so a prior fan-out whose
+            # completion was dropped can't leave the gallery stuck deferring.
+            self._allinone_bulk_active = True
+            self._allinone_repopulate_pending = False
+
+        def _allinone_end_bulk(flush=False):
+            was_active = getattr(self, "_allinone_bulk_active", False)
+            self._allinone_bulk_active = False
+            if (was_active and self._allinone_repopulate_pending) or flush:
+                self._allinone_repopulate_pending = False
+                _allinone_repopulate_now()
+
         self._allinone_repopulate = _allinone_repopulate
+        self._allinone_begin_bulk = _allinone_begin_bulk
+        self._allinone_end_bulk = _allinone_end_bulk
 
         # --- Paging handlers (client-side over the merged result list) ---
         def allinone_on_prev():
@@ -18182,12 +18269,15 @@ class MainWindow(QMainWindow):
 
             pending = {"count": len(sources)}
 
+            # Coalesce the per-source AllInOne rebuilds into one at the end.
+            _allinone_begin_bulk()
+
             def _allinone_source_done():
                 pending["count"] -= 1
                 if pending["count"] <= 0:
                     _stop_tab_spinner(ZX_NEXT_UNITE_TAB_TITLE_ALLINONE)
                     try:
-                        _allinone_repopulate()
+                        _allinone_end_bulk(flush=True)
                     except Exception:
                         pass
 
@@ -18253,6 +18343,10 @@ class MainWindow(QMainWindow):
 
             state = {"pending": len(actions), "done": False}
 
+            # Coalesce the per-source AllInOne rebuilds into a single rebuild
+            # when the fan-out completes (the watchdog guarantees _finish runs).
+            _allinone_begin_bulk()
+
             watchdog = QTimer(self)
             watchdog.setSingleShot(True)
             watchdog.setInterval(30000)
@@ -18267,7 +18361,7 @@ class MainWindow(QMainWindow):
                     pass
                 _stop_tab_spinner(ZX_NEXT_UNITE_TAB_TITLE_ALLINONE)
                 try:
-                    _allinone_repopulate()
+                    _allinone_end_bulk(flush=True)
                 except Exception:
                     pass
 
@@ -18861,7 +18955,8 @@ class MainWindow(QMainWindow):
                 from zxnu_pygame import PygameItemViewer
                 viewer = opener(
                     entry,
-                    make_viewer=lambda **kw: PygameItemViewer(host, **kw),
+                    make_viewer=lambda **kw: PygameItemViewer(
+                        host, anim_mode_getter=lambda: self._gallery_anim_mode, **kw),
                     install=False,
                 )
             except Exception:
@@ -19091,13 +19186,15 @@ class MainWindow(QMainWindow):
             "Controls when multi-screenshot tiles cycle through their images\n"
             "in the GetIt / ZXDB / zxArt 'Gallery' (picture) view.\n"
             "  • On hover (default): cycles only while the mouse is over the tile.\n"
-            "  • Timed: cycles continuously while the gallery is visible."
+            "  • Timed: cycles continuously while the gallery is visible.\n"
+            "  • None: never cycles between images (animated GIFs still play)."
         )
         grid_tab_Settings.addWidget(gallery_anim_lbl, 6, 0)
 
         self.settings_gallery_anim_combo = QComboBox()
         self.settings_gallery_anim_combo.addItem("On hover (default)", "hover")
         self.settings_gallery_anim_combo.addItem("Timed",              "timer")
+        self.settings_gallery_anim_combo.addItem("None",               "none")
         self.settings_gallery_anim_combo.setToolTip(gallery_anim_lbl.toolTip())
         self.settings_gallery_anim_combo.currentIndexChanged.connect(
             lambda _i: _settings_gallery_anim_changed()

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -72,6 +72,15 @@ ITCH_MAX_PAGES = 1000
 # key is configured). Paging is applied client-side on the merged result list.
 ALLINONE_PAGE_SIZE = GETIT_PAGE_SIZE + ZXDB_PAGE_SIZE + ZXART_PAGE_SIZE
 
+# Caps how many gallery thumbnail/asset fetches do their HTTP + image-decode
+# work at once (enforced by a semaphore). A full Unite! page can have ~58 cells,
+# each kicking off an image (and sometimes a metadata) fetch; letting them all
+# run simultaneously starves the UI thread (Python GIL) and floods the remote
+# servers, hanging the UI on Latest/Random. High enough to download several in
+# parallel, low enough to keep the UI responsive. Tune up for faster bulk loads,
+# down for a smoother UI.
+GALLERY_THUMB_FETCH_WORKERS = 16
+
 
 HDF_MONKEY_WINDOWS_URL = "https://uto.speccy.org/downloads/hdfmonkey_windows.zip"
 
@@ -114,7 +123,7 @@ SETTING_BG_OPACITY        = "bg_opacity"
 SETTING_BG_IMAGE          = "bg_image"          # "" = Random, else filename (basename only)
 SETTING_CONTENT_DISCLAIMER_AGREED = "content_disclaimer_agreed"
 SETTING_NEXTSYNC_SEND_CONFLICT = "nextsync_send_conflict"   # "prompt" (default) | "overwrite" | "ignore"
-SETTING_GALLERY_ANIM_MODE      = "gallery_anim_mode"        # "hover" (default) or "timer"
+SETTING_GALLERY_ANIM_MODE      = "gallery_anim_mode"        # "hover" (default), "timer" or "none"
 SETTING_GALLERY_ROWS_PER_PAGE  = "gallery_rows_per_page"    # int 1..10, default 2
 SETTING_GALLERY_COLS           = "gallery_cols"             # int: 2 | 4 (default) | 8
 SETTING_GALLERY_IMG_SIZE       = "gallery_img_size"         # "small" | "medium" (default) | "large"

--- a/zxnu_gallery.py
+++ b/zxnu_gallery.py
@@ -499,7 +499,11 @@ class GalleryCell(QFrame):
         the main thumbnail (used immediately if already cached)."""
         if not self._is_alive():
             return
-        urls = [u for u in (urls or []) if u]
+        # Keep only renderable images — drop non-picture downloads (archives,
+        # tape/disk images, text files) the online APIs sometimes mix in, so the
+        # thumbnail never tries to decode a .zip/.txt as a picture.
+        urls = [u for u in (urls or [])
+                if u and zxfmt_url_is_displayable_image(u)]
         self._screenshots = urls
         # An animated GIF first frame is played as a looping QMovie rather than
         # shown as a static thumbnail (the prefetch below skips gif URLs when a
@@ -724,7 +728,13 @@ class GalleryCell(QFrame):
         # .gif URLs when a byte-fetcher is wired, so PNG/SCR/etc. keep their
         # existing static-pixmap path untouched.
         if self._gif_fetch_cb and self._url_is_gif(url):
-            self._play_gif(url)
+            # In "none" animation mode a GIF is frozen to its first frame so an
+            # animated (e.g. FLASH-effect) screen does not blink; the timed and
+            # on-hover modes keep playing it as a QMovie.
+            if self._anim_mode_is_none():
+                self._show_gif_static(url)
+            else:
+                self._play_gif(url)
             return
         cached = self._shot_cache.get(url)
         if cached is not None:
@@ -754,6 +764,11 @@ class GalleryCell(QFrame):
             i = self._screenshots.index(url)
         except ValueError:
             return
+        # Whether the frame currently on screen is the one being removed. The
+        # prefetch validates every URL up front and prunes the broken ones; most
+        # are not the displayed frame, so re-rendering for each would needlessly
+        # repaint (and could flicker) the thumbnail.
+        was_current = (i == self._shot_index)
         del self._screenshots[i]
         self._shot_cache.pop(url, None)
         if not self._screenshots:
@@ -769,8 +784,10 @@ class GalleryCell(QFrame):
         self._shot_index = new_idx
         if len(self._screenshots) <= 1:
             self._timer.stop()
-        # Show whichever URL is now at this slot (cached or trigger a fetch).
-        self._show_index(new_idx)
+        # Only repaint when the displayed frame actually changed (it was the
+        # dropped URL); pruning a background URL leaves the current frame as-is.
+        if was_current:
+            self._show_index(new_idx)
 
     def _notify_no_image(self):
         if self._no_image_notified:
@@ -792,6 +809,44 @@ class GalleryCell(QFrame):
         return self._shot_cache.get(self._screenshots[self._shot_index])
 
     # ---- animated GIF playback -----------------------------------------
+
+    def _anim_mode_is_none(self) -> bool:
+        """True when the global "Gallery animation" setting is "none" (no motion
+        at all, including frozen GIF thumbnails)."""
+        try:
+            return self._anim_mode_getter() == "none"
+        except Exception:
+            return False
+
+    def _show_gif_static(self, url):
+        """Show a GIF's first frame as a static thumbnail (used in "none" mode so
+        an animated screen does not blink)."""
+        if not self._gif_fetch_cb or not self._is_alive():
+            return
+        cached = self._shot_cache.get(url)
+        if cached is not None:
+            self._stop_movie()
+            self._apply_pixmap(cached)
+            return
+        def _on_bytes(data, _u=url):
+            if not self._is_alive():
+                return
+            if (self._shot_index >= len(self._screenshots)
+                    or self._screenshots[self._shot_index] != _u):
+                return
+            if data:
+                pm = QPixmap()
+                pm.loadFromData(QByteArray(data))
+                if not pm.isNull():
+                    self._shot_cache[_u] = pm
+                    self._stop_movie()
+                    self._apply_pixmap(pm)
+                    return
+            self._drop_bad_url(_u)
+        try:
+            self._gif_fetch_cb(url, _on_bytes)
+        except Exception:
+            self._drop_bad_url(url)
 
     def _play_gif(self, url):
         """Fetch *url*'s raw bytes and play it as a looping QMovie thumbnail.
@@ -1538,6 +1593,90 @@ def _gallery_stars(rating_value) -> str:
     return "★" * full + "☆" * empty + f"  ({rating_value})"
 
 
+class _ScalingImageLabel(QLabel):
+    """A QLabel that keeps the *original* pixmap and always rescales it
+    (aspect-fit, smooth) to its own current size.
+
+    Scaling happens in the label's own ``resizeEvent``, which is the single
+    authoritative signal that its geometry changed — so the picture tracks the
+    label whenever the layout resizes it (on open, on a side-panel relayout, on
+    a window resize), with no external resize plumbing to get the timing wrong.
+    This is what keeps a small native-resolution SCR screen filling the image
+    area instead of being left at a stale size (the "first screenshot doesn't
+    get rescaled" symptom)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._orig_pm = None
+        # (cacheKey, size) of the pixmap currently painted on screen. Used to
+        # skip a redundant re-paint when the exact same picture is handed back at
+        # the same size (e.g. a background URL prune or a duplicate fetch
+        # re-delivers the current image) — that was a source of visible flicker.
+        self._shown_key = None
+        # Rescaling is debounced: when an item opens, the image area is resized
+        # several times in quick succession (the stacked-widget show, then the
+        # metadata side panel laying out via refresh_meta). Rescaling on every
+        # intermediate size repaints the picture growing step by step — the
+        # "first screenshot animates from small to big" symptom. Coalesce the
+        # burst and paint once, at the final size.
+        self._apply_timer = QTimer(self)
+        self._apply_timer.setSingleShot(True)
+        self._apply_timer.setInterval(70)
+        self._apply_timer.timeout.connect(self._apply_scaled)
+
+    def set_image(self, pm):
+        """Show *pm*, remembering it as the original so later resizes can
+        rescale from full quality. Passing a null/None pixmap clears it."""
+        if pm is None or pm.isNull():
+            self.clear_image()
+            return
+        # No-op when the exact same picture is already painted at the current
+        # size: re-applying it would blank-and-repaint for nothing (flicker).
+        if (self._shown_key is not None
+                and self._shown_key == (pm.cacheKey(), self.size())):
+            self._orig_pm = pm
+            return
+        self._orig_pm = pm
+        # Debounce too, so a picture set right as the layout is still settling
+        # is painted once at the final size rather than at a transient one.
+        self._apply_timer.start()
+
+    def clear_image(self):
+        """Forget any stored image and blank the label (used for the
+        'Loading…' state and when a QMovie takes over)."""
+        self._orig_pm = None
+        self._shown_key = None
+        self._apply_timer.stop()
+        super().setPixmap(QPixmap())
+
+    def has_image(self):
+        return self._orig_pm is not None
+
+    def _apply_scaled(self):
+        if self._orig_pm is None:
+            return
+        sz = self.size()
+        if sz.width() <= 1 or sz.height() <= 1:
+            return
+        # Scale to *device* pixels and tag the pixmap with the display's device
+        # pixel ratio. On a high-DPI screen (dpr > 1) scaling only to the logical
+        # label size leaves the picture drawn at 1/dpr of the area — the "first
+        # screenshot is small" symptom; the animated frames went through a
+        # different path and filled the area, so they looked fine by contrast.
+        dpr = self.devicePixelRatioF() or 1.0
+        target = QSize(max(1, round(sz.width() * dpr)),
+                       max(1, round(sz.height() * dpr)))
+        scaled = self._orig_pm.scaled(
+            target, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        scaled.setDevicePixelRatio(dpr)
+        super().setPixmap(scaled)
+        self._shown_key = (self._orig_pm.cacheKey(), sz)
+
+    def resizeEvent(self, ev):
+        super().resizeEvent(ev)
+        self._apply_timer.start()
+
+
 class GalleryItemViewer(QWidget):
     """In-pane item viewer opened from Gallery mode (double-click on a cell).
 
@@ -1561,7 +1700,7 @@ class GalleryItemViewer(QWidget):
     )
 
     def __init__(self, title: str, info_rows: list, screenshots: list,
-                 extra_fetch_cb, tags=None, parent=None):
+                 extra_fetch_cb, tags=None, parent=None, anim_mode_getter=None):
         """
         Parameters
         ----------
@@ -1569,15 +1708,21 @@ class GalleryItemViewer(QWidget):
         info_rows      : list of (label, value) tuples; empty value → skip row
         screenshots    : list of image URL strings for the slideshow
         extra_fetch_cb : callable(url, on_pixmap_cb) – async image loader
+        anim_mode_getter : optional callable -> "hover"|"timer"|"none". When it
+                         returns "none" the multi-screenshot slideshow does not
+                         auto-advance (the user still pages with ◀/▶, and any
+                         animated GIF still plays via QMovie). Defaults to the
+                         legacy always-cycling behaviour when not supplied.
         """
         super().__init__(parent)
         self.setFocusPolicy(Qt.StrongFocus)
         self.setStyleSheet("background: #0d0d0d;")
 
-        self._screenshots    = list(screenshots or [])
+        self._screenshots    = self._filter_shots(screenshots)
         self._shot_index     = 0
         self._shot_cache     = {}
         self._extra_fetch_cb = extra_fetch_cb
+        self._anim_mode_getter = anim_mode_getter
         self._gif_fetch_cb   = None   # (url, on_bytes) raw-bytes fetcher for GIFs
         self._movie          = None   # active QMovie for an animated GIF
         self._movie_native   = None   # QSize of the GIF's native frame
@@ -1605,7 +1750,7 @@ class GalleryItemViewer(QWidget):
         img_layout.setContentsMargins(8, 8, 8, 8)
         img_layout.setSpacing(4)
 
-        self._img_lbl = QLabel()
+        self._img_lbl = _ScalingImageLabel()
         self._img_lbl.setAlignment(Qt.AlignCenter)
         self._img_lbl.setStyleSheet("background: #0a0a0a; color: #666;")
         self._img_lbl.setText("Loading…")
@@ -1646,6 +1791,16 @@ class GalleryItemViewer(QWidget):
         nav_row.addStretch()
         img_layout.addLayout(nav_row)
 
+        # File-name caption under the image (e.g. "0035473-load-1.scr"). A fixed
+        # height keeps it from perturbing the image area's layout, and it doubles
+        # as a diagnostic for which screenshot/file is currently on screen.
+        self._shot_name = QLabel("")
+        self._shot_name.setAlignment(Qt.AlignCenter)
+        self._shot_name.setStyleSheet("color: #888; font-size: 10px; background: transparent;")
+        self._shot_name.setFixedHeight(16)
+        self._shot_name.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        img_layout.addWidget(self._shot_name)
+
         self._prev_btn.clicked.connect(self._go_prev)
         self._next_btn.clicked.connect(self._go_next)
 
@@ -1654,8 +1809,13 @@ class GalleryItemViewer(QWidget):
         # ── RIGHT: metadata + actions ────────────────────────────────────
         right_panel = QWidget()
         right_panel.setStyleSheet("background: #111;")
-        right_panel.setMinimumWidth(300)
-        right_panel.setMaximumWidth(400)
+        # Fixed width (not a min/max range): with a stretch-0 panel the layout
+        # otherwise sizes it to its *content* hint, so when the metadata reflows
+        # (a long Description wrapping, the scroll area's scrollbar toggling) the
+        # panel width shifts and the stretch-3 image panel absorbs the change —
+        # making a letterboxed picture (e.g. a 256×192 .scr) visibly rescale
+        # small↔big on the same image. A fixed width keeps the image area put.
+        right_panel.setFixedWidth(340)
         right_layout = QVBoxLayout(right_panel)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(0)
@@ -1769,6 +1929,55 @@ class GalleryItemViewer(QWidget):
 
     # ── public API ────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _filter_shots(urls):
+        """Keep only URLs the viewer can actually render as a picture, dropping
+        non-image downloads (archives, tape/disk images, text files) that the
+        online APIs sometimes mix into the screenshot list."""
+        return [u for u in (urls or []) if zxfmt_url_is_displayable_image(u)]
+
+    @staticmethod
+    def _shot_filename(url) -> str:
+        """Human-readable file name for *url*, shown under the image. Synthetic
+        placeholder URLs have no real file, so they render blank."""
+        if not isinstance(url, str) or not url or url.startswith("placeholder://"):
+            return ""
+        s = url.split("?", 1)[0].split("#", 1)[0]
+        try:
+            from urllib.parse import unquote
+            s = unquote(s)
+        except Exception:
+            pass
+        return s.rstrip("/").rsplit("/", 1)[-1]
+
+    def _update_shot_name(self):
+        """Refresh the file-name caption under the image for the current shot."""
+        lbl = getattr(self, "_shot_name", None)
+        if lbl is None:
+            return
+        name = ""
+        if 0 <= self._shot_index < len(self._screenshots):
+            name = self._shot_filename(self._screenshots[self._shot_index])
+        lbl.setText(name)
+        lbl.setToolTip(name)
+
+    def _anim_should_cycle(self) -> bool:
+        """Whether the slideshow may auto-advance. Honours the global "Gallery
+        animation" setting: anything other than "none" cycles (preserving the
+        legacy behaviour); "none" disables auto-advance entirely."""
+        if self._anim_mode_getter is None:
+            return True
+        try:
+            return self._anim_mode_getter() != "none"
+        except Exception:
+            return True
+
+    def _maybe_start_timer(self):
+        """Start the auto-advance timer only when there is more than one
+        screenshot *and* the animation mode permits cycling."""
+        if len(self._screenshots) > 1 and self._anim_should_cycle():
+            self._timer.start()
+
     def install_into_stack(self, stack: QStackedWidget, close_fn=None):
         """Add this widget to *stack* (if not already there) and show it."""
         self._close_fn = close_fn
@@ -1777,8 +1986,7 @@ class GalleryItemViewer(QWidget):
         stack.setCurrentWidget(self)
         self.setFocus()
         self._ensure_alien_overlay()
-        if len(self._screenshots) > 1:
-            self._timer.start()
+        self._maybe_start_timer()
 
     def _ensure_alien_overlay(self):
         """When the optional Alien Floyd's background mode is on, float a
@@ -1825,14 +2033,13 @@ class GalleryItemViewer(QWidget):
         """Replace screenshot list and restart slideshow."""
         self._timer.stop()
         self._stop_movie()
-        self._screenshots = list(urls or [])
+        self._screenshots = self._filter_shots(urls)
         self._shot_index  = 0
         self._shot_cache  = {}
         self._update_nav()
         if self._screenshots:
             self._show_index(0)
-            if len(self._screenshots) > 1:
-                self._timer.start()
+            self._maybe_start_timer()
             # Proactively fetch every URL so that broken ones (HTTP 404,
             # network error, etc.) are pruned up front rather than only
             # when the cycling timer happens to land on them.
@@ -1945,6 +2152,12 @@ class GalleryItemViewer(QWidget):
             if ev.type() == QEvent.Resize:
                 self._position_alien_overlay()
                 self._position_tag_overlay()
+                # Static pictures are rescaled by the self-scaling label itself;
+                # a playing movie's scaled size is refreshed here, since the
+                # label's size can change on a layout pass (e.g. refresh_meta)
+                # without the viewer itself resizing.
+                if self._movie is not None:
+                    self._scale_movie_to_label()
             elif ev.type() in (QEvent.MouseButtonPress, QEvent.MouseButtonDblClick):
                 if ev.button() == Qt.LeftButton:
                     self._do_close()
@@ -2075,16 +2288,11 @@ class GalleryItemViewer(QWidget):
         subtitle = self._placeholder_subtitle or self._title
         pm = zxfmt_make_placeholder_pixmap(label, subtitle)
         if pm and not pm.isNull():
-            sz = self._img_lbl.size()
-            if sz.width() > 0 and sz.height() > 0:
-                self._img_lbl.setPixmap(
-                    pm.scaled(sz, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-                )
-            else:
-                self._img_lbl.setPixmap(pm)
+            self._stop_movie()
+            self._img_lbl.set_image(pm)
             self._img_lbl.setText("")
         else:
-            self._img_lbl.setPixmap(QPixmap())
+            self._img_lbl.clear_image()
             self._img_lbl.setText("No preview available")
         self._position_tag_overlay()
 
@@ -2195,7 +2403,7 @@ class GalleryItemViewer(QWidget):
         self._timer.stop()
         self._shot_index = (self._shot_index - 1) % len(self._screenshots)
         self._show_index(self._shot_index)
-        self._timer.start()
+        self._maybe_start_timer()
 
     def _go_next(self):
         if not self._screenshots:
@@ -2203,7 +2411,7 @@ class GalleryItemViewer(QWidget):
         self._timer.stop()
         self._shot_index = (self._shot_index + 1) % len(self._screenshots)
         self._show_index(self._shot_index)
-        self._timer.start()
+        self._maybe_start_timer()
 
     def _update_nav(self):
         multi = len(self._screenshots) > 1
@@ -2212,6 +2420,7 @@ class GalleryItemViewer(QWidget):
         self._shot_counter.setText(
             f"{self._shot_index + 1} / {len(self._screenshots)}" if self._screenshots else ""
         )
+        self._update_shot_name()
 
     def _show_index(self, idx: int):
         if not self._screenshots:
@@ -2226,19 +2435,27 @@ class GalleryItemViewer(QWidget):
         # .gif URLs when a byte-fetcher is wired, so other formats (PNG, SCR, …)
         # keep their existing QPixmap path untouched.
         if self._gif_fetch_cb and self._url_is_gif(url):
+            # In "none" animation mode a GIF is frozen to its first frame (a
+            # static pixmap) so an animated screen — e.g. the 2-frame ZX FLASH
+            # effect — does not blink; Timed/On-hover still play it as a QMovie.
+            play = self._anim_should_cycle()
+            if not play and url in self._shot_cache:
+                self._display_pixmap(self._shot_cache[url])
+                return
             self._stop_movie()
-            self._img_lbl.setPixmap(QPixmap())
+            self._img_lbl.clear_image()
             self._img_lbl.setText("Loading…")
-            def _on_bytes(data, _u=url):
+            def _on_bytes(data, _u=url, _play=play):
                 # Ignore a late result if the user navigated to another frame.
                 if (self._shot_index >= len(self._screenshots)
                         or self._screenshots[self._shot_index] != _u):
                     return
-                movie = self._make_movie(data)
-                if movie is not None:
-                    self._play_movie(movie)
-                    return
-                # Not actually an animated GIF — fall back to a static pixmap.
+                if _play:
+                    movie = self._make_movie(data)
+                    if movie is not None:
+                        self._play_movie(movie)
+                        return
+                # "none" mode, or not an animated GIF — show a static frame.
                 if data:
                     pm = QPixmap()
                     pm.loadFromData(QByteArray(data))
@@ -2256,7 +2473,7 @@ class GalleryItemViewer(QWidget):
         if cached is not None:
             self._display_pixmap(cached)
             return
-        self._img_lbl.setPixmap(QPixmap())
+        self._img_lbl.clear_image()
         self._img_lbl.setText("Loading…")
         if self._extra_fetch_cb:
             def _on_px(pm, _u=url):
@@ -2282,6 +2499,12 @@ class GalleryItemViewer(QWidget):
             i = self._screenshots.index(url)
         except ValueError:
             return
+        # Whether the picture currently on screen is the one being removed. The
+        # validation prefetch prunes *every* broken screenshot URL, most of
+        # which the user is not looking at; re-rendering the displayed image for
+        # each of those made the current picture flicker (blank → repaint) every
+        # time a 404 trickled in — very visible when parked on a single frame.
+        was_current = (i == self._shot_index)
         del self._screenshots[i]
         self._shot_cache.pop(url, None)
         if not self._screenshots:
@@ -2300,7 +2523,10 @@ class GalleryItemViewer(QWidget):
         self._update_nav()
         if len(self._screenshots) <= 1:
             self._timer.stop()
-        self._show_index(new_idx)
+        # Only repaint when the displayed image actually changed: either it was
+        # the dropped URL, or the index now resolves to a different screenshot.
+        if was_current:
+            self._show_index(new_idx)
 
     def set_gif_fetch_cb(self, cb):
         """Register a callback ``cb(url, on_bytes)`` that fetches raw image bytes
@@ -2357,6 +2583,9 @@ class GalleryItemViewer(QWidget):
 
     def _play_movie(self, movie):
         self._stop_movie()
+        # Drop any stored still so the self-scaling label can't repaint it over
+        # the movie on a later resize.
+        self._img_lbl.clear_image()
         self._movie = movie
         try:
             movie.jumpToFrame(0)
@@ -2376,23 +2605,27 @@ class GalleryItemViewer(QWidget):
         if pm is None or pm.isNull():
             return
         self._stop_movie()
-        sz = self._img_lbl.size()
-        self._img_lbl.setPixmap(
-            pm.scaled(sz, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-        )
-        self._img_lbl.setText("")
+        # Hand the original to the self-scaling label; it fits it to its current
+        # size now and re-fits on every later resize, so the picture is never
+        # left at a stale size regardless of when it arrives relative to layout.
+        # Note: we deliberately do NOT setText("") here. set_image() debounces
+        # the actual paint by ~70ms, and blanking the label in the meantime made
+        # it flash empty on every (re)display; the scaled pixmap replaces any
+        # "Loading…" text on its own once it paints.
+        self._img_lbl.set_image(pm)
         self._position_tag_overlay()
+
+    def showEvent(self, ev):
+        super().showEvent(ev)
+        # Static pictures re-fit themselves via the self-scaling label; a
+        # playing movie needs its scaled size refreshed once we have a geometry.
+        if self._movie is not None:
+            self._scale_movie_to_label()
 
     def resizeEvent(self, ev):
         super().resizeEvent(ev)
         if self._movie is not None:
             self._scale_movie_to_label()
-        elif self._screenshots and self._shot_index < len(self._screenshots):
-            cached = self._shot_cache.get(self._screenshots[self._shot_index])
-            if cached:
-                self._display_pixmap(cached)
-        elif not self._screenshots and self._placeholder_label:
-            self._render_placeholder()
 
     def hideEvent(self, ev):
         self._timer.stop()

--- a/zxnu_media.py
+++ b/zxnu_media.py
@@ -535,6 +535,39 @@ def zxscr_url_is_scr(url) -> bool:
     return n.endswith(".scr")
 
 
+# Extensions the in-pane image viewer cannot render. Screenshot lists coming
+# from the online APIs (ZXDB "additionalDownloads" especially) sometimes mix
+# non-picture downloads — archives, tape/disk images, text files — in with the
+# real screens, because they are tagged with an image-ish "type". These are
+# filtered out so the viewer never tries to decode a .zip / .txt as a picture.
+ZXFMT_NON_IMAGE_EXTS = (
+    ".zip", ".rar", ".7z", ".gz", ".tar", ".lzh", ".arc",
+    ".txt", ".nfo", ".diz", ".doc", ".pdf", ".md", ".htm", ".html",
+    ".tap", ".tzx", ".pzx", ".cdt", ".csw",
+    ".z80", ".sna", ".szx", ".sp", ".slt", ".dck",
+    ".trd", ".scl", ".dsk", ".fdi", ".td0", ".mgt", ".img", ".hdf", ".mbr",
+    ".rom", ".bin", ".dat", ".pok", ".mp3", ".wav", ".ogg", ".ay", ".vtx",
+)
+
+
+def zxfmt_url_is_displayable_image(url) -> bool:
+    """Whether *url* can plausibly be shown by the image viewer.
+
+    Returns False for URLs that clearly point at a non-picture file (archive,
+    tape/disk image, text, audio, …) by extension. Synthetic ``placeholder://``
+    URLs and extensionless URLs are kept (the latter may still be images served
+    by an API endpoint); only known non-image extensions are rejected."""
+    if not isinstance(url, str) or not url:
+        return False
+    if url.startswith("placeholder://"):
+        return True
+    n = url.lower()
+    for sep in ("?", "#"):
+        if sep in n:
+            n = n.split(sep, 1)[0]
+    return not n.endswith(ZXFMT_NON_IMAGE_EXTS)
+
+
 # In-memory cache: url/base_name -> QPixmap (avoids repeated decoding)
 # Guarded by a lock because it is populated from background worker threads
 # (SCR byte conversion) and read from the GUI thread (extra-fetch callbacks).

--- a/zxnu_pygame.py
+++ b/zxnu_pygame.py
@@ -37,6 +37,8 @@ from PySide6.QtCore import Qt, QPoint, QTimer
 from PySide6.QtGui import QColor, QImage, QPainter
 from PySide6.QtWidgets import QWidget
 
+from zxnu_media import zxfmt_url_is_displayable_image
+
 
 # ── lazy pygame handle ──────────────────────────────────────────────────────
 _pg = None  # set by _ensure_pg()
@@ -3944,6 +3946,35 @@ class GalleryScene(_Scene):
         self._requested = set()
         self._scroll = 0
         self._hover = -1
+        # Thumbnails are scaled to the cell size every frame, so painting them
+        # while the host widget is still growing to its final size (e.g. right
+        # after toggling into pygame mode, before setCurrentWidget) makes a
+        # fast-arriving picture visibly "grow". Hold image drawing until the
+        # layout size has been stable briefly; show the "…" placeholder until
+        # then. (Network covers arrive after this anyway; cached SCR screens are
+        # the ones delivered fast enough to catch the resize.)
+        self._last_layout_size = None
+        self._settled = True
+        self._settle_timer = QTimer()
+        self._settle_timer.setSingleShot(True)
+        self._settle_timer.setInterval(150)
+        self._settle_timer.timeout.connect(self._on_settled)
+
+    def layout(self, size, dpr):
+        super().layout(size, dpr)
+        if size != self._last_layout_size:
+            self._last_layout_size = size
+            # Size changed (initial layout or resize): defer image drawing until
+            # it stays put for the settle interval.
+            self._settled = False
+            try:
+                self._settle_timer.start()
+            except Exception:
+                self._settled = True
+
+    def _on_settled(self):
+        self._settled = True
+        self.redraw()
 
     def set_entries(self, entries):
         self._entries = list(entries or [])
@@ -4033,7 +4064,10 @@ class GalleryScene(_Scene):
             img_rect = _pg.Rect(cell.x, cell.y, cw, img_h)
             surface.fill(C_IMG_BG, img_rect)
             surf = self._surfs.get(i)
-            if surf is not None:
+            # Only draw the picture once the layout size has settled; otherwise
+            # a fast-arriving thumbnail would be scaled to an intermediate cell
+            # size and then "grow" as the widget reaches its final size.
+            if surf is not None and self._settled:
                 scaled = _scale_keep_aspect(surf, cw, img_h)
                 sw, sh = scaled.get_size()
                 surface.blit(scaled, (cell.x + (cw - sw) // 2, cell.y + (img_h - sh) // 2))
@@ -4105,13 +4139,20 @@ class PygameItemViewer(_Scene):
                      "uninstall", "open_folder")
 
     def __init__(self, host, title="", info_rows=None, screenshots=None,
-                 extra_fetch_cb=None, tags=None):
+                 extra_fetch_cb=None, tags=None, anim_mode_getter=None):
         super().__init__()
         self.attach(host)
         self._title = title or ""
         self._rows = list(info_rows or [])
-        self._screens = [u for u in (screenshots or []) if u]
+        # Keep only renderable images — drop non-picture downloads (archives,
+        # tape/disk images, text files) the online APIs sometimes mix in.
+        self._screens = [u for u in (screenshots or [])
+                         if u and zxfmt_url_is_displayable_image(u)]
         self._extra_fetch = extra_fetch_cb
+        # Optional callable -> "hover"|"timer"|"none". "none" disables the
+        # auto-advancing slideshow (the user still pages with ◀/▶); mirrors the
+        # Qt GalleryItemViewer. Defaults to legacy always-cycling when absent.
+        self._anim_mode_getter = anim_mode_getter
         self._tags = [str(t) for t in (tags or []) if t]
         self._shot_idx = 0
         self._shot_cache = {}          # url -> Surface
@@ -4153,13 +4194,24 @@ class PygameItemViewer(_Scene):
             self._prefetch_all()
 
     # -- public API (matches GalleryItemViewer) ---------------------------
+    def _anim_should_cycle(self) -> bool:
+        """Whether the slideshow may auto-advance. Honours the global "Gallery
+        animation" setting: anything other than "none" cycles; "none" disables
+        auto-advance entirely."""
+        if self._anim_mode_getter is None:
+            return True
+        try:
+            return self._anim_mode_getter() != "none"
+        except Exception:
+            return True
+
     def install_into_stack(self, _stack, close_fn=None):
         self._close_fn = close_fn
         if self.host is not None:
             self.host.set_scene(self)
 
     def on_attach(self):
-        if len(self._screens) > 1:
+        if len(self._screens) > 1 and self._anim_should_cycle():
             self._timer.start()
 
     def on_detach(self):
@@ -4248,12 +4300,14 @@ class PygameItemViewer(_Scene):
 
     def set_screenshots(self, urls):
         self._timer.stop()
-        self._screens = [u for u in (urls or []) if u]
+        self._screens = [u for u in (urls or [])
+                         if u and zxfmt_url_is_displayable_image(u)]
         self._shot_idx = 0
         self._shot_cache = {}
         if self._screens:
             self._prefetch_all()
-            if len(self._screens) > 1 and self.host is not None and self.host.scene() is self:
+            if (len(self._screens) > 1 and self.host is not None
+                    and self.host.scene() is self and self._anim_should_cycle()):
                 self._timer.start()
         self.redraw()
 
@@ -4361,6 +4415,7 @@ class PygameItemViewer(_Scene):
             surface.blit(scaled, (area.x + (area.w - sw) // 2,
                                   area.y + (area.h - nav_h - sh) // 2))
             self._render_nav(surface, area)
+            self._render_shot_name(surface, area)
         else:
             label, subtitle = self._placeholder
             f1 = _font(self.s(28), bold=True)
@@ -4396,6 +4451,33 @@ class PygameItemViewer(_Scene):
         _draw_text(surface, "◀", self._prev_rect.x + self.s(9), y + self.s(1), f, C_TITLE)
         _draw_text(surface, "▶", self._next_rect.x + self.s(9), y + self.s(1), f, C_TITLE)
         _draw_text(surface, cnt, cx - cw // 2, y + self.s(3), _font(self.s(11)), C_TEXT_DIM)
+
+    def _shot_filename(self):
+        """File name of the screenshot currently on screen (blank for synthetic
+        placeholders) — shown under the image and handy as a diagnostic."""
+        if not self._screens:
+            return ""
+        url = self._screens[self._shot_idx % len(self._screens)]
+        if not isinstance(url, str) or url.startswith("placeholder://"):
+            return ""
+        s = url.split("?", 1)[0].split("#", 1)[0]
+        try:
+            from urllib.parse import unquote
+            s = unquote(s)
+        except Exception:
+            pass
+        return s.rstrip("/").rsplit("/", 1)[-1]
+
+    def _render_shot_name(self, surface, area):
+        name = self._shot_filename()
+        if not name:
+            return
+        f = _font(self.s(11))
+        has_nav = len(self._screens) > 1
+        y = area.bottom - self.s(44 if has_nav else 20)
+        text = _elide(name, f, area.w - self.s(20))
+        tw = f.size(text)[0]
+        _draw_text(surface, text, area.centerx - tw // 2, y, f, C_TEXT_DIM)
 
     def _render_tags(self, surface, area):
         f = _font(self.s(10), bold=True)


### PR DESCRIPTION
…king

- Settings: new "Gallery animation" = None option (alongside On hover / Timed).
- Item viewer and gallery tiles now honour the mode: None disables the auto-advancing slideshow and freezes animated GIFs (e.g. 2-frame ZX FLASH loading screens) to a static first frame; Timed/On-hover still animate.
- Fix item-viewer "small<->big" flicker: pin the metadata panel to a fixed width so the image area no longer reflows; stop re-rendering the current image when a background URL is pruned; drop the blank-on-redisplay; skip redundant same-size repaints.
- Skip non-image downloads (.zip/.txt/tape/disk/etc.) in both viewers.
- Show the current screenshot's file name under the image.
- ZXDB screenshots: prefer a static format (.png/.scr) over an animated .gif twin; dedup on (screen kind, normalised stem) so load/run screens named inconsistently collapse correctly; show the loading screen first.
- Route ZXInfo .scr / archive asset paths (/pub, /zxdb) to spectrumcomputing.co.uk (zxinfo.dk/media 404s them) so .scr screens actually render.