### PR TITLE
Add Retro (pygame) item viewers: text consoles, per-pane mode toggle,…

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -978,6 +978,7 @@ def zxdb_parse_game_detail(payload) -> dict:
         "remarks":     str(zxdb_pick(src, "remarks", "originalPublication")),
         "screenshot_url": "",
         "screenshots":   [],   # list of {url, type}
+        "text_files":    [],   # list of {url, type} — readable .txt/.nfo pages
         "downloads":   [],
     }
 
@@ -1023,7 +1024,12 @@ def zxdb_parse_game_detail(payload) -> dict:
     # Web-renderable raster formats; preferred over raw .scr screen dumps when
     # the same screen is offered in more than one format.
     web_image_exts = (".png", ".gif", ".jpg", ".jpeg", ".bmp")
+    # Plain-text assets (manuals/instructions/.nfo) that the Pygame item viewer
+    # can render as a log console.  Collected separately from screenshots so the
+    # detail-pane slideshow and thumbnails stay images-only.
+    text_exts = (".txt", ".nfo", ".diz", ".asc", ".md")
     seen_urls = set()
+    seen_text_urls = set()
     # Maps a screen's base filename (without extension) to its index in
     # detail["screenshots"], so the same picture offered both as a PNG and as
     # a raw .scr screen dump (e.g. ZXInfo "additionalDownloads") is counted
@@ -1081,6 +1087,15 @@ def zxdb_parse_game_detail(payload) -> dict:
                 ))
             )
             if not is_image:
+                # Surface readable text files (e.g. "Instructions | Document
+                # (TXT)") as viewer pages — the Pygame item viewer renders them
+                # as a log console; the Qt viewer filters them back out.
+                if ulow.endswith(text_exts) and url not in seen_text_urls:
+                    seen_text_urls.add(url)
+                    detail["text_files"].append({
+                        "url":  url,
+                        "type": str(a.get("type") or ""),
+                    })
                 continue
             if url in seen_urls:
                 continue
@@ -2075,6 +2090,114 @@ def _gif_fetch_bytes(url, on_bytes):
                         lambda _e: on_bytes(None), gated=True)
 
 
+# Readable-text extensions surfaced as Pygame item-viewer "log console" pages.
+_GALLERY_TEXT_EXTS = (".txt", ".nfo", ".diz", ".asc", ".md")
+
+
+def _gallery_text_urls(files):
+    """From a list of file/download descriptors, return the URLs that point at a
+    readable text file (instructions/.nfo/…), preserving order and de-duping.
+
+    *files* items may be download dicts (``{"url", "filename"/"fileName"/"name",
+    "type", "format"}``) or ``(url, name)`` pairs. Detection is by the file
+    name's extension, so an extension-less download URL is still recognised when
+    its filename is known (the Pygame viewer is told to treat it as text via
+    GalleryItemViewer-compatible add_text_pages)."""
+    out, seen = [], set()
+    for f in files or []:
+        if isinstance(f, dict):
+            url = f.get("url") or f.get("path") or ""
+            name = (f.get("filename") or f.get("fileName")
+                    or f.get("name") or url)
+        elif isinstance(f, (tuple, list)) and len(f) >= 2:
+            url, name = f[0], f[1]
+        else:
+            url, name = f, f
+        if not url or url in seen:
+            continue
+        base = str(name or url).lower().split("?", 1)[0].split("#", 1)[0]
+        if base.endswith(_GALLERY_TEXT_EXTS):
+            seen.add(url)
+            out.append(url)
+    return out
+
+
+def _gallery_add_text_pages(viewer, files):
+    """Surface any readable text files in *files* as console pages on *viewer*
+    (no-op for the Qt GalleryItemViewer, which has no add_text_pages). Returns
+    the list of URLs added so callers can decide whether a fallback description
+    page is still needed."""
+    add = getattr(viewer, "add_text_pages", None)
+    if add is None:
+        return []
+    urls = _gallery_text_urls(files)
+    if urls:
+        add(urls)
+    return urls
+
+
+def _gallery_add_description_page(viewer, description, label="Description"):
+    """Surface the item's description/About text as a Pygame log-console page
+    (no-op for the Qt viewer or an empty description). Used as the readable-text
+    fallback for sources without a standalone .txt file."""
+    add = getattr(viewer, "add_text_document", None)
+    if add is None or not description:
+        return
+    add(label, description)
+
+
+def _make_retro_toggle_button(window, flag_attr, status_cb=None, on_change=None):
+    """Build a checkable "Classic ↔ Retro" toggle button for a gallery pane.
+
+    When checked the pane opens items in the Retro (pygame) item viewer — which
+    renders .txt/instruction pages as a green log console — instead of the
+    Classic Qt viewer. The chosen mode is stored on *window* as *flag_attr*
+    (e.g. ``_zxdb_item_retro``). The label mirrors the SD/NextSync/Unite! pygame
+    buttons: it shows the mode you will switch *to* ("🎮 Retro" while Classic,
+    "🖼 Classic" while Retro). *on_change(checked)* — when given — is called after
+    a successful toggle so the caller can persist the choice. Returns the
+    QPushButton."""
+    btn = QPushButton("🎮 Retro")
+    btn.setCheckable(True)
+    btn.setToolTip(
+        "Open items in the Retro (pygame) viewer.\n"
+        "Retro mode renders instruction/.txt pages as a green log console.\n"
+        "Requires pygame-ce (pip install pygame-ce).")
+    setattr(window, flag_attr, False)
+
+    def _toggled(checked):
+        if checked:
+            try:
+                from zxnu_pygame import pygame_available
+                ok, why = pygame_available()
+            except Exception as exc:
+                ok, why = False, str(exc)
+            if not ok:
+                btn.blockSignals(True)
+                btn.setChecked(False)
+                btn.blockSignals(False)
+                btn.setToolTip(f"{why}\nInstall with: pip install pygame-ce")
+                if status_cb is not None:
+                    try:
+                        status_cb("Retro mode unavailable — run: pip install pygame-ce")
+                    except Exception:
+                        pass
+                return
+            setattr(window, flag_attr, True)
+            btn.setText("🖼 Classic")
+        else:
+            setattr(window, flag_attr, False)
+            btn.setText("🎮 Retro")
+        if on_change is not None:
+            try:
+                on_change(checked)
+            except Exception:
+                pass
+
+    btn.toggled.connect(_toggled)
+    return btn
+
+
 
 
 
@@ -3066,6 +3189,28 @@ class MainWindow(QMainWindow):
                         self.main_pygame_button.setChecked(True)
                     finally:
                         self._main_pygame_restoring = False
+
+                # Restore each pane's Classic/Retro item-viewer choice. Routed
+                # through the toggle button so the pygame-availability check and
+                # label update are reused; persisting during restore is a no-op
+                # (save_configuration_file is guarded while _initialising).
+                self._retro_restoring = True
+                try:
+                    for _retro_key, _retro_btn_attr in (
+                        (SETTING_GETIT_ITEM_RETRO,     "getit_retro_button"),
+                        (SETTING_ZXDB_ITEM_RETRO,      "zxdb_retro_button"),
+                        (SETTING_ZXART_ITEM_RETRO,     "zxart_retro_button"),
+                        (SETTING_ITCHIO_ITEM_RETRO,    "itchio_retro_button"),
+                        (SETTING_FAVORITES_ITEM_RETRO, "favorites_retro_button"),
+                    ):
+                        _retro_pref = configuration_dictionary.get(
+                            _retro_key, "").strip().lower()
+                        _retro_btn = getattr(self, _retro_btn_attr, None)
+                        if (_retro_pref in ("true", "1", "yes") and _retro_btn is not None
+                                and not _retro_btn.isChecked()):
+                            _retro_btn.setChecked(True)
+                finally:
+                    self._retro_restoring = False
 
                 # itch.io tab: prefill the saved API key and apply the saved
                 # show/hide preference (the tab is built visible by default).
@@ -7659,6 +7804,18 @@ class MainWindow(QMainWindow):
         for c in CONFIG_FILE_SETTINGS:
             configuration_dictionary[c] = ""
 
+        def _persist_retro(key, checked):
+            """Persist a pane's Classic/Retro item-viewer choice to the config
+            file. Skips the file write while restoring saved settings (the value
+            is already loaded) and is a no-op during __init__ anyway via
+            save_configuration_file's _initialising guard."""
+            try:
+                configuration_dictionary[key] = "true" if checked else "false"
+                if not getattr(self, "_retro_restoring", False):
+                    save_configuration_file()
+            except Exception:
+                pass
+
         # Pre-populate color defaults so save works correctly before first load
         configuration_dictionary[SETTING_COLOR_UP_DIRECTORY] = DEFAULT_COLOR_UP_DIRECTORY
         configuration_dictionary[SETTING_COLOR_DIR_NAME]     = DEFAULT_COLOR_DIR_NAME
@@ -8216,7 +8373,7 @@ class MainWindow(QMainWindow):
         self._main_retro_log = None
         self._main_pygame_on = False
 
-        self.main_pygame_button = QPushButton("🎮 Pygame")
+        self.main_pygame_button = QPushButton("🎮 Retro")
         self.main_pygame_button.setCheckable(True)
         self.main_pygame_button.setToolTip(
             "Switch the SD Card log window to a retro 8-bit pygame display:\n"
@@ -8257,7 +8414,7 @@ class MainWindow(QMainWindow):
             btn = self.main_pygame_button
             btn.blockSignals(True)
             btn.setChecked(False)
-            btn.setText("🎮 Pygame")
+            btn.setText("🎮 Retro")
             btn.blockSignals(False)
             btn.setEnabled(False)
             if reason:
@@ -8300,7 +8457,7 @@ class MainWindow(QMainWindow):
                 _main_pygame_persist(True)
             else:
                 self._main_pygame_on = False
-                self.main_pygame_button.setText("🎮 Pygame")
+                self.main_pygame_button.setText("🎮 Retro")
                 if self._main_retro_log is not None:
                     self._main_retro_log.stop()
                 self.main_log_stack.setCurrentWidget(self.listWidgetLog)
@@ -8850,7 +9007,7 @@ class MainWindow(QMainWindow):
         if not hasattr(self, "_nextsync_pygame_anim"):
             self._nextsync_pygame_anim = True
 
-        self.nextsync_pygame_button = QPushButton("🎮 Pygame")
+        self.nextsync_pygame_button = QPushButton("🎮 Retro")
         self.nextsync_pygame_button.setCheckable(True)
         self.nextsync_pygame_button.setToolTip(
             "Switch the NextSync log window to a retro 8-bit pygame display:\n"
@@ -8887,7 +9044,7 @@ class MainWindow(QMainWindow):
             btn = self.nextsync_pygame_button
             btn.blockSignals(True)
             btn.setChecked(False)
-            btn.setText("🎮 Pygame")
+            btn.setText("🎮 Retro")
             btn.blockSignals(False)
             btn.setEnabled(False)
             if reason:
@@ -8930,7 +9087,7 @@ class MainWindow(QMainWindow):
                 _nextsync_pygame_persist(True)
             else:
                 self._nextsync_pygame_on = False
-                self.nextsync_pygame_button.setText("🎮 Pygame")
+                self.nextsync_pygame_button.setText("🎮 Retro")
                 if self._nextsync_retro_log is not None:
                     self._nextsync_retro_log.stop()
                 self.nextsync_log_stack.setCurrentWidget(self.nextsync_log)
@@ -9089,6 +9246,11 @@ class MainWindow(QMainWindow):
             "Persisted across sessions in the config file."
         )
         getit_search_row.addWidget(self.getit_view_combo)
+        self.getit_retro_button = _make_retro_toggle_button(
+            self, "_getit_item_retro",
+            on_change=lambda c, k=SETTING_GETIT_ITEM_RETRO: (
+                _persist_retro(k, c), self._pane_retro_gallery_set("getit", c)))
+        getit_search_row.addWidget(self.getit_retro_button)
 
         self.getit_status_label = QLabel("")
         getit_search_row.addWidget(self.getit_status_label, 1)
@@ -9423,6 +9585,7 @@ class MainWindow(QMainWindow):
                 self.getit_results_table.setItem(row, 3, QTableWidgetItem(e["size"]))
             self._getit_last_entries = list(entries)
             self.getit_gallery_view.populate(entries)
+            self._pane_retro_gallery_refresh("getit")
             self.getit_gallery_view.select_entry(
                 lambda _e, _sel=self._getit_selected_id: bool(_sel) and _e.get("id") == _sel
             )
@@ -10011,6 +10174,25 @@ class MainWindow(QMainWindow):
             viewer.set_placeholder(_ph_label, title)
             _fav_entry_getit = {**entry, "_fav_source": "getit"}
             viewer.set_favorite_hooks(_fav_entry_getit, self._fav_is, self._fav_toggle)
+            # Fetch the GetIt detail (DESC + real LINK filename) so the Pygame
+            # viewer can show readable text: if the entry's file is itself a
+            # text file, surface the file; otherwise show its description.
+            if getattr(viewer, "add_text_document", None) is not None:
+                def _getit_text_fn(_eid=eid):
+                    return getit_parse_detail(getit_fetch(f"/nx/{_eid}/f/"))
+
+                def _getit_text_ok(d, _eid=eid):
+                    link = (d.get("LINK") or "").strip()
+                    added = []
+                    if link.lower().endswith(_GALLERY_TEXT_EXTS):
+                        added = _gallery_add_text_pages(viewer, [{
+                            "url": f"{GETIT_BASE_URL}/nx/{_eid}/", "filename": link,
+                        }])
+                    if not added:
+                        _gallery_add_description_page(viewer, d.get("DESC"))
+
+                self._getit_viewer_text_thread = getit_run_in_thread(
+                    _getit_text_fn, _getit_text_ok, lambda _e: None)
 
             # ── action buttons ──────────────────────────────────────────
             default_name = self._getit_selected_link or f"{eid}.bin"
@@ -10048,7 +10230,8 @@ class MainWindow(QMainWindow):
                 )
             return viewer
 
-        self.getit_gallery_view.cell_dbl_clicked.connect(_getit_open_gallery_viewer)
+        self.getit_gallery_view.cell_dbl_clicked.connect(
+            lambda e: self._pane_open_item("getit", e, getattr(self, "_getit_item_retro", False)))
 
         def _getit_table_on_double_clicked(item):
             row = self.getit_results_table.currentRow()
@@ -10070,7 +10253,7 @@ class MainWindow(QMainWindow):
                     "size":   (self.getit_results_table.item(row, 3).text()
                                if self.getit_results_table.item(row, 3) else ""),
                 }
-            _getit_open_gallery_viewer(entry)
+            self._pane_open_item("getit", entry, getattr(self, "_getit_item_retro", False))
 
         self.getit_results_table.itemDoubleClicked.connect(_getit_table_on_double_clicked)
 
@@ -10080,6 +10263,8 @@ class MainWindow(QMainWindow):
                 mode = "table"
             self._getit_view_mode = mode
             self.getit_view_stack.setCurrentIndex(1 if mode == "gallery" else 0)
+            if getattr(self, "_pane_retro_gallery_refresh", None):
+                self._pane_retro_gallery_refresh("getit")
             _table = (mode == "table")
             # Keep the right column visible in both modes so the zxnext.uk site
             # link stays shown (mirrors ZXDB/zxArt); only the preview screenshot
@@ -10620,6 +10805,11 @@ class MainWindow(QMainWindow):
             "Persisted across sessions in the config file."
         )
         zxdb_search_row.addWidget(self.zxdb_view_combo)
+        self.zxdb_retro_button = _make_retro_toggle_button(
+            self, "_zxdb_item_retro",
+            on_change=lambda c, k=SETTING_ZXDB_ITEM_RETRO: (
+                _persist_retro(k, c), self._pane_retro_gallery_set("zxdb", c)))
+        zxdb_search_row.addWidget(self.zxdb_retro_button)
 
         self.zxdb_status_label = QLabel("")
         self.zxdb_status_label.setCursor(Qt.ArrowCursor)
@@ -11117,6 +11307,7 @@ class MainWindow(QMainWindow):
                 self.zxdb_results_table.setItem(row, 5, QTableWidgetItem(e.get("genre", "")))
             self._zxdb_last_entries = list(entries)
             self.zxdb_gallery_view.populate(entries)
+            self._pane_retro_gallery_refresh("zxdb")
             self.zxdb_gallery_view.select_entry(
                 lambda _e, _sel=self._zxdb_selected_id: bool(_sel) and _e.get("id") == _sel
             )
@@ -12504,14 +12695,21 @@ class MainWindow(QMainWindow):
                 kind2, detail, shots = res
                 if kind2 == "magazine":
                     return
-                urls = [s.get("url") for s in shots if isinstance(s, dict) and s.get("url")]
-                if urls:
-                    viewer.set_screenshots(urls)
+                img_urls = [s.get("url") for s in shots
+                            if isinstance(s, dict) and s.get("url")]
+                if img_urls:
+                    viewer.set_screenshots(img_urls)
                 else:
                     _dls_tmp = _filter_download_urls(detail.get("downloads", []) or [])
                     _ph_label, _ph_fname = zxfmt_pick_best_download(_dls_tmp)
                     _ph_sub = _ph_fname or detail.get("title") or title
                     viewer.set_placeholder(_ph_label, _ph_sub)
+                # Surface readable text files (e.g. instructions) as Pygame
+                # log-console pages after the pictures; the Qt viewer ignores
+                # them. When there is none, fall back to the description.
+                if not _gallery_add_text_pages(viewer, detail.get("text_files")):
+                    _gallery_add_description_page(
+                        viewer, detail.get("description") or detail.get("remarks"))
                 rows = [
                     ("Title:",       detail.get("title", title)),
                     ("Year:",        str(detail.get("year", "") or "")),
@@ -12537,7 +12735,8 @@ class MainWindow(QMainWindow):
                 )
             return viewer
 
-        self.zxdb_gallery_view.cell_dbl_clicked.connect(_zxdb_open_gallery_viewer)
+        self.zxdb_gallery_view.cell_dbl_clicked.connect(
+            lambda e: self._pane_open_item("zxdb", e, getattr(self, "_zxdb_item_retro", False)))
 
         def _zxdb_apply_view_mode(mode: str, *, persist: bool = True):
             mode = (mode or "table").lower()
@@ -12545,6 +12744,8 @@ class MainWindow(QMainWindow):
                 mode = "table"
             self._zxdb_view_mode = mode
             self.zxdb_view_stack.setCurrentIndex(1 if mode == "gallery" else 0)
+            if getattr(self, "_pane_retro_gallery_refresh", None):
+                self._pane_retro_gallery_refresh("zxdb")
             _table = (mode == "table")
             if hasattr(self, '_zxdb_preview_container'):
                 self._zxdb_preview_container.setVisible(_table)
@@ -12610,7 +12811,7 @@ class MainWindow(QMainWindow):
                         zxdb_set_status(f"Error loading issues: {err[1]}")
                     self._zxdb_detail_thread = getit_run_in_thread(_fn_dbl, _on_ok_dbl, _on_err_dbl)
             else:
-                _zxdb_open_gallery_viewer(entry)
+                self._pane_open_item("zxdb", entry, getattr(self, "_zxdb_item_retro", False))
 
         self.zxdb_results_table.itemDoubleClicked.connect(zxdb_on_row_double_clicked)
 
@@ -13572,6 +13773,11 @@ class MainWindow(QMainWindow):
             "Persisted across sessions in the config file."
         )
         zxart_search_row.addWidget(self.zxart_view_combo)
+        self.zxart_retro_button = _make_retro_toggle_button(
+            self, "_zxart_item_retro",
+            on_change=lambda c, k=SETTING_ZXART_ITEM_RETRO: (
+                _persist_retro(k, c), self._pane_retro_gallery_set("zxart", c)))
+        zxart_search_row.addWidget(self.zxart_retro_button)
 
         self.zxart_language_text_label = QLabel(_zxart_tr("Language:"))
         zxart_search_row.addWidget(self.zxart_language_text_label)
@@ -14418,6 +14624,7 @@ class MainWindow(QMainWindow):
             if _pending_author_rows:
                 _zxart_resolve_author_cols_async(_pending_author_rows)
             self.zxart_gallery_view.populate(entries)
+            self._pane_retro_gallery_refresh("zxart")
             self.zxart_gallery_view.select_entry(
                 lambda _e, _sel=self._zxart_selected_id: bool(_sel) and _e.get("id") == _sel
             )
@@ -15434,7 +15641,7 @@ class MainWindow(QMainWindow):
                 return
             entry = id_item.data(Qt.UserRole) or {}
             if entry:
-                _zxart_open_gallery_viewer(entry)
+                self._pane_open_item("zxart", entry, getattr(self, "_zxart_item_retro", False))
 
         self.zxart_results_table.itemDoubleClicked.connect(zxart_on_row_double_clicked)
 
@@ -15692,6 +15899,21 @@ class MainWindow(QMainWindow):
                                 _ph_label = zxfmt_label_for_name("x." + _fmts[0].lower())
                     viewer.set_placeholder(_ph_label, fetched_title)
                 _gallery_viewer_refresh_meta(viewer, fetched_title, rows)
+                # Surface readable text files among the releases (.txt/.nfo
+                # notes) as Pygame log-console pages; the Qt viewer ignores them.
+                # When there is none, fall back to the description (pulled from
+                # the metadata rows by its translated label).
+                _txt_added = []
+                if releases:
+                    _txt_added = _gallery_add_text_pages(
+                        viewer,
+                        [{"url": r.get("file"), "fileName": r.get("fileName")}
+                         for r in releases if isinstance(r, dict)])
+                if not _txt_added:
+                    _desc_label = _zxart_tr("Description:")
+                    _desc = next((r[1] for r in (rows or [])
+                                  if r and r[0] == _desc_label and len(r) > 1 and r[1]), "")
+                    _gallery_add_description_page(viewer, _desc)
                 # Mirror the ZXDB viewer: once metadata resolves, (re)assert the
                 # action-button visibility so "Download" / "Send to SD card" /
                 # "Send via NextSync" are shown when downloads are enabled for
@@ -15736,7 +15958,8 @@ class MainWindow(QMainWindow):
                 )
             return viewer
 
-        self.zxart_gallery_view.cell_dbl_clicked.connect(_zxart_open_gallery_viewer)
+        self.zxart_gallery_view.cell_dbl_clicked.connect(
+            lambda e: self._pane_open_item("zxart", e, getattr(self, "_zxart_item_retro", False)))
 
         def _zxart_apply_view_mode(mode: str, *, persist: bool = True):
             mode = (mode or "table").lower()
@@ -15744,6 +15967,8 @@ class MainWindow(QMainWindow):
                 mode = "table"
             self._zxart_view_mode = mode
             self.zxart_view_stack.setCurrentIndex(1 if mode == "gallery" else 0)
+            if getattr(self, "_pane_retro_gallery_refresh", None):
+                self._pane_retro_gallery_refresh("zxart")
             _table = (mode == "table")
             if hasattr(self, '_zxart_preview_container'):
                 self._zxart_preview_container.setVisible(_table)
@@ -16615,7 +16840,10 @@ class MainWindow(QMainWindow):
                     self._tab_widget.setCurrentIndex(i)
                     break
             try:
-                opener(entry)
+                # Honour the Favorites pane's Classic/Retro toggle, opening the
+                # item in the source pane's chosen viewer mode.
+                self._pane_open_item(
+                    src, entry, getattr(self, "_favorites_item_retro", False))
             except Exception:
                 pass
 
@@ -16638,6 +16866,11 @@ class MainWindow(QMainWindow):
             "Persisted across sessions in the config file."
         )
         fav_top_row.addWidget(self.favorites_view_combo)
+        self.favorites_retro_button = _make_retro_toggle_button(
+            self, "_favorites_item_retro",
+            on_change=lambda c, k=SETTING_FAVORITES_ITEM_RETRO: (
+                _persist_retro(k, c), self._pane_retro_gallery_set("favorites", c)))
+        fav_top_row.addWidget(self.favorites_retro_button)
         fav_top_row.addStretch(1)
 
         # ── Table view of favorites ────────────────────────────────────────
@@ -16794,7 +17027,7 @@ class MainWindow(QMainWindow):
         )
         allinone_search_row.addWidget(self.allinone_view_combo)
 
-        self.allinone_pygame_button = QPushButton("🎮 Pygame")
+        self.allinone_pygame_button = QPushButton("🎮 Retro")
         self.allinone_pygame_button.setCheckable(True)
         self.allinone_pygame_button.setToolTip(
             "Switch the Unite! Table & Gallery views to a pygame-rendered\n"
@@ -17111,6 +17344,11 @@ class MainWindow(QMainWindow):
                 "Switch between the classic table view and the picture (gallery)\n"
                 "view. Persisted across sessions in the config file.")
             _itchio_crow.addWidget(self.itchio_view_combo)
+            self.itchio_retro_button = _make_retro_toggle_button(
+                self, "_itchio_item_retro",
+                on_change=lambda c, k=SETTING_ITCHIO_ITEM_RETRO: (
+                    _persist_retro(k, c), self._pane_retro_gallery_set("itchio", c)))
+            _itchio_crow.addWidget(self.itchio_retro_button)
             _itchio_v.addLayout(_itchio_crow)
 
             # --- Search row (filters the library: collections + purchases) ---
@@ -17318,12 +17556,13 @@ class MainWindow(QMainWindow):
                 self._itchio_installed_names_cache = None
                 self.itchio_gallery_view.populate(entries)
                 _itchio_fill_table(entries)
+                self._pane_retro_gallery_refresh("itchio")
             self._itchio_populate = _itchio_populate
 
             def _itchio_table_dbl(_idx):
                 e = _itchio_table_entry_for_row(self.itchio_results_table.currentRow())
                 if e is not None:
-                    _itchio_open_gallery_viewer(e)
+                    self._pane_open_item("itchio", e, getattr(self, "_itchio_item_retro", False))
             self.itchio_results_table.doubleClicked.connect(_itchio_table_dbl)
 
             def _itchio_apply_view_mode(mode, *, persist=True):
@@ -17332,6 +17571,8 @@ class MainWindow(QMainWindow):
                     mode = "gallery"
                 self._itchio_view_mode = mode
                 self.itchio_view_stack.setCurrentIndex(0 if mode == "table" else 1)
+                if getattr(self, "_pane_retro_gallery_refresh", None):
+                    self._pane_retro_gallery_refresh("itchio")
                 cb = self.itchio_view_combo
                 target = 0 if mode == "table" else 1
                 if cb.currentIndex() != target:
@@ -17423,6 +17664,13 @@ class MainWindow(QMainWindow):
                 viewer._itchio_busy = False   # True while an install runs
 
                 viewer._itchio_busy = False   # True while an install runs
+
+                # itch.io items are game uploads (zip/exe), not standalone text
+                # files, so surface the item's About/description as the readable
+                # Pygame log-console page (no-op for the Qt viewer).
+                _gallery_add_description_page(
+                    viewer, entry.get("short_text") or entry.get("description"),
+                    label="About")
 
                 def _itchio_open_install_folder(_=False, _e=entry):
                     """Open the item's install folder (or the itch.io downloads
@@ -17781,7 +18029,8 @@ class MainWindow(QMainWindow):
                 return viewer
 
             self._itchio_open_gallery_viewer = _itchio_open_gallery_viewer
-            self.itchio_gallery_view.cell_dbl_clicked.connect(_itchio_open_gallery_viewer)
+            self.itchio_gallery_view.cell_dbl_clicked.connect(
+                lambda e: self._pane_open_item("itchio", e, getattr(self, "_itchio_item_retro", False)))
 
             # --- Collection / search loading (async) ---
             def _itchio_load_collection_games(cid):
@@ -18915,6 +19164,7 @@ class MainWindow(QMainWindow):
         def _fav_repopulate():
             try:
                 self.favorites_gallery_view.populate(list(self._favorites))
+                self._pane_retro_gallery_refresh("favorites")
             except Exception:
                 pass
             try:
@@ -18965,6 +19215,8 @@ class MainWindow(QMainWindow):
                 mode = "gallery"
             self._favorites_view_mode = mode
             self.favorites_view_stack.setCurrentIndex(1 if mode == "gallery" else 0)
+            if getattr(self, "_pane_retro_gallery_refresh", None):
+                self._pane_retro_gallery_refresh("favorites")
             cb = self.favorites_view_combo
             target_idx = 1 if mode == "gallery" else 0
             if cb.currentIndex() != target_idx:
@@ -19084,8 +19336,209 @@ class MainWindow(QMainWindow):
             except Exception:
                 viewer = None
             if viewer is not None:
+                # In Pygame mode a content item may be a plain-text file (.txt,
+                # .nfo, …); wire the raw-bytes fetcher so the viewer can render
+                # it as a retro log console instead of dropping it. The same
+                # fetcher also streams animated .gif screenshots.
+                if hasattr(viewer, "set_text_fetch_cb"):
+                    viewer.set_text_fetch_cb(_gif_fetch_bytes)
+                if hasattr(viewer, "set_gif_fetch_cb"):
+                    viewer.set_gif_fetch_cb(_gif_fetch_bytes)
                 viewer.install_into_stack(None, close_fn=lambda: host.set_scene(prev))
         self._allinone_pygame_open_viewer = _allinone_pygame_open_viewer
+
+        # ── Per-pane Classic ↔ Retro item-viewer routing ────────────────────
+        # Each source pane (GetIt/ZXDB/zxArt/itch.io) can open an item either in
+        # the Classic Qt GalleryItemViewer or, when its Retro toggle is on, in
+        # the pygame PygameItemViewer (which renders .txt/instruction pages as a
+        # log console). The pygame viewer needs a PygameSurfaceWidget host added
+        # to the pane's own stack; created lazily and reused across opens.
+        self._pane_pygame_hosts = {}
+
+        def _pane_info(src):
+            return {
+                "getit": (_getit_open_gallery_viewer, getattr(self, "_getit_stack", None)),
+                "zxdb":  (_zxdb_open_gallery_viewer,  getattr(self, "_zxdb_stack", None)),
+                "zxart": (_zxart_open_gallery_viewer, getattr(self, "_zxart_stack", None)),
+                "itchio": (getattr(self, "_itchio_open_gallery_viewer", None),
+                           getattr(self, "_itchio_stack", None)),
+            }.get(src)
+
+        def _ensure_pane_host(src, stack):
+            host = self._pane_pygame_hosts.get(src)
+            if host is None:
+                import zxnu_pygame as _zpg
+                host = _zpg.PygameSurfaceWidget()
+                try:
+                    host.enable_background(getattr(self, "_allinone_pygame_anim", True))
+                except Exception:
+                    pass
+                stack.addWidget(host)
+                self._pane_pygame_hosts[src] = host
+            return host
+
+        def _pane_open_item(src, entry, retro=False):
+            info = _pane_info(src)
+            if not info or info[0] is None:
+                return None
+            opener, stack = info
+            if retro and stack is not None:
+                try:
+                    from zxnu_pygame import pygame_available, PygameItemViewer
+                    ok, _why = pygame_available()
+                except Exception:
+                    ok = False
+                if ok:
+                    host = _ensure_pane_host(src, stack)
+                    viewer = opener(
+                        entry,
+                        make_viewer=lambda **kw: PygameItemViewer(
+                            host, anim_mode_getter=lambda: self._gallery_anim_mode, **kw),
+                        install=False,
+                    )
+                    if viewer is not None:
+                        if hasattr(viewer, "set_text_fetch_cb"):
+                            viewer.set_text_fetch_cb(_gif_fetch_bytes)
+                        if hasattr(viewer, "set_gif_fetch_cb"):
+                            viewer.set_gif_fetch_cb(_gif_fetch_bytes)
+                        viewer.install_into_stack(
+                            None, close_fn=lambda _s=stack: _s.setCurrentIndex(0))
+                        stack.setCurrentWidget(host)
+                    return viewer
+            # Classic (Qt) path — the opener installs into the pane stack itself.
+            return opener(entry)
+        self._pane_open_item = _pane_open_item
+
+        # ── Per-pane Retro (pygame-rendered) gallery grid ───────────────────
+        # When a pane's Retro toggle is on, its results grid is rendered by the
+        # pygame TableScene/GalleryScene (like the Unite! tab) instead of the Qt
+        # table/gallery. Built lazily and added as index 2 of the pane's
+        # <src>_view_stack; reuses the getters the pane already registered in
+        # self._fav_fetchers.
+        self._pane_retro_galleries = {}   # src -> (host, table_scene, gallery_scene)
+
+        def _pane_gallery_runtime(src):
+            # (view_stack, entries_attr, view_mode_attr, label)
+            return {
+                "getit":  (getattr(self, "getit_view_stack", None),  "_getit_last_entries",  "_getit_view_mode",  "GetIt"),
+                "zxdb":   (getattr(self, "zxdb_view_stack", None),   "_zxdb_last_entries",   "_zxdb_view_mode",   "ZXDB"),
+                "zxart":  (getattr(self, "zxart_view_stack", None),  "_zxart_last_entries",  "_zxart_view_mode",  "zxArt"),
+                "itchio": (getattr(self, "itchio_view_stack", None), "_itchio_last_entries", "_itchio_view_mode", "itch.io"),
+                "favorites": (getattr(self, "favorites_view_stack", None), "_favorites", "_favorites_view_mode", "Favorites"),
+            }.get(src)
+
+        def _pane_retro_getters(src):
+            # (title, info, thumb, open_cb, source_label, is_fav, toggle_fav)
+            if src == "favorites":
+                return (_fav_title_getter, _fav_info_getter, _fav_thumb_fetch,
+                        lambda e: self._fav_open_fullscreen(e),
+                        self._fav_source_label_for,
+                        lambda e: self._fav_is(e), lambda e: self._fav_toggle(e))
+            f = (getattr(self, "_fav_fetchers", None) or {}).get(src) or {}
+            title = f.get("title") or (lambda e: str(e.get("title") or e.get("id") or ""))
+            info = f.get("info") or (lambda e: "")
+            thumb = f.get("thumb")
+            label = {"getit": "GetIt", "zxdb": "ZXDB", "zxart": "zxArt",
+                     "itchio": "itch.io"}.get(src, src)
+            return (title, info, thumb,
+                    lambda e, _s=src: self._pane_open_item(_s, e, True),
+                    lambda _e, _l=label: _l,
+                    lambda e, _s=src: self._fav_is({**e, "_fav_source": _s}),
+                    lambda e, _s=src: self._fav_toggle({**e, "_fav_source": _s}))
+
+        def _pane_retro_gallery_build(src):
+            built = self._pane_retro_galleries.get(src)
+            if built is not None:
+                return built
+            cfg = _pane_gallery_runtime(src)
+            if not cfg or cfg[0] is None:
+                return None
+            import zxnu_pygame as _zpg
+            title, info, thumb, open_cb, src_label, is_fav, tog_fav = _pane_retro_getters(src)
+            host = _zpg.PygameSurfaceWidget()
+            table = _zpg.TableScene(source_label_getter=src_label, title_getter=title,
+                                    info_getter=info, open_cb=open_cb)
+            gallery = _zpg.GalleryScene(title_getter=title, source_label_getter=src_label,
+                                        thumb_fetch_cb=thumb, is_favorite_cb=is_fav,
+                                        toggle_favorite_cb=tog_fav, open_cb=open_cb,
+                                        cols_getter=lambda: self._gallery_cols)
+            # Animate .gif thumbnails regardless of the "Gallery animation"
+            # setting, mirroring the Qt gallery cells.
+            try:
+                gallery.set_gif_fetch_cb(_gif_fetch_bytes)
+            except Exception:
+                pass
+            try:
+                host.enable_background(getattr(self, "_allinone_pygame_anim", True))
+            except Exception:
+                pass
+            cfg[0].addWidget(host)   # index 2 of the pane's view stack
+            self._pane_retro_galleries[src] = (host, table, gallery)
+            return self._pane_retro_galleries[src]
+
+        def _pane_retro_gallery_feed(src):
+            built = self._pane_retro_galleries.get(src)
+            if built is None:
+                return
+            cfg = _pane_gallery_runtime(src)
+            entries = list(getattr(self, cfg[1], []) or []) if cfg else []
+            try:
+                built[1].set_entries(entries)
+                built[2].set_entries(entries)
+            except Exception:
+                pass
+        self._pane_retro_gallery_feed = _pane_retro_gallery_feed
+
+        def _pane_retro_gallery_set_scene(src):
+            built = self._pane_retro_galleries.get(src)
+            cfg = _pane_gallery_runtime(src)
+            if built is None or cfg is None:
+                return
+            mode = (getattr(self, cfg[2], "gallery") or "gallery")
+            built[0].set_scene(built[2] if mode == "gallery" else built[1])
+
+        def _pane_retro_gallery_set(src, on):
+            cfg = _pane_gallery_runtime(src)
+            if not cfg or cfg[0] is None:
+                return
+            view_stack = cfg[0]
+            if on:
+                try:
+                    from zxnu_pygame import pygame_available
+                    ok, _why = pygame_available()
+                except Exception:
+                    ok = False
+                if not ok:
+                    return
+                built = _pane_retro_gallery_build(src)
+                if built is None:
+                    return
+                _pane_retro_gallery_feed(src)
+                _pane_retro_gallery_set_scene(src)
+                try:
+                    built[0].enable_background(getattr(self, "_allinone_pygame_anim", True))
+                except Exception:
+                    pass
+                view_stack.setCurrentWidget(built[0])
+            else:
+                mode = (getattr(self, cfg[2], "gallery") or "gallery")
+                view_stack.setCurrentIndex(1 if mode == "gallery" else 0)
+        self._pane_retro_gallery_set = _pane_retro_gallery_set
+
+        def _pane_retro_gallery_refresh(src):
+            """Re-feed + re-assert the Retro grid when a pane's data or view mode
+            changes while Retro is on (no-op when Classic)."""
+            if not getattr(self, "_" + src + "_item_retro", False):
+                return
+            if self._pane_retro_galleries.get(src) is None:
+                _pane_retro_gallery_set(src, True)
+                return
+            _pane_retro_gallery_feed(src)
+            _pane_retro_gallery_set_scene(src)
+            cfg = _pane_gallery_runtime(src)
+            if cfg and cfg[0] is not None:
+                cfg[0].setCurrentWidget(self._pane_retro_galleries[src][0])
+        self._pane_retro_gallery_refresh = _pane_retro_gallery_refresh
 
         def _allinone_pygame_build():
             if self._allinone_pygame_widget is not None:
@@ -19107,6 +19560,12 @@ class MainWindow(QMainWindow):
                 open_cb=_allinone_pygame_open_viewer,
                 cols_getter=lambda: self._gallery_cols,
             )
+            # Animate .gif thumbnails regardless of the "Gallery animation"
+            # setting, mirroring the Qt gallery cells.
+            try:
+                self._allinone_pygame_gallery.set_gif_fetch_cb(_gif_fetch_bytes)
+            except Exception:
+                pass
             self._allinone_pygame_widget = host
             try:
                 host.enable_background(getattr(self, "_allinone_pygame_anim", True))
@@ -19143,7 +19602,7 @@ class MainWindow(QMainWindow):
             btn = self.allinone_pygame_button
             btn.blockSignals(True)
             btn.setChecked(False)
-            btn.setText("🎮 Pygame")
+            btn.setText("🎮 Retro")
             btn.blockSignals(False)
             btn.setEnabled(False)
             if reason:
@@ -19198,7 +19657,7 @@ class MainWindow(QMainWindow):
                 _allinone_pygame_persist(True)
             else:
                 self._allinone_pygame_on = False
-                self.allinone_pygame_button.setText("🎮 Pygame")
+                self.allinone_pygame_button.setText("🎮 Retro")
                 # Back to Classic: restore the autocomplete completer, honouring
                 # the global "Enable search autocompletion" setting.
                 try:

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -140,6 +140,13 @@ SETTING_SDCARD_PYGAME_LOG      = "sdcard_pygame_log"       # "true" => retro 8-b
 SETTING_ITCHIO_API_KEY         = "itchio_api_key"          # str: personal itch.io API key (https://itch.io/user/settings/api-keys)
 SETTING_SHOW_ITCHIO_TAB        = "show_itchio_tab"         # "false" => hide the itch.io tab (default shown when itch-dl is installed)
 SETTING_ITCHIO_VIEW_MODE       = "itchio_view_mode"        # "gallery" (default) or "table"
+# Per-pane item-viewer mode: "true" => open items in the Retro (pygame) viewer
+# (renders .txt/instruction pages as a log console), else the Classic Qt viewer.
+SETTING_GETIT_ITEM_RETRO       = "getit_item_retro"
+SETTING_ZXDB_ITEM_RETRO        = "zxdb_item_retro"
+SETTING_ZXART_ITEM_RETRO       = "zxart_item_retro"
+SETTING_ITCHIO_ITEM_RETRO      = "itchio_item_retro"
+SETTING_FAVORITES_ITEM_RETRO   = "favorites_item_retro"
 SETTING_NEXTSYNC_PYGAME_ANIM   = "nextsync_pygame_anim"    # "false" => freeze the starfield in the NextSync retro log (default on)
 SETTING_ALLINONE_PYGAME_ANIM   = "allinone_pygame_anim"    # "false" => disable the Space-Invaders background (default on)
 SETTING_ALIEN_FLOYD_BG         = "alien_floyd_bg"          # "true" => pygame-ce "Alien Floyd's" animated background on all tabs (default off)
@@ -476,7 +483,8 @@ SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVO
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
 SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_SDCARD_PYGAME_LOG,
-SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE)
+SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE,
+SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
 
 IMAGE_BUTTONS_SIZE = 190
 DISK_ARROWS_BUTTONS_SIZE = 30

--- a/zxnu_pygame.py
+++ b/zxnu_pygame.py
@@ -160,6 +160,96 @@ def qpixmap_to_surface(qpix):
     return qimage_to_surface(qpix.toImage())
 
 
+def _url_is_gif(url) -> bool:
+    """Whether *url* points at a (possibly animated) GIF."""
+    if not isinstance(url, str) or not url:
+        return False
+    n = url.lower()
+    for sep in ("?", "#"):
+        if sep in n:
+            n = n.split(sep, 1)[0]
+    return n.endswith(".gif")
+
+
+class _GifPlayer:
+    """Plays an animated GIF via ``QMovie``, exposing the current frame as a
+    pygame ``Surface``.
+
+    Memory-light: QMovie streams frames on demand (CacheNone), so we keep only
+    the *current* frame in memory — even a multi-megabyte, several-hundred-frame
+    GIF stays cheap (decoding all frames up front would freeze the UI and cost
+    hundreds of MB). *on_frame* is invoked on the GUI thread after each new
+    frame so the host can repaint. Requires the Qt event loop to be running
+    (true inside the app) to advance frames."""
+
+    def __init__(self, data, on_frame=None):
+        self._ok = False
+        self.surface = None
+        self._on_frame = on_frame
+        self._movie = None
+        if not data or bytes(data[:4]) != b"GIF8":
+            return
+        try:
+            from PySide6.QtCore import QBuffer, QByteArray
+            from PySide6.QtGui import QMovie
+        except Exception:
+            return
+        try:
+            self._ba = QByteArray(bytes(data))
+            self._buf = QBuffer(self._ba)
+            self._buf.open(QBuffer.ReadOnly)
+            self._movie = QMovie(self._buf, b"gif")
+            self._movie.setCacheMode(QMovie.CacheNone)
+            if not self._movie.isValid():
+                self._movie = None
+                return
+            self._movie.frameChanged.connect(self._on_changed)
+            self._ok = True
+        except Exception:
+            self._ok = False
+            self._movie = None
+
+    def animated(self):
+        """True if this is a playable (multi-frame) GIF."""
+        if not self._ok:
+            return False
+        try:
+            # frameCount() can report 0 for some streamed GIFs; treat anything
+            # other than an explicit single frame as animated.
+            return self._movie.frameCount() != 1
+        except Exception:
+            return True
+
+    def start(self):
+        if self._ok:
+            try:
+                self._movie.start()
+            except Exception:
+                pass
+
+    def stop(self):
+        if self._movie is not None:
+            try:
+                self._movie.stop()
+            except Exception:
+                pass
+
+    def _on_changed(self, _i):
+        if self._movie is None:
+            return
+        try:
+            surf = qpixmap_to_surface(self._movie.currentPixmap())
+        except Exception:
+            surf = None
+        if surf is not None:
+            self.surface = surf
+            if self._on_frame is not None:
+                try:
+                    self._on_frame()
+                except Exception:
+                    pass
+
+
 def _surface_to_qimage(surf):
     pg = _pg
     w, h = surf.get_size()
@@ -395,6 +485,61 @@ def _elide(text, font, max_w):
     while text and font.size(text + ell)[0] > max_w:
         text = text[:-1]
     return text + ell if text else ell
+
+
+# Phosphor green used by the retro 8-bit log panes (RetroLogWidget) and the
+# item-viewer text-file console so a .txt page looks like the SD Card Utility /
+# NextSync logs in "Pygame" mode.
+_C_LOG_GREEN = (120, 255, 140)
+
+# Plain-text extensions the item viewer renders as a scrolling log console
+# (instead of trying to decode them as a picture). Mirrors the text members of
+# zxnu_media.ZXFMT_NON_IMAGE_EXTS.
+_PYG_TEXT_EXTS = (".txt", ".nfo", ".diz", ".asc", ".md", ".me", ".1st",
+                  ".text", ".readme", ".log")
+
+# Sentinel cached in PygameItemViewer._text_cache when a text fetch failed, so
+# the console shows an error instead of an endless "Loading…".
+_TEXT_FETCH_FAILED = object()
+
+
+def _url_is_text(url) -> bool:
+    """Whether *url* points at a plain-text file the item viewer should render
+    as a log console rather than an image."""
+    if not isinstance(url, str) or not url or url.startswith("placeholder://"):
+        return False
+    n = url.lower()
+    for sep in ("?", "#"):
+        if sep in n:
+            n = n.split(sep, 1)[0]
+    return n.endswith(_PYG_TEXT_EXTS)
+
+
+def _decode_text_bytes(data) -> list:
+    """Decode raw *data* bytes into a list of display lines for the console.
+    Tries UTF-8, then common 8-bit code pages, expanding tabs and normalising
+    newlines."""
+    if not data:
+        return []
+    text = None
+    for enc in ("utf-8", "cp1252", "latin-1"):
+        try:
+            text = bytes(data).decode(enc)
+            break
+        except Exception:
+            text = None
+    if text is None:
+        text = bytes(data).decode("latin-1", "replace")
+    return _text_to_lines(text)
+
+
+def _text_to_lines(text) -> list:
+    """Normalise an in-memory string into console display lines (newline
+    normalisation + tab expansion)."""
+    if not text:
+        return []
+    s = str(text).replace("\r\n", "\n").replace("\r", "\n").expandtabs(8)
+    return s.split("\n")
 
 
 def _wrap_lines(text, font, max_w):
@@ -3946,6 +4091,13 @@ class GalleryScene(_Scene):
         self._requested = set()
         self._scroll = 0
         self._hover = -1
+        # Animated-GIF thumbnails (played regardless of the "Gallery animation"
+        # setting, mirroring the Qt GalleryCell's QMovie behaviour). A raw-bytes
+        # fetcher is wired via set_gif_fetch_cb; each animated thumbnail streams
+        # through a _GifPlayer and repaints the grid as frames arrive.
+        self._gif_fetch = None
+        self._gif_players = {}  # index -> _GifPlayer
+        self._gif_urls = {}     # index -> url already handled (avoid re-fetch)
         # Thumbnails are scaled to the cell size every frame, so painting them
         # while the host widget is still growing to its final size (e.g. right
         # after toggling into pygame mode, before setCurrentWidget) makes a
@@ -3976,17 +4128,35 @@ class GalleryScene(_Scene):
         self._settled = True
         self.redraw()
 
+    def set_gif_fetch_cb(self, cb):
+        """Wire the raw-bytes fetcher (url, on_bytes) used to play animated
+        ``.gif`` thumbnails — the same fetcher the Qt gallery uses."""
+        self._gif_fetch = cb
+
+    def _stop_gif_players(self):
+        for p in self._gif_players.values():
+            try:
+                p.stop()
+            except Exception:
+                pass
+        self._gif_players = {}
+        self._gif_urls = {}
+
     def set_entries(self, entries):
         self._entries = list(entries or [])
         self._surfs = {}
         self._requested = set()
         self._scroll = 0
         self._hover = -1
+        self._stop_gif_players()
         self._fetch_visible()
         self.redraw()
 
     def on_attach(self):
         self._fetch_visible()
+
+    def on_detach(self):
+        self._stop_gif_players()
 
     def _cols(self):
         if self._cols_getter:
@@ -4026,8 +4196,34 @@ class GalleryScene(_Scene):
                     self._surfs[_i] = surf
                     self.redraw()
 
+            def _on_urls(urls, _i=i):
+                # The thumbnail's source URL(s); if the first is an animated GIF
+                # and a fetcher is wired, stream it via QMovie so the cell
+                # animates (independent of the "Gallery animation" setting).
+                if not urls or not self._gif_fetch:
+                    return
+                u = urls[0] if isinstance(urls, (list, tuple)) else urls
+                if not _url_is_gif(u) or self._gif_urls.get(_i) == u:
+                    return
+                self._gif_urls[_i] = u
+
+                def _on_bytes(data, _i2=_i):
+                    player = _GifPlayer(data, on_frame=self.redraw)
+                    if player.animated():
+                        old = self._gif_players.get(_i2)
+                        if old is not None:
+                            old.stop()
+                        self._gif_players[_i2] = player
+                        player.start()
+                        self.redraw()
+
+                try:
+                    self._gif_fetch(u, _on_bytes)
+                except Exception:
+                    pass
+
             try:
-                self._thumb_fetch(e, _on_px, lambda *_: None)
+                self._thumb_fetch(e, _on_px, _on_urls)
             except Exception:
                 pass
 
@@ -4063,7 +4259,10 @@ class GalleryScene(_Scene):
                 _pg.draw.rect(surface, C_BORDER, cell, self.s(2))
             img_rect = _pg.Rect(cell.x, cell.y, cw, img_h)
             surface.fill(C_IMG_BG, img_rect)
-            surf = self._surfs.get(i)
+            # Prefer the current animated-GIF frame; fall back to the static
+            # thumbnail surface.
+            _gp = self._gif_players.get(i)
+            surf = (_gp.surface if _gp is not None else None) or self._surfs.get(i)
             # Only draw the picture once the layout size has settled; otherwise
             # a fast-arriving thumbnail would be scaled to an intermediate cell
             # size and then "grow" as the widget reaches its final size.
@@ -4144,11 +4343,27 @@ class PygameItemViewer(_Scene):
         self.attach(host)
         self._title = title or ""
         self._rows = list(info_rows or [])
-        # Keep only renderable images — drop non-picture downloads (archives,
-        # tape/disk images, text files) the online APIs sometimes mix in.
+        # Keep renderable images *and* plain-text files (.txt/.nfo/…): images go
+        # through the slideshow as pictures, text files are rendered as a retro
+        # log console (matching the SD Card Utility / NextSync "Pygame" logs).
+        # Other non-picture downloads (archives, tape/disk images) are dropped.
         self._screens = [u for u in (screenshots or [])
-                         if u and zxfmt_url_is_displayable_image(u)]
+                         if u and (zxfmt_url_is_displayable_image(u)
+                                   or _url_is_text(u))]
         self._extra_fetch = extra_fetch_cb
+        # Text-file ("log console") support: a raw-bytes fetcher wired by the
+        # owning pane (set_text_fetch_cb), a url->lines cache (or the failure
+        # sentinel), the in-flight set, a per-width wrapped-line cache, and the
+        # vertical scroll offset/limit for the document currently on screen.
+        self._text_fetch = None
+        self._text_cache = {}
+        self._text_pending = set()
+        self._text_wrap_cache = {}
+        self._text_scroll = 0
+        self._text_max_scroll = 0
+        # URLs a caller explicitly marked as text pages (see add_text_pages),
+        # so even extension-less file endpoints render as a log console.
+        self._forced_text = set()
         # Optional callable -> "hover"|"timer"|"none". "none" disables the
         # auto-advancing slideshow (the user still pages with ◀/▶); mirrors the
         # Qt GalleryItemViewer. Defaults to legacy always-cycling when absent.
@@ -4156,6 +4371,12 @@ class PygameItemViewer(_Scene):
         self._tags = [str(t) for t in (tags or []) if t]
         self._shot_idx = 0
         self._shot_cache = {}          # url -> Surface
+        # Animated-GIF screenshots: a raw-bytes fetcher (set_gif_fetch_cb) plus a
+        # url->_GifPlayer cache so a .gif screenshot animates instead of showing
+        # a frozen first frame (always animated, like the Qt viewer's QMovie).
+        self._gif_fetch = None
+        self._gif_players = {}         # url -> _GifPlayer
+        self._gif_requested = set()
         self._close_fn = None
         self._placeholder = ("", "")
         self._meta_scroll = 0
@@ -4219,6 +4440,7 @@ class PygameItemViewer(_Scene):
             self._timer.stop()
         except Exception:
             pass
+        self._stop_gif_players()
 
     def set_favorite_hooks(self, entry, is_favorite_cb, toggle_favorite_cb):
         self._fav_entry = entry
@@ -4301,9 +4523,17 @@ class PygameItemViewer(_Scene):
     def set_screenshots(self, urls):
         self._timer.stop()
         self._screens = [u for u in (urls or [])
-                         if u and zxfmt_url_is_displayable_image(u)]
+                         if u and (zxfmt_url_is_displayable_image(u)
+                                   or _url_is_text(u))]
+        # Keep any explicitly-marked text pages (add_text_pages) after the
+        # pictures so re-setting the screenshots doesn't drop them.
+        for u in self._forced_text:
+            if u not in self._screens:
+                self._screens.append(u)
         self._shot_idx = 0
         self._shot_cache = {}
+        self._text_scroll = 0
+        self._stop_gif_players()
         if self._screens:
             self._prefetch_all()
             if (len(self._screens) > 1 and self.host is not None
@@ -4321,6 +4551,50 @@ class PygameItemViewer(_Scene):
         self._tags = [str(t) for t in (tags or []) if t]
         self.redraw()
 
+    def set_text_fetch_cb(self, cb):
+        """Wire the raw-bytes fetcher used to load plain-text (.txt/.nfo/…)
+        content pages, which are rendered as a retro log console. *cb* has the
+        signature ``cb(url, on_bytes)`` and must invoke ``on_bytes(bytes|None)``
+        on the GUI thread (same contract as the GIF fetcher)."""
+        self._text_fetch = cb
+        # A text page already on screen may have been waiting on the fetcher.
+        if self._current_is_text():
+            self.redraw()
+
+    def set_gif_fetch_cb(self, cb):
+        """Wire the raw-bytes fetcher (url, on_bytes) used to play animated
+        ``.gif`` screenshots — the same fetcher the gallery uses."""
+        self._gif_fetch = cb
+        self.redraw()
+
+    def _stop_gif_players(self):
+        for p in self._gif_players.values():
+            try:
+                p.stop()
+            except Exception:
+                pass
+        self._gif_players = {}
+        self._gif_requested = set()
+
+    def _ensure_gif(self, url):
+        """Lazily stream an animated ``.gif`` screenshot via QMovie (once)."""
+        if (url in self._gif_players or url in self._gif_requested
+                or not self._gif_fetch or not _url_is_gif(url)):
+            return
+        self._gif_requested.add(url)
+
+        def _on_bytes(data, _u=url):
+            player = _GifPlayer(data, on_frame=self.redraw)
+            if player.animated():
+                self._gif_players[_u] = player
+                player.start()
+                self.redraw()
+
+        try:
+            self._gif_fetch(url, _on_bytes)
+        except Exception:
+            pass
+
     # -- internals ---------------------------------------------------------
     def _wire(self, key, cb, enabled, tooltip=""):
         b = self._buttons[key]
@@ -4336,6 +4610,15 @@ class PygameItemViewer(_Scene):
             return
         for url in list(self._screens):
             if url in self._shot_cache:
+                continue
+            # Text pages are fetched lazily as raw bytes (see _ensure_text_fetch)
+            # — never run them through the image fetcher (which would decode-fail
+            # and _drop_url them out of the slideshow).
+            if self._is_text_url(url):
+                continue
+            # Animated GIFs are streamed on demand via QMovie (_ensure_gif); skip
+            # the static prefetch so a multi-megabyte gif isn't downloaded twice.
+            if self._gif_fetch and _url_is_gif(url):
                 continue
 
             def _on_px(px, _u=url):
@@ -4368,13 +4651,97 @@ class PygameItemViewer(_Scene):
         if not self._screens:
             return
         self._shot_idx = (self._shot_idx - 1) % len(self._screens)
+        self._text_scroll = 0
         self.redraw()
 
     def _go_next(self):
         if not self._screens:
             return
         self._shot_idx = (self._shot_idx + 1) % len(self._screens)
+        self._text_scroll = 0
         self.redraw()
+
+    # -- text-file ("log console") pages -----------------------------------
+    def _current_url(self):
+        if not self._screens:
+            return None
+        return self._screens[self._shot_idx % len(self._screens)]
+
+    def _is_text_url(self, url):
+        """Whether *url* should be rendered as a text console — either by its
+        extension or because a caller explicitly marked it text via
+        add_text_pages (used for sources whose file URLs carry no extension)."""
+        return bool(url) and (url in self._forced_text or _url_is_text(url))
+
+    def _current_is_text(self):
+        cur = self._current_url()
+        return cur is not None and self._is_text_url(cur)
+
+    def add_text_pages(self, urls):
+        """Append readable text files as console pages, regardless of whether
+        their URL carries a recognisable extension. Used by the per-source
+        openers (ZXDB instructions, zxArt/GetIt text releases, …) so a text item
+        shows up after the pictures in Pygame mode."""
+        changed = False
+        for u in (urls or []):
+            if not u:
+                continue
+            if u not in self._forced_text:
+                self._forced_text.add(u)
+                changed = True
+            if u not in self._screens:
+                self._screens.append(u)
+                changed = True
+        if changed:
+            self.redraw()
+
+    def add_text_document(self, label, text):
+        """Add an in-memory text page (e.g. the item's description/About) as a
+        log console. Unlike add_text_pages there is no network fetch — *text* is
+        supplied directly, HTML-stripped, and cached immediately. *label* is the
+        caption shown under the page."""
+        text = _strip_html(text) if text else ""
+        if not text.strip():
+            return
+        key = "textdoc://" + (str(label) or "Text")
+        self._forced_text.add(key)
+        self._text_cache[key] = _text_to_lines(text)
+        if key not in self._screens:
+            self._screens.append(key)
+        self.redraw()
+
+    def _ensure_text_fetch(self, url):
+        """Kick off a lazy raw-bytes fetch for a text page (once per url)."""
+        if url in self._text_cache or url in self._text_pending:
+            return
+        if not self._text_fetch:
+            return                       # fetcher not wired yet; keep "Loading…"
+        self._text_pending.add(url)
+
+        def _on_bytes(data, _u=url):
+            self._text_pending.discard(_u)
+            self._text_cache[_u] = (_decode_text_bytes(data) if data
+                                    else _TEXT_FETCH_FAILED)
+            self.redraw()
+
+        try:
+            self._text_fetch(url, _on_bytes)
+        except Exception:
+            self._text_pending.discard(url)
+            self._text_cache[url] = _TEXT_FETCH_FAILED
+            self.redraw()
+
+    def _wrapped_text(self, url, lines, font, max_w):
+        """Word-wrap a text document to *max_w*, cached per (url, width)."""
+        key = (url, max_w)
+        cached = self._text_wrap_cache.get(key)
+        if cached is not None:
+            return cached
+        out = []
+        for raw in lines:
+            out.extend(_wrap_lines(raw, font, max_w) or [""])
+        self._text_wrap_cache[key] = out
+        return out
 
     def _close(self):
         self._timer.stop()
@@ -4396,7 +4763,11 @@ class PygameItemViewer(_Scene):
         img_w = w - pw
         # left image area
         img_area = _pg.Rect(self.s(8), self.s(8), img_w - self.s(16), h - self.s(16))
-        surface.fill(C_IMG_BG, _pg.Rect(0, 0, img_w, h))
+        # A text page keeps the animated starfield/veil backdrop (painted by
+        # _paint_backdrop) showing through for the retro-log look; an image page
+        # gets the usual solid photo backing.
+        if not self._current_is_text():
+            surface.fill(C_IMG_BG, _pg.Rect(0, 0, img_w, h))
         self._render_image(surface, img_area)
         # right panel
         panel = _pg.Rect(img_w, 0, pw, h)
@@ -4404,10 +4775,29 @@ class PygameItemViewer(_Scene):
         self._render_panel(surface, panel)
 
     def _render_image(self, surface, area):
+        # Plain-text content (.txt/.nfo/…) is drawn as a scrolling log console
+        # rather than a picture, but keeps the same nav / file-name / tag chrome.
+        cur = self._current_url()
+        if cur is not None and self._is_text_url(cur):
+            self._render_text_console(surface, area, cur)
+            self._render_nav(surface, area)
+            self._render_shot_name(surface, area)
+            if self._tags:
+                self._render_tags(surface, area)
+            return
         surf = None
         if self._screens:
             url = self._screens[self._shot_idx % len(self._screens)]
-            surf = self._shot_cache.get(url)
+            # Animated GIF: stream it via QMovie (always, regardless of the
+            # slideshow animation mode); fall back to the static first frame
+            # until the player has produced a frame.
+            if _url_is_gif(url):
+                self._ensure_gif(url)
+                _gp = self._gif_players.get(url)
+                if _gp is not None and _gp.surface is not None:
+                    surf = _gp.surface
+            if surf is None:
+                surf = self._shot_cache.get(url)
         if surf is not None:
             nav_h = self.s(26)
             scaled = _scale_keep_aspect(surf, area.w, area.h - nav_h)
@@ -4435,6 +4825,61 @@ class PygameItemViewer(_Scene):
         if self._tags:
             self._render_tags(surface, area)
 
+    def _render_text_console(self, surface, area, url):
+        """Render a plain-text page as a retro log console: phosphor-green
+        Consolas over a dark veil (matching the SD Card Utility / NextSync
+        "Pygame" logs), scrollable with the mouse wheel."""
+        # Deepen contrast for the green text over whatever backdrop shows through.
+        veil = _pg.Surface((area.w, area.h), _pg.SRCALPHA)
+        veil.fill((4, 6, 10, 150))
+        surface.blit(veil, (area.x, area.y))
+        _pg.draw.rect(surface, C_BORDER, area, 1)
+
+        f = _font(self.s(13))
+        lh = f.get_height() + self.s(2)
+        pad = self.s(10)
+        # Reserve bottom space so the text never runs under the ◀/▶ nav row and
+        # the file-name caption.
+        has_nav = len(self._screens) > 1
+        text_top = area.y + pad
+        text_bottom = area.bottom - self.s(50 if has_nav else 28)
+        view_h = max(lh, text_bottom - text_top)
+        max_w = max(self.s(40), area.w - 2 * pad)
+
+        lines = self._text_cache.get(url)
+        if lines is None:
+            self._ensure_text_fetch(url)
+            msg = "Loading text…" if self._text_fetch else "No text loader available"
+            tw = f.size(msg)[0]
+            _draw_text(surface, msg, area.centerx - tw // 2,
+                       area.centery - lh // 2, f, (90, 170, 110))
+            self._text_max_scroll = 0
+            return
+        if lines is _TEXT_FETCH_FAILED:
+            msg = "Could not load text file."
+            tw = f.size(msg)[0]
+            _draw_text(surface, msg, area.centerx - tw // 2,
+                       area.centery - lh // 2, f, (200, 120, 120))
+            self._text_max_scroll = 0
+            return
+
+        wrapped = self._wrapped_text(url, lines, f, max_w)
+        self._text_max_scroll = max(0, len(wrapped) * lh - view_h)
+        self._text_scroll = max(0, min(self._text_scroll, self._text_max_scroll))
+
+        prev_clip = surface.get_clip()
+        surface.set_clip(_pg.Rect(area.x + self.s(2), text_top,
+                                  area.w - self.s(4), view_h))
+        x = area.x + pad
+        y = text_top - self._text_scroll
+        for line in wrapped:
+            if y > text_bottom:
+                break
+            if y + lh >= text_top:
+                _draw_text(surface, line, x, int(y), f, _C_LOG_GREEN)
+            y += lh
+        surface.set_clip(prev_clip)
+
     def _render_nav(self, surface, area):
         if len(self._screens) <= 1:
             self._prev_rect = self._next_rect = None
@@ -4460,6 +4905,8 @@ class PygameItemViewer(_Scene):
         url = self._screens[self._shot_idx % len(self._screens)]
         if not isinstance(url, str) or url.startswith("placeholder://"):
             return ""
+        if url.startswith("textdoc://"):
+            return url[len("textdoc://"):]      # caption = the document label
         s = url.split("?", 1)[0].split("#", 1)[0]
         try:
             from urllib.parse import unquote
@@ -4600,6 +5047,11 @@ class PygameItemViewer(_Scene):
                 bottom = self.size[1] - ab_h
                 self._meta_scroll = max(0, min(self._meta_max_scroll(top, bottom),
                                                self._meta_scroll - int(ev["dy"] * 0.5)))
+                self.redraw()
+            elif self._current_is_text():
+                # Wheel over the left area scrolls the text-file console.
+                self._text_scroll = max(0, min(self._text_max_scroll,
+                                               self._text_scroll - int(ev["dy"] * 0.5)))
                 self.redraw()
             return
         x = ev.get("x", -1)


### PR DESCRIPTION
… animated GIFs

- Render .txt/.nfo content (and a description fallback) as a green log console in the Pygame item viewer; surface text files from ZXDB instructions and zxArt/GetIt releases.
- Add a per-pane Classic/Retro toggle to ZXDB, zxArt, GetIt, itch.io and Favorites that switches both the gallery grid and the item viewer to the pygame renderer; rename the existing "Pygame" buttons to "Retro".
- Persist each pane's Classic/Retro choice across sessions.
- Animate .gif thumbnails (gallery) and .gif screenshots (item viewer) via streaming QMovie, independent of the "Gallery animation" setting; handles large multi-hundred-frame GIFs without freezing.