### PR TITLE
Compact SEARCHING loading overlay over both modes; bump to 8.1

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -9509,12 +9509,13 @@ class MainWindow(QMainWindow):
         self.getit_view_stack.addWidget(self.getit_gallery_view)  # index 1: Gallery
 
         getit_table_row.addWidget(self.getit_view_stack, 1)
-        # Animated retro "LOADING CONTENT..." banner shown over the results area
-        # while the first fetch is in flight and nothing has been rendered yet.
+        # Animated retro "SEARCHING..." banner shown over the results area
+        # whenever a fetch is in flight — including re-searches
+        # over already-populated content, so it stays visible on top of the
+        # pygame GalleryScene (not only on the first/empty load).
         self._getit_loading_overlay = RetroLoadingOverlay(
             self.getit_view_stack,
-            lambda: (self.getit_results_table.rowCount() == 0
-                     and getattr(self, "_getit_search_loading", False)))
+            lambda: getattr(self, "_getit_search_loading", False))
         getit_table_row.addWidget(getit_right_widget)
         getit_table_container = QWidget()
         getit_table_container.setLayout(getit_table_row)
@@ -11197,12 +11198,13 @@ class MainWindow(QMainWindow):
         self.zxdb_view_stack.addWidget(self.zxdb_gallery_view)  # index 1
 
         zxdb_table_row.addWidget(self.zxdb_view_stack, 1)
-        # Animated retro "LOADING CONTENT..." banner over the results area while
-        # the first fetch is in flight and nothing has been rendered yet.
+        # Animated retro "SEARCHING..." banner over the
+        # results area whenever a fetch is in flight — including re-searches over
+        # already-populated content, so it stays visible on top of the pygame
+        # GalleryScene (not only on the first/empty load).
         self._zxdb_loading_overlay = RetroLoadingOverlay(
             self.zxdb_view_stack,
-            lambda: (self.zxdb_results_table.rowCount() == 0
-                     and getattr(self, "_zxdb_search_loading", False)))
+            lambda: getattr(self, "_zxdb_search_loading", False))
         zxdb_table_row.addWidget(zxdb_right_widget)
         zxdb_table_container = QWidget()
         zxdb_table_container.setLayout(zxdb_table_row)
@@ -14298,12 +14300,13 @@ class MainWindow(QMainWindow):
         self.zxart_view_stack.addWidget(self.zxart_gallery_view)  # index 1
 
         zxart_table_row.addWidget(self.zxart_view_stack, 1)
-        # Animated retro "LOADING CONTENT..." banner over the results area while
-        # the first fetch is in flight and nothing has been rendered yet.
+        # Animated retro "SEARCHING..." banner over the
+        # results area whenever a fetch is in flight — including re-searches over
+        # already-populated content, so it stays visible on top of the pygame
+        # GalleryScene (not only on the first/empty load).
         self._zxart_loading_overlay = RetroLoadingOverlay(
             self.zxart_view_stack,
-            lambda: (self.zxart_results_table.rowCount() == 0
-                     and getattr(self, "_zxart_search_loading", False)))
+            lambda: getattr(self, "_zxart_search_loading", False))
         zxart_table_row.addWidget(zxart_right_widget)
         zxart_table_container = QWidget()
         zxart_table_container.setLayout(zxart_table_row)
@@ -17212,14 +17215,15 @@ class MainWindow(QMainWindow):
         # Wrap view_stack + right preview widget in a horizontal row
         allinone_table_row = QHBoxLayout()
         allinone_table_row.addWidget(self.allinone_view_stack, 1)
-        # Animated retro "LOADING CONTENT..." banner over the results area while
-        # the startup "Latest" multi-search is in flight and nothing has been
-        # rendered yet.  Works in both Classic (table/gallery) and Pygame modes:
-        # the overlay floats above whichever page the view-stack is showing.
+        # Animated retro "SEARCHING..." banner over the
+        # results area whenever a multi-source fan-out is in flight — including
+        # re-searches over already-populated content, so it stays visible on top
+        # of the pygame GalleryScene (not only on the first/empty load).
+        # Works in both Classic (table/gallery) and Pygame modes: the overlay
+        # floats above whichever page the view-stack is showing.
         self._allinone_loading_overlay = RetroLoadingOverlay(
             self.allinone_view_stack,
-            lambda: (self.allinone_results_table.rowCount() == 0
-                     and getattr(self, "_allinone_bulk_active", False)))
+            lambda: getattr(self, "_allinone_bulk_active", False))
         allinone_table_row.addWidget(allinone_right_widget)
         allinone_table_container = QWidget()
         allinone_table_container.setLayout(allinone_table_row)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -13,7 +13,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "8.0"
+ZX_NEXT_UNITE_VERSION = "8.1"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False

--- a/zxnu_gallery.py
+++ b/zxnu_gallery.py
@@ -2852,15 +2852,14 @@ class BackgroundWidget(QWidget):
 
 class RetroLoadingOverlay(QWidget):
     """A translucent overlay that paints a chunky, animated 8-bit
-    ``LOADING CONTENT...`` banner centred over a host widget.
+    ``SEARCHING...`` banner centred over a host widget.
 
     It is a plain Qt overlay drawn entirely with ``QPainter`` (a hand-coded
     5x7 pixel font), so it floats over whatever the host shows underneath —
     the classic table / gallery widgets *or* the pygame-rendered Unite! view —
     without caring which.  Visibility is driven by a caller-supplied predicate
-    polled on the animation timer, so the banner appears only while the pane is
-    still empty and a fetch is running, then disappears the instant real
-    content lands.
+    polled on the animation timer, so the banner appears while a fetch is in
+    flight (even over already-populated content) and disappears when it lands.
 
     Usage::
 
@@ -2891,10 +2890,13 @@ class RetroLoadingOverlay(QWidget):
         "C": (".XXX." "X...X" "X...." "X...." "X...." "X...X" ".XXX."),
         "T": ("XXXXX" "..X.." "..X.." "..X.." "..X.." "..X.." "..X.."),
         "E": ("XXXXX" "X...." "X...." "XXXX." "X...." "X...." "XXXXX"),
+        "S": (".XXXX" "X...." "X...." ".XXX." "....X" "....X" "XXXX."),
+        "R": ("XXXX." "X...X" "X...X" "XXXX." "X.X.." "X..X." "X...X"),
+        "H": ("X...X" "X...X" "X...X" "XXXXX" "X...X" "X...X" "X...X"),
         ".": ("....." "....." "....." "....." "....." ".XX.." ".XX.."),
     }
 
-    def __init__(self, host, should_show_cb, text="LOADING CONTENT", parent=None):
+    def __init__(self, host, should_show_cb, text="SEARCHING", parent=None):
         super().__init__(parent or host)
         self._host = host
         self._should_show_cb = should_show_cb
@@ -2960,9 +2962,11 @@ class RetroLoadingOverlay(QWidget):
         # horizontally as the animated "..." grows and shrinks.
         n_slots = len(text) + 3
         total_w_cells = n_slots * 6 - 1            # 5 px glyph + 1 px gap each
-        px = int(min(w * 0.86 / max(1, total_w_cells), h * 0.34 / 7))
-        if px < 2:
-            px = 2
+        # Compact, centred "flyout": size the pixel font to a small fraction of
+        # the host and cap it so the banner stays small/unobtrusive even on big
+        # windows (was 0.86*w / 0.34*h, which filled most of the pane).
+        px = int(min(w * 0.40 / max(1, total_w_cells), h * 0.16 / 7))
+        px = max(2, min(px, 5))
         text_w = total_w_cells * px
         glyph_h = 7 * px
         amp = max(1.0, px * 1.5)


### PR DESCRIPTION
## What

Make the retro loading banner a small, coherent **"SEARCHING…"** flyout that stays visible for the whole search in **both** Classic/Qt and Retro/pygame modes, and bump the app version to **8.1**.

## Why

While a search runs, the app animates the spinning-earth tab indicator (kept as-is), but the on-screen loading banner had three issues:

1. **Too big / invasive** — it sized its 8-bit pixel font to ~0.86×width, filling most of the pane.
2. **Vanished as soon as cells existed** — each overlay's predicate required `results_table.rowCount() == 0`, so a re-search over already-populated content (or results streaming in) showed no feedback. This *looked* like a z-order problem (banner "behind" the populated `GalleryScene`) but was actually the predicate.
3. **Inconsistent text** — classic showed "LOADING CONTENT", which didn't match the pygame side.

## How

- **`zxnu_gallery.py` (`RetroLoadingOverlay`)** — shrink the banner to a compact, centred flyout (`~0.40×width` with the per-cell pixel size capped) so it's unobtrusive on any window size. Unify the text to a single **"SEARCHING…"** (added pixel glyphs for `S`, `R`, `H`).
- **`zx-next-unite.py`** — relax the GetIt / ZXDB / zxArt / Unite overlay predicates to show whenever a fetch is in flight (drop the `rowCount() == 0` requirement), so the banner stays on top of already-populated content until the search completes. The overlay is a raised sibling of the pane's view-stack, so it composites above the pygame view.
- **`zxnu_config.py`** — bump `ZX_NEXT_UNITE_VERSION` `8.0` → `8.1` (single source of truth; window title and all API user-agents derive from it).

## Testing

All verified offscreen (`QT_QPA_PLATFORM=offscreen`):

- **Compact size:** banner shrank from ~86% → ~35% of host width and stays compact on large windows (1000px and 1600px hosts).
- **Z-order over populated pygame:** rendered the overlay over a fully populated `GalleryScene` — bright/saturated centre pixels went 0 → 3400, proving it composites on top (z-order was never the issue).
- **Boot:** full app boots clean; all four overlays construct and report `text='SEARCHING'`.
- **Version:** derived strings confirmed — window title `zx-next-unite 8.1`, user-agent `ZX-Next-Unite/8.1`, help banner `Welcome to zx-next-unite 8.1 help`.

## Notes for reviewer

- The spinning-earth tab animation is unchanged.
- The loading flags are only true during active fetches (`_*_search_loading`, `_allinone_bulk_active` which wraps every Unite fan-out), so dropping the empty-table check does not show the banner at idle.
- Kept the chunky hand-coded 8-bit pixel font (truer to the retro look than Consolas).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
