### PR TITLE
Bump app version from 8.1 to 8.2

### DIFF
--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -13,7 +13,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "8.1"
+ZX_NEXT_UNITE_VERSION = "8.2"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False


### PR DESCRIPTION
## Summary

Bumps the application version from **8.1** to **8.2**.

`ZX_NEXT_UNITE_VERSION` in [zxnu_config.py](zxnu_config.py) is the single source of truth for the version string — the window title, the in-app help banner, and all third-party API user-agents (`GETIT_USER_AGENT`, `ZXDB_USER_AGENT`, `ZXART_USER_AGENT`, `ITCH_USER_AGENT`) are derived from it, so this one-line change updates them all consistently.

## Notes for reviewers

- No functional/behavioural changes — version string only.
- `zxnu_config.py` byte-compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)