### PR TITLE
SD Card tab: group MAME/CSpect controls and add MAME option combos

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -3280,6 +3280,12 @@ class MainWindow(QMainWindow):
                 self.cspect_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_JOYSTICK]))
                 self.cspect_mouse.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MOUSE]))
                 self.cspect_frequency.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_HERTZ]))
+                # MAME option combos (aspect / mouse / joystick). Stored as combo
+                # indices; an absent value ("") maps to index 0 (the default).
+                if hasattr(self, "mame_aspect"):
+                    self.mame_aspect.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_ASPECT]))
+                    self.mame_mouse.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_MOUSE]))
+                    self.mame_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_JOYSTICK]))
 
                 if configuration_dictionary[SETTING_DEFAULT_TAB_WHEN_OPENING]== "":
                     # First run (no previously saved tab): default to the
@@ -3405,6 +3411,13 @@ class MainWindow(QMainWindow):
                     _params = configuration_dictionary.get(
                         SETTING_MAME_COMMAND_LINE_PARAMETERS, "")
                     if not _params:
+                        _params = MAME_DEFAULT_COMMAND_LINE
+                    # Migrate the legacy default that hard-coded "-aspect 2:1" to
+                    # the new default now that aspect is a combo box, so the
+                    # editable command-line box no longer shows a stale, now
+                    # combo-controlled option. (Launch-time stripping still handles
+                    # any other custom occurrences — see launch_mame.)
+                    elif _params.strip() == MAME_DEFAULT_COMMAND_LINE_LEGACY:
                         _params = MAME_DEFAULT_COMMAND_LINE
                     self.settings_mame_params_edit.blockSignals(True)
                     self.settings_mame_params_edit.setText(_params)
@@ -3944,6 +3957,20 @@ class MainWindow(QMainWindow):
             configuration_dictionary[SETTING_HERTZ] = self.cspect_frequency.currentIndex()
             save_configuration_file()
 
+        # MAME per-launch option combos (aspect / mouse / joystick). Persisted as
+        # combo indices, mirroring the CSpect option setters above.
+        def set_mame_aspect():
+            configuration_dictionary[SETTING_MAME_ASPECT] = self.mame_aspect.currentIndex()
+            save_configuration_file()
+
+        def set_mame_mouse():
+            configuration_dictionary[SETTING_MAME_MOUSE] = self.mame_mouse.currentIndex()
+            save_configuration_file()
+
+        def set_mame_joystick():
+            configuration_dictionary[SETTING_MAME_JOYSTICK] = self.mame_joystick.currentIndex()
+            save_configuration_file()
+
         def open_cspect_configuration_file():
             if platform.system() == "Windows":
                 execute_shell_command("notepad", ZX_NEXT_UNITE_CONFIG_FILE_NAME)
@@ -4079,7 +4106,25 @@ class MainWindow(QMainWindow):
             mame_image = self.imageinput.currentText().strip().strip('"')
             if mame_image:
                 mame_image = os.path.abspath(mame_image)
-            mame_argv = [mame_path, mame_rom] + shlex.split(mame_parameters)
+            # Drop any aspect/mouse/joystick options from the (editable) params —
+            # these are now controlled by the MAME group combos and appended
+            # below, so they must not be duplicated or conflict.
+            _param_tokens = strip_mame_combo_options(shlex.split(mame_parameters))
+            mame_argv = [mame_path, mame_rom] + _param_tokens
+
+            # Append the per-launch combo options (aspect / mouse / joystick) so
+            # the UI selections are authoritative regardless of the params string.
+            for _mame_combo, _mame_opts in (
+                (getattr(self, "mame_aspect", None), MAME_ASPECT),
+                (getattr(self, "mame_mouse", None), MAME_MOUSE),
+                (getattr(self, "mame_joystick", None), MAME_JOYSTICK),
+            ):
+                if _mame_combo is None:
+                    continue
+                _mame_arg = get_tuple_value(_mame_opts, _mame_combo.currentText())
+                if _mame_arg:
+                    mame_argv += shlex.split(_mame_arg)
+
             if mame_image:
                 mame_argv += [MAME_HARD_DISK_PARAMETER, mame_image]
 
@@ -4343,6 +4388,13 @@ class MainWindow(QMainWindow):
             try:
                 self.button_install_mame.setVisible(False)
                 self.button_start_mame.setVisible(True)
+                # Reveal the MAME option combos, hidden while only "Install MAME"
+                # was offered.
+                for _mame_combo in (getattr(self, "mame_aspect", None),
+                                    getattr(self, "mame_mouse", None),
+                                    getattr(self, "mame_joystick", None)):
+                    if _mame_combo is not None:
+                        _mame_combo.setVisible(True)
             except RuntimeError:
                 pass
             add_main_log_window(f"MAME install ▸ SUCCESS — MAME detected at: {detected}")
@@ -8813,7 +8865,7 @@ class MainWindow(QMainWindow):
         # horizontal3 (explorers) and horizontal4 (Path) are now the
         # sdcard_explorer_grid built further below.
         self.horizontal5 = QHBoxLayout()
-        self.horizontal6 = QHBoxLayout()
+        # (horizontal6 replaced by the MAME / CSpect QGroupBox rows built below.)
 
         # nextsync horizontals
 
@@ -9467,7 +9519,12 @@ class MainWindow(QMainWindow):
 
         self.zx_next_unite_form.addRow(self.horizontal5)
 
-        # Add action buttons at the bottom
+        # Add action buttons at the bottom, split into two titled groups so the
+        # MAME and CSpect controls read as separate emulators rather than one
+        # long undifferentiated button row. The MAME group sits on its own line
+        # with the CSpect group (launch + display options) stacked below it.
+        self.mame_group = QGroupBox("MAME")
+        self.mame_group_layout = QHBoxLayout(self.mame_group)
 
         # "Launch Mame" button — placed before "Launch CSpect". Only shown when
         # a MAME executable was found (PATH or a prior downloads/mame install).
@@ -9476,7 +9533,7 @@ class MainWindow(QMainWindow):
         self.button_start_mame.setText("🕹  Launch Mame")
         self.button_start_mame.clicked.connect(launch_mame)
         self.button_start_mame.setVisible(_mame_available)
-        self.horizontal6.addWidget(self.button_start_mame)
+        self.mame_group_layout.addWidget(self.button_start_mame)
 
         # "Install MAME" button — shown in place of "Launch Mame" when MAME is
         # missing, on platforms where the automatic install is supported (64-bit
@@ -9489,14 +9546,56 @@ class MainWindow(QMainWindow):
             "install it into the downloads/mame folder. Requires an internet\n"
             "connection (~90 MB download, ~500 MB installed).")
         self.button_install_mame.clicked.connect(install_mame)
-        self.button_install_mame.setVisible(
-            (not _mame_available) and (mame_windows_asset_arch() is not None))
-        self.horizontal6.addWidget(self.button_install_mame)
+        _mame_install_offered = (not _mame_available) and (mame_windows_asset_arch() is not None)
+        self.button_install_mame.setVisible(_mame_install_offered)
+        self.mame_group_layout.addWidget(self.button_install_mame)
+
+        # MAME per-launch option combos (aspect / mouse / joystick), mirroring the
+        # CSpect options. Their values are appended to the MAME command line at
+        # launch (see launch_mame) and persisted to hdfg.cfg as combo indices.
+        # They are only meaningful once MAME is installed, so they are hidden
+        # while only "Install MAME" is offered and revealed after a successful
+        # install (see _on_mame_install_result).
+        self.mame_aspect = QComboBox()
+        for _ma in MAME_ASPECT:
+            self.mame_aspect.addItem(_ma[0])
+        self.mame_aspect.setToolTip("MAME display aspect ratio (-aspect).")
+        self.mame_aspect.currentIndexChanged.connect(set_mame_aspect)
+        self.mame_group_layout.addWidget(self.mame_aspect)
+
+        self.mame_mouse = QComboBox()
+        for _mm in MAME_MOUSE:
+            self.mame_mouse.addItem(_mm[0])
+        self.mame_mouse.setToolTip(
+            "Enable host mouse capture (Kempston mouse) or disable it\n"
+            "(-mouse / -mouse_device none).")
+        self.mame_mouse.currentIndexChanged.connect(set_mame_mouse)
+        self.mame_group_layout.addWidget(self.mame_mouse)
+
+        self.mame_joystick = QComboBox()
+        for _mj in MAME_JOYSTICK:
+            self.mame_joystick.addItem(_mj[0])
+        self.mame_joystick.setToolTip(
+            "Enable or disable joystick input\n"
+            "(-joystick / -joystickprovider none).")
+        self.mame_joystick.currentIndexChanged.connect(set_mame_joystick)
+        self.mame_group_layout.addWidget(self.mame_joystick)
+
+        # Hide the option combos until MAME is actually installed (the group can
+        # still be visible to host the "Install MAME" button).
+        for _mame_combo in (self.mame_aspect, self.mame_mouse, self.mame_joystick):
+            _mame_combo.setVisible(_mame_available)
+
+        self.mame_group_layout.addStretch(1)
+
+        # --- CSpect group: launch button plus its display / input options -----
+        self.cspect_group = QGroupBox("CSpect")
+        self.cspect_group_layout = QHBoxLayout(self.cspect_group)
 
         self.button_start_cspect = QPushButton("🕹  LaunchCSpect", self)
         self.button_start_cspect.setText("🕹  Launch CSpect")
         self.button_start_cspect.clicked.connect(launch_cspect)
-        self.horizontal6.addWidget(self.button_start_cspect)
+        self.cspect_group_layout.addWidget(self.button_start_cspect)
 
         # Populate Screen Size Combo
         self.cspect_screensize = QComboBox()
@@ -9515,7 +9614,7 @@ class MainWindow(QMainWindow):
         self.cspect_screensize.show()
         self.cspect_screensize.currentIndexChanged.connect(set_cspect_screen_size)
 
-        self.horizontal6.addWidget(self.cspect_screensize)
+        self.cspect_group_layout.addWidget(self.cspect_screensize)
 
         # Populate Sound Combo
         self.cspect_sound = QComboBox()
@@ -9526,7 +9625,7 @@ class MainWindow(QMainWindow):
         self.cspect_sound.show()
         self.cspect_sound.currentIndexChanged.connect(set_cspect_sound_on_off)
 
-        self.horizontal6.addWidget(self.cspect_sound)
+        self.cspect_group_layout.addWidget(self.cspect_sound)
 
         # Populate vsync Combo
         self.cspect_vsync = QComboBox()
@@ -9537,7 +9636,7 @@ class MainWindow(QMainWindow):
         self.cspect_vsync.show()
         self.cspect_vsync.currentIndexChanged.connect(set_cspect_vsync_on_off)
 
-        self.horizontal6.addWidget(self.cspect_vsync)
+        self.cspect_group_layout.addWidget(self.cspect_vsync)
 
         # Populate Joystick Combo
         self.cspect_joystick = QComboBox()
@@ -9548,7 +9647,7 @@ class MainWindow(QMainWindow):
         self.cspect_joystick.show()
         self.cspect_joystick.currentIndexChanged.connect(set_cspect_joystick_on_off)
 
-        self.horizontal6.addWidget(self.cspect_joystick)
+        self.cspect_group_layout.addWidget(self.cspect_joystick)
 
         # Populate Mouse Combo (mouse capture on/off; "Mouse Off" passes -mouse)
         self.cspect_mouse = QComboBox()
@@ -9559,7 +9658,7 @@ class MainWindow(QMainWindow):
         self.cspect_mouse.show()
         self.cspect_mouse.currentIndexChanged.connect(set_cspect_mouse_on_off)
 
-        self.horizontal6.addWidget(self.cspect_mouse)
+        self.cspect_group_layout.addWidget(self.cspect_mouse)
 
         # Populate frequency Combo
         self.cspect_frequency = QComboBox()
@@ -9570,23 +9669,26 @@ class MainWindow(QMainWindow):
         self.cspect_frequency.show()
         self.cspect_frequency.currentIndexChanged.connect(set_cspect_display_frequency)
 
-        self.horizontal6.addWidget(self.cspect_frequency)
+        self.cspect_group_layout.addWidget(self.cspect_frequency)
 
-        # Hide all CSpect controls when the CSpect emulator was not found at
-        # startup (application directory or PATH). The MAME button is unaffected.
+        self.cspect_group_layout.addStretch(1)
+
+        # Hide the MAME group when neither of its buttons applies — i.e. MAME is
+        # not installed and the in-app installer isn't offered on this platform
+        # (only 64-bit Windows) — so we never show an empty titled box.
+        if not _mame_available and not _mame_install_offered:
+            self.mame_group.setVisible(False)
+
+        # Hide the whole CSpect group when the CSpect emulator was not found at
+        # startup (application directory or PATH). The individual controls keep
+        # their own visible flags so the async downloads/cspect scan can reveal
+        # the group later just by showing it. The MAME group is unaffected.
         if self._cspect_executable_path is None:
-            for _cspect_widget in (
-                self.button_start_cspect,
-                self.cspect_screensize,
-                self.cspect_sound,
-                self.cspect_vsync,
-                self.cspect_joystick,
-                self.cspect_mouse,
-                self.cspect_frequency,
-            ):
-                _cspect_widget.setVisible(False)
+            self.cspect_group.setVisible(False)
 
-        self.zx_next_unite_form.addRow(self.horizontal6)
+        # MAME group on its own line, CSpect group stacked directly beneath it.
+        self.zx_next_unite_form.addRow(self.mame_group)
+        self.zx_next_unite_form.addRow(self.cspect_group)
 
         set_all_buttons_disabled()
         enable_image_selection()
@@ -21587,7 +21689,11 @@ class MainWindow(QMainWindow):
                 "Command-line parameters passed to MAME. The '{MAME_EXECUTABLE_NAME}'\n"
                 "placeholder resolves to the detected executable. The ROM/system above\n"
                 "and the '-hard1 <image>' arguments are added automatically at launch,\n"
-                "so the loaded image is always the last argument."
+                "so the loaded image is always the last argument.\n"
+                "The aspect ratio, mouse and joystick options are set with the combo\n"
+                "boxes in the MAME group on the SD Card Utility tab; any -aspect,\n"
+                "-mouse/-mouse_device or -joystick/-joystickprovider options typed here\n"
+                "are ignored (the combos take precedence)."
             )
             grid_tab_Settings.addWidget(mame_params_lbl, 26, 0)
 
@@ -22682,13 +22788,9 @@ class MainWindow(QMainWindow):
             if cspect_path and not self._cspect_executable_path:
                 self._cspect_executable_path = cspect_path
                 self._cspect_from_downloads = True
-                # The CSpect controls were hidden at construction because no
-                # emulator was found; reveal them now that a bundled copy exists.
-                for _w in (self.button_start_cspect, self.cspect_screensize,
-                           self.cspect_sound, self.cspect_vsync,
-                           self.cspect_joystick, self.cspect_mouse,
-                           self.cspect_frequency):
-                    _w.setVisible(True)
+                # The CSpect group was hidden at construction because no emulator
+                # was found; reveal it now that a bundled copy exists.
+                self.cspect_group.setVisible(True)
                 add_main_log_window(f"Found CSpect under downloads/cspect: {cspect_path}")
 
             if hdfmonkey_path and not self._hdfmonkey_executable_path:
@@ -22785,21 +22887,15 @@ class MainWindow(QMainWindow):
                 except (ValueError, OSError):
                     return False
 
-            cspect_widgets = (
-                self.button_start_cspect, self.cspect_screensize,
-                self.cspect_sound, self.cspect_vsync,
-                self.cspect_joystick, self.cspect_mouse, self.cspect_frequency)
-
             cleared_cspect = False
             if _under(self._cspect_executable_path, removed_path):
                 self._cspect_executable_path = None
                 self._cspect_from_downloads = False
                 cleared_cspect = True
-                # These controls were revealed when CSpect was found; hide them
-                # again now that the build is gone.
-                for _w in cspect_widgets:
-                    try: _w.setVisible(False)
-                    except RuntimeError: pass
+                # The group was revealed when CSpect was found; hide it again now
+                # that the build is gone.
+                try: self.cspect_group.setVisible(False)
+                except RuntimeError: pass
             if _under(self._hdfmonkey_executable_path, removed_path):
                 self._hdfmonkey_executable_path = None
 
@@ -22813,9 +22909,8 @@ class MainWindow(QMainWindow):
                 if _path_cspect:
                     self._cspect_executable_path = _path_cspect
                     self._cspect_from_downloads = False
-                    for _w in cspect_widgets:
-                        try: _w.setVisible(True)
-                        except RuntimeError: pass
+                    try: self.cspect_group.setVisible(True)
+                    except RuntimeError: pass
 
             # Re-run detection for whatever is still missing (walks downloads),
             # then re-show the hdfmonkey download button (any platform) if no copy

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -119,6 +119,9 @@ SETTING_MAME_COMMAND_LINE_PARAMETERS = "mame_command_line_parameters"
 SETTING_MAME_ROM_CHOICE              = "mame_rom_choice"            # MAME system/ROM, e.g. "tbblue" (default)
 SETTING_MAME_UPDATE_CHECK            = "mame_update_check"          # "false" => skip the startup MAME update check (default on)
 SETTING_MAME_INSTALLED_TAG           = "mame_installed_tag"         # GitHub release tag of the MAME build installed via the app (e.g. "mame0272")
+SETTING_MAME_ASPECT                  = "mame_aspect"               # combo index into MAME_ASPECT (display aspect ratio, e.g. 2:1 / 1:1)
+SETTING_MAME_MOUSE                   = "mame_mouse"                # combo index into MAME_MOUSE (mouse capture on/off)
+SETTING_MAME_JOYSTICK                = "mame_joystick"             # combo index into MAME_JOYSTICK (joystick input on/off)
 SETTING_DISABLE_NO_EMULATOR_TOAST  = "disable_no_emulator_toast"   # bool (default False)
 SETTING_NEXTSYNC_EXPLORERPATH = "nextsync_explorerpath"
 SETTING_NEXTSYNC_SYNCONCE = "nextsync_synconce"
@@ -707,7 +710,7 @@ SETTING_COLOR_FILE_EXT, SETTING_COLOR_FILE_SIZE, SETTING_COLOR_GENERAL_TEXT, SET
 SETTING_GALLERY_ROWS_PER_PAGE, SETTING_GALLERY_COLS, SETTING_GALLERY_IMG_SIZE, SETTING_GALLERY_SLIDESHOW_SECS, SETTING_GETIT_VIEW_MODE, SETTING_ZXDB_VIEW_MODE,
 SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVORITES_VIEW_MODE,
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
-SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
+SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_SDCARD_PYGAME_LOG, SETTING_HELP_PYGAME_LOG,
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
@@ -731,11 +734,58 @@ FONT_RED = QColor(255, 0, 0)
 
 MAME_ROM_CHOICE = (("tbblue"), ("specnext_ks1"), ("specnext_ks2"), ("specnext_ks3"))
 MAME_EXECUTABLE_NAME = "mame"
-# The ROM/system (e.g. "tbblue") and the "-hard1 <image>" arguments are NOT part
-# of this default: the ROM is chosen by the user (SETTING_MAME_ROM_CHOICE) and
-# "-hard1 <image>" is appended dynamically at launch so the image is always the
-# last argument passed to MAME.
-MAME_DEFAULT_COMMAND_LINE = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -aspect 2:1 -video bgfx  -bgfx_screen_chains unfiltered -window -skip_gameinfo -confirm_quit"
+
+# MAME per-launch options exposed as combo boxes in the SD Card Utility's MAME
+# group, mirroring the CSpect options. Each tuple is (label, argument); the
+# first entry is the first-run default. These are appended dynamically at launch
+# (see launch_mame) and are NOT baked into MAME_DEFAULT_COMMAND_LINE, so the
+# user can flip them from the UI without editing the raw command line. Option
+# names follow the specnext MAME guide (https://wiki.specnext.dev/MAME:Installing)
+# and `mame -showusage`:
+#   -aspect W:H            display aspect ratio (2:1 is the crisp-pixel default)
+#   -mouse                 enable host mouse capture (Kempston mouse)
+#   -mouse_device none     disable the mouse control (wiki's recommended default)
+#   -joystick              enable joystick input
+#   -joystickprovider none disable joystick detection
+MAME_ASPECT = (("Aspect 2:1", "-aspect 2:1"), ("Aspect 1:1", "-aspect 1:1"))
+MAME_MOUSE = (("Mouse Off", "-mouse_device none"), ("Mouse On", "-mouse"))
+MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovider none"))
+
+# Options now driven by the MAME group combos above. They are stripped from any
+# user-edited command-line params at launch so the combo selections are the
+# single source of truth (never duplicated or in conflict). Flag options take no
+# value; value options consume the following token.
+MAME_COMBO_FLAG_OPTIONS = frozenset({"-mouse", "-nomouse", "-joystick", "-nojoystick"})
+MAME_COMBO_VALUE_OPTIONS = frozenset({"-aspect", "-mouse_device", "-joystickprovider"})
+
+def strip_mame_combo_options(tokens):
+    """Remove the aspect/mouse/joystick options (and their values) from a list of
+    MAME command-line tokens so the values chosen in the MAME group combos are
+    authoritative. Returns a new list; the input is left unchanged."""
+    result = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in MAME_COMBO_VALUE_OPTIONS:
+            skip_next = True
+            continue
+        if token in MAME_COMBO_FLAG_OPTIONS:
+            continue
+        result.append(token)
+    return result
+
+# The ROM/system (e.g. "tbblue"), the aspect/mouse/joystick options (chosen via
+# the combos above) and the "-hard1 <image>" arguments are NOT part of this
+# default: the ROM is chosen by the user (SETTING_MAME_ROM_CHOICE), the combo
+# options are appended at launch, and "-hard1 <image>" is appended dynamically
+# so the image is always the last argument passed to MAME.
+MAME_DEFAULT_COMMAND_LINE = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -video bgfx -bgfx_screen_chains unfiltered -window -skip_gameinfo -confirm_quit"
+# Previous default that hard-coded "-aspect 2:1"; a saved cfg still carrying this
+# exact string is migrated to MAME_DEFAULT_COMMAND_LINE on load so the Settings
+# command-line box no longer duplicates the now combo-controlled aspect option.
+MAME_DEFAULT_COMMAND_LINE_LEGACY = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -aspect 2:1 -video bgfx  -bgfx_screen_chains unfiltered -window -skip_gameinfo -confirm_quit"
 # Appended right before the image path at launch time.
 MAME_HARD_DISK_PARAMETER = "-hard1"
 # Setup guide for the ZX Spectrum Next MAME support. Notably it documents the


### PR DESCRIPTION
## Summary

Reworks the SD Card Utility launch controls into two titled groups and adds MAME launch-option combo boxes, mirroring the existing CSpect options.

### Grouping
- The launch row is split into two `QGroupBox`es — a **MAME** group on its own line and a **CSpect** group stacked directly beneath it — so the two emulators' controls are no longer one long, easily-confused button row.
- Visibility is preserved: the CSpect group hides entirely when CSpect isn't found; the MAME group hides when neither Launch nor Install applies, so no empty titled box is ever shown.

### MAME option combos
Added three combos to the MAME group, persisted as separate cfg settings (`mame_aspect`, `mame_mouse`, `mame_joystick`, stored as combo indices):

| Combo | Options (default first) | MAME argument |
|---|---|---|
| Aspect | Aspect 2:1 / Aspect 1:1 | `-aspect 2:1` / `-aspect 1:1` |
| Mouse | Mouse Off / Mouse On | `-mouse_device none` / `-mouse` |
| Joystick | Joystick On / Joystick Off | `-joystick` / `-joystickprovider none` |

Option names follow the [specnext MAME guide](https://wiki.specnext.dev/MAME:Installing) and `mame -showusage` (verified against MAME 0.288). Defaults match the wiki's recommendation (aspect 2:1, mouse disabled, joystick enabled).

### Dynamic command line
- Removed the hardcoded `-aspect 2:1` from `MAME_DEFAULT_COMMAND_LINE`; aspect/mouse/joystick are now appended dynamically at launch from the combos.
- `launch_mame` strips any `-aspect` / `-mouse`/`-mouse_device` / `-joystick`/`-joystickprovider` tokens from the editable "MAME launch parameters" before appending the combo selections, so the combos are the single source of truth (no duplicate/conflicting flags).
- A saved cfg still carrying the legacy default (with `-aspect 2:1`) is migrated to the new default on load.
- The Settings tab tooltip now notes that these options are combo-controlled and take precedence.

## Testing
- Byte-compiles cleanly; unit-tested argument assembly and option-stripping (defaults, non-defaults, legacy dedup, stray-flag removal).
- Live-verified in the running app: MAME group renders **Launch Mame · Aspect 2:1 · Mouse Off · Joystick On**.
- Live load: a cfg seeded with `1/1/1` restored **Aspect 1:1 · Mouse On · Joystick Off**.
- Live save: changing the aspect combo wrote `mame_aspect=0` to disk and migrated the legacy command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)