### PR TITLE
itch.io CSpect install fix (Cloudflare bypass), MAME sound method, OpenAL notice

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2306,7 +2306,7 @@ class _CompleterPopupHider(QtCore.QObject):
 class MainWindow(QMainWindow):
 
     def _show_toast(self, title: str, message: str = "", *, variant: str = "green",
-                    duration_ms: int = 10000):
+                    duration_ms: int = 10000, rich: bool = False):
         """Show a small, auto-dismissing toast in the bottom-right corner.
 
         ``variant`` selects the colour scheme:
@@ -2314,7 +2314,11 @@ class MainWindow(QMainWindow):
           - "yellow" : warning / advisory
 
         The toast disappears automatically after ``duration_ms`` milliseconds,
-        or immediately when the user clicks the OK button.
+        or immediately when the user clicks the OK button. When ``rich`` is True
+        the message is rendered as rich text (HTML) with clickable external
+        links (use ``<br>`` for line breaks and ``<a href=…>`` for links);
+        otherwise it is plain text so embedded URLs and ``\\r\\n`` line breaks
+        are shown verbatim.
         """
         # Colour schemes per variant: (bg, border, title_fg, btn_bg, btn_border,
         # btn_hover).
@@ -2346,6 +2350,9 @@ class MainWindow(QMainWindow):
                 msg_lbl.setWordWrap(True)
                 msg_lbl.setMaximumWidth(360)
                 msg_lbl.setStyleSheet("color: #e8e8e8; background: transparent;")
+                if rich:
+                    msg_lbl.setTextFormat(Qt.RichText)
+                    msg_lbl.setOpenExternalLinks(True)
                 lay.addWidget(msg_lbl)
 
             btn_row = QHBoxLayout()
@@ -2423,12 +2430,34 @@ class MainWindow(QMainWindow):
             mame_path = getattr(self, "_mame_executable_path", None)
             if mame_path:
                 body += "\r\nMame: " + mame_path
-            self._show_toast(
-                "\u2705  Emulator(s) detected",
-                body,
-                variant="green",
-                duration_ms=5000,
-            )
+            # After a fresh itch.io CSpect install (one-shot flag), append the
+            # Windows-only reminder to install OpenAL 1.1 \u2014 CSpect has no sound
+            # on Windows without it (Linux/macOS ship OpenAL, so it's skipped
+            # there). The link is clickable and the toast stays up \u2265 1 minute.
+            _openal = (self._cspect_openal_notice_pending
+                       and "CSpect" in found
+                       and platform.system() == "Windows")
+            self._cspect_openal_notice_pending = False
+            if _openal:
+                rich_body = body.replace("\r\n", "<br>")
+                rich_body += (
+                    "<br><br>\u26a0 On Windows, CSpect needs <b>OpenAL 1.1</b> "
+                    "for sound. If you have no audio, install it from "
+                    "<a href=\"https://www.openal.org/\">openal.org</a>.")
+                self._show_toast(
+                    "\u2705  CSpect installed",
+                    rich_body,
+                    variant="green",
+                    duration_ms=65000,
+                    rich=True,
+                )
+            else:
+                self._show_toast(
+                    "\u2705  Emulator(s) detected",
+                    body,
+                    variant="green",
+                    duration_ms=5000,
+                )
         else:
             _suppress = self.settings_disable_no_emulator_toast_checkbox.isChecked()
             if not _suppress:
@@ -2577,6 +2606,12 @@ class MainWindow(QMainWindow):
         # worker and its signals alive until the scan finishes (otherwise Qt
         # drops the queued result/finished events when the sender is collected).
         self._emulator_scan_worker = None
+        # One-shot: set True by an itch.io CSpect install so the next
+        # emulator-detection toast appends the Windows-only "install OpenAL for
+        # sound" notice (CSpect needs OpenAL 1.1 for audio on Windows). Consumed
+        # by _show_emulator_detection_toast so it never fires on a plain startup
+        # detection.
+        self._cspect_openal_notice_pending = False
 
         # Live QColor instances for the image explorer — updated by Settings pickers
         self.img_color_up_directory = hex_to_qcolor(DEFAULT_COLOR_UP_DIRECTORY)
@@ -3280,10 +3315,12 @@ class MainWindow(QMainWindow):
                 self.cspect_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_JOYSTICK]))
                 self.cspect_mouse.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MOUSE]))
                 self.cspect_frequency.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_HERTZ]))
-                # MAME option combos (aspect / mouse / joystick). Stored as combo
-                # indices; an absent value ("") maps to index 0 (the default).
+                # MAME option combos (aspect / sound / mouse / joystick). Stored
+                # as combo indices; an absent value ("") maps to index 0 (the
+                # default, i.e. "Sound On" for audio).
                 if hasattr(self, "mame_aspect"):
                     self.mame_aspect.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_ASPECT]))
+                    self.mame_sound.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_SOUND]))
                     self.mame_mouse.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_MOUSE]))
                     self.mame_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_JOYSTICK]))
 
@@ -3957,10 +3994,14 @@ class MainWindow(QMainWindow):
             configuration_dictionary[SETTING_HERTZ] = self.cspect_frequency.currentIndex()
             save_configuration_file()
 
-        # MAME per-launch option combos (aspect / mouse / joystick). Persisted as
-        # combo indices, mirroring the CSpect option setters above.
+        # MAME per-launch option combos (aspect / sound / mouse / joystick).
+        # Persisted as combo indices, mirroring the CSpect option setters above.
         def set_mame_aspect():
             configuration_dictionary[SETTING_MAME_ASPECT] = self.mame_aspect.currentIndex()
+            save_configuration_file()
+
+        def set_mame_sound():
+            configuration_dictionary[SETTING_MAME_SOUND] = self.mame_sound.currentIndex()
             save_configuration_file()
 
         def set_mame_mouse():
@@ -4116,6 +4157,7 @@ class MainWindow(QMainWindow):
             # the UI selections are authoritative regardless of the params string.
             for _mame_combo, _mame_opts in (
                 (getattr(self, "mame_aspect", None), MAME_ASPECT),
+                (getattr(self, "mame_sound", None), MAME_SOUND),
                 (getattr(self, "mame_mouse", None), MAME_MOUSE),
                 (getattr(self, "mame_joystick", None), MAME_JOYSTICK),
             ):
@@ -4391,6 +4433,7 @@ class MainWindow(QMainWindow):
                 # Reveal the MAME option combos, hidden while only "Install MAME"
                 # was offered.
                 for _mame_combo in (getattr(self, "mame_aspect", None),
+                                    getattr(self, "mame_sound", None),
                                     getattr(self, "mame_mouse", None),
                                     getattr(self, "mame_joystick", None)):
                     if _mame_combo is not None:
@@ -9563,6 +9606,16 @@ class MainWindow(QMainWindow):
         self.mame_aspect.currentIndexChanged.connect(set_mame_aspect)
         self.mame_group_layout.addWidget(self.mame_aspect)
 
+        self.mame_sound = QComboBox()
+        for _ms in MAME_SOUND:
+            self.mame_sound.addItem(_ms[0])
+        self.mame_sound.setToolTip(
+            "MAME audio output method (-sound). 'Sound On' (default) keeps MAME's\n"
+            "own backend; WASAPI / XAudio2 / PortAudio force a specific method\n"
+            "(WASAPI and XAudio2 are Windows-only); 'Sound Off' mutes (-sound none).")
+        self.mame_sound.currentIndexChanged.connect(set_mame_sound)
+        self.mame_group_layout.addWidget(self.mame_sound)
+
         self.mame_mouse = QComboBox()
         for _mm in MAME_MOUSE:
             self.mame_mouse.addItem(_mm[0])
@@ -9583,7 +9636,7 @@ class MainWindow(QMainWindow):
 
         # Hide the option combos until MAME is actually installed (the group can
         # still be visible to host the "Install MAME" button).
-        for _mame_combo in (self.mame_aspect, self.mame_mouse, self.mame_joystick):
+        for _mame_combo in (self.mame_aspect, self.mame_sound, self.mame_mouse, self.mame_joystick):
             _mame_combo.setVisible(_mame_available)
 
         self.mame_group_layout.addStretch(1)
@@ -19048,6 +19101,10 @@ class MainWindow(QMainWindow):
 
                     def _redetect():
                         if is_cspect:
+                            # Arm the Windows-only "install OpenAL for sound"
+                            # notice appended to the detection toast that the
+                            # rescan triggers once CSpect is found.
+                            self._cspect_openal_notice_pending = True
                             try:
                                 self._rescan_emulators_after_install()
                             except Exception:
@@ -19090,6 +19147,61 @@ class MainWindow(QMainWindow):
                     _itchio_set_status(f"Extracting {os.path.basename(chosen)}…")
                     getit_run_in_thread(_xfn, _xok, _xerr)
 
+                def _itchio_pick_and_install_zip(_e=entry):
+                    """Let the user install from a .zip they downloaded manually
+                    from the itch.io page (the browser fallback). The archive is
+                    copied into the item's install folder, extracted into a
+                    build-numbered subfolder, and emulator detection re-run so a
+                    manually fetched CSpect becomes usable (and its group shows)."""
+                    fn, _sel = QFileDialog.getOpenFileName(
+                        self, "Select the downloaded itch.io .zip", dest,
+                        "Zip archives (*.zip)")
+                    if not fn:
+                        return
+                    _itchio_set_status(f"Installing from {os.path.basename(fn)}…")
+                    def _fn(_g=_e, _zip=fn):
+                        return zxnu_itchio.manual_install_zip(_g, _zip, dest)
+                    def _ok(out, _g=_e):
+                        _itchio_set_status(f"Installed to {out}")
+                        _itchio_mark_local_state_changed()
+                        # Reveal the CSpect group if this was a CSpect build, and
+                        # arm the Windows-only OpenAL sound notice for it.
+                        _is_cspect = "cspect" in (
+                            (_g.get("url") or "") + " " + (_g.get("title") or "")
+                        ).lower()
+                        if _is_cspect:
+                            self._cspect_openal_notice_pending = True
+                        if hasattr(self, "_rescan_emulators_after_install"):
+                            try: self._rescan_emulators_after_install()
+                            except Exception: pass
+                    def _err(e):
+                        _itchio_set_status(f"Could not install from file: {e}")
+                    getit_run_in_thread(_fn, _ok, _err)
+
+                def _itchio_offer_manual_fallback(_e=entry, _msg=""):
+                    """On a failed/blocked automated install, offer the manual
+                    browser download: open the itch.io page, or install from an
+                    already-downloaded .zip."""
+                    url = (_e.get("url") or "").strip()
+                    box = QMessageBox(self)
+                    box.setIcon(QMessageBox.Warning)
+                    box.setWindowTitle("itch.io download")
+                    box.setText(_msg or "The automated download failed.")
+                    box.setInformativeText(
+                        "You can download it manually from the itch.io page in "
+                        "your browser, then install it from the downloaded .zip.")
+                    open_btn = (box.addButton("Open itch.io page", QMessageBox.ActionRole)
+                                if url else None)
+                    pick_btn = box.addButton("Install from .zip…", QMessageBox.AcceptRole)
+                    box.addButton("Close", QMessageBox.RejectRole)
+                    box.exec()
+                    clicked = box.clickedButton()
+                    if open_btn is not None and clicked is open_btn:
+                        try: webbrowser.open(url, new=2)
+                        except Exception: pass
+                    elif clicked is pick_btn:
+                        _itchio_pick_and_install_zip(_e)
+
                 def _install(_=False, _e=entry, _viewer=viewer):
                     key = _itchio_api_key()
                     if not key:
@@ -19104,7 +19216,7 @@ class MainWindow(QMainWindow):
                     except RuntimeError: pass
                     _itchio_enable_download(_viewer, False)
                     _itchio_label_button(_viewer, "download", "⬇  Installing…")
-                    _itchio_set_status(f"Installing “{title}” via itch-dl…")
+                    _itchio_set_status(f"Installing “{title}”…")
                     def _fn(_g=_e, _k=key):
                         return zxnu_itchio.install_game(
                             _g, _k, dest, log_cb=lambda ln: None)
@@ -19129,12 +19241,18 @@ class MainWindow(QMainWindow):
                         if ok:
                             _itchio_mark_local_state_changed()
                             _itchio_run_setup_extract(_e)
+                        else:
+                            # Automated download failed (e.g. itch.io's Cloudflare
+                            # block on non-owned items). Offer the manual browser
+                            # download fallback.
+                            _itchio_offer_manual_fallback(_e, msg)
                     def _err(e, _v=_viewer):
                         _itchio_set_status(f"Install failed: {e}")
                         try: _v._itchio_busy = False
                         except RuntimeError: pass
                         _itchio_enable_download(_v, True)
                         _itchio_label_button(_v, "download", "⬇  Install")
+                        _itchio_offer_manual_fallback(_e, f"Install failed: {e}")
                     getit_run_in_thread(_fn, _ok, _err)
 
                 def _itchio_uninstall(_=False, _e=entry, _viewer=viewer):

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -120,6 +120,7 @@ SETTING_MAME_ROM_CHOICE              = "mame_rom_choice"            # MAME syste
 SETTING_MAME_UPDATE_CHECK            = "mame_update_check"          # "false" => skip the startup MAME update check (default on)
 SETTING_MAME_INSTALLED_TAG           = "mame_installed_tag"         # GitHub release tag of the MAME build installed via the app (e.g. "mame0272")
 SETTING_MAME_ASPECT                  = "mame_aspect"               # combo index into MAME_ASPECT (display aspect ratio, e.g. 2:1 / 1:1)
+SETTING_MAME_SOUND                   = "mame_sound"                # combo index into MAME_SOUND (audio on/off)
 SETTING_MAME_MOUSE                   = "mame_mouse"                # combo index into MAME_MOUSE (mouse capture on/off)
 SETTING_MAME_JOYSTICK                = "mame_joystick"             # combo index into MAME_JOYSTICK (joystick input on/off)
 SETTING_DISABLE_NO_EMULATOR_TOAST  = "disable_no_emulator_toast"   # bool (default False)
@@ -710,7 +711,7 @@ SETTING_COLOR_FILE_EXT, SETTING_COLOR_FILE_SIZE, SETTING_COLOR_GENERAL_TEXT, SET
 SETTING_GALLERY_ROWS_PER_PAGE, SETTING_GALLERY_COLS, SETTING_GALLERY_IMG_SIZE, SETTING_GALLERY_SLIDESHOW_SECS, SETTING_GETIT_VIEW_MODE, SETTING_ZXDB_VIEW_MODE,
 SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVORITES_VIEW_MODE,
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
-SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
+SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_SDCARD_PYGAME_LOG, SETTING_HELP_PYGAME_LOG,
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
@@ -743,11 +744,24 @@ MAME_EXECUTABLE_NAME = "mame"
 # names follow the specnext MAME guide (https://wiki.specnext.dev/MAME:Installing)
 # and `mame -showusage`:
 #   -aspect W:H            display aspect ratio (2:1 is the crisp-pixel default)
+#   -sound <method>        audio output method: wasapi, xaudio2, portaudio or
+#                          none ("Sound On" leaves MAME's own default backend)
 #   -mouse                 enable host mouse capture (Kempston mouse)
 #   -mouse_device none     disable the mouse control (wiki's recommended default)
 #   -joystick              enable joystick input
 #   -joystickprovider none disable joystick detection
 MAME_ASPECT = (("Aspect 2:1", "-aspect 2:1"), ("Aspect 1:1", "-aspect 1:1"))
+# MAME's "-sound" selects the audio output backend (per `mame -showusage`), not a
+# simple on/off. "Sound On" (the first-run default) passes nothing so MAME keeps
+# its own default backend; the middle entries force a specific method; "Sound
+# Off" mutes with "-sound none". wasapi/xaudio2 are Windows-only backends.
+MAME_SOUND = (
+    ("Sound On", ""),
+    ("Sound WASAPI", "-sound wasapi"),
+    ("Sound XAudio2", "-sound xaudio2"),
+    ("Sound PortAudio", "-sound portaudio"),
+    ("Sound Off", "-sound none"),
+)
 MAME_MOUSE = (("Mouse Off", "-mouse_device none"), ("Mouse On", "-mouse"))
 MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovider none"))
 
@@ -756,7 +770,7 @@ MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovid
 # single source of truth (never duplicated or in conflict). Flag options take no
 # value; value options consume the following token.
 MAME_COMBO_FLAG_OPTIONS = frozenset({"-mouse", "-nomouse", "-joystick", "-nojoystick"})
-MAME_COMBO_VALUE_OPTIONS = frozenset({"-aspect", "-mouse_device", "-joystickprovider"})
+MAME_COMBO_VALUE_OPTIONS = frozenset({"-aspect", "-sound", "-mouse_device", "-joystickprovider"})
 
 def strip_mame_combo_options(tokens):
     """Remove the aspect/mouse/joystick options (and their values) from a list of
@@ -955,11 +969,13 @@ HDFMONKEY_EXECUTABLE = "hdfmonkey"
 # hdfmonkey archive when the automatic download from specnext.com is blocked.
 DOWNLOADS_ROOT_DIRNAME = "downloads"
 
-# Sub-directory (relative to the application directory) where itch.io CSpect
-# installs are downloaded by the itch.io tab. Several CSpect versions may live
-# here, each in its own sub-folder, and the Windows builds ship hdfmonkey.exe
-# alongside CSpect.exe.
-DOWNLOADS_CSPECT_DIRNAME = os.path.join("downloads", "itchio", "mdf200", "cspect")
+# Root (relative to the application directory) scanned for an itch.io CSpect
+# install. itch.io downloads land in per-author/game/version sub-folders here
+# (e.g. itchio/mdf200/cspect/files/CSpect3_1_4_0/), and the exact author/slug
+# depends on the item — plus a user may drop a manually-downloaded build here —
+# so the whole itchio tree is walked rather than one hardcoded sub-path. The
+# Windows builds ship hdfmonkey.exe alongside CSpect.exe.
+DOWNLOADS_CSPECT_DIRNAME = os.path.join("downloads", "itchio")
 
 # Sub-directory (relative to the application directory) where the standalone
 # hdfmonkey auto-download (HDF_MONKEY_JJJS_URL) unpacks the build for the current
@@ -1071,14 +1087,15 @@ def ensure_hdfmonkey_executable(hdfmonkey_path):
 
 
 def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonkey=True):
-    """Recursively search ``<base_dir>/downloads/cspect`` for a CSpect.exe and a
+    """Recursively search ``<base_dir>/downloads/itchio`` for a CSpect.exe and a
     bundled hdfmonkey executable built for the current platform.
 
     Returns ``(cspect_path, hdfmonkey_path)`` where each element is the full path
     to the first matching executable found, or ``None`` if not found / not
     searched for. This is the fallback used when neither tool is present in the
     application directory or on PATH — itch.io CSpect installs land under
-    ``downloads/cspect`` (optionally in a per-version sub-folder).
+    ``downloads/itchio`` in a per-author/game/version sub-folder (and a manually
+    downloaded build dropped anywhere under that tree is picked up too).
 
     The hdfmonkey search now covers Windows, Linux and macOS (Intel + Apple
     Silicon): the itch.io CSpect package ships an hdfmonkey build for each of

--- a/zxnu_itchio.py
+++ b/zxnu_itchio.py
@@ -319,6 +319,64 @@ class _StreamToLog(io.TextIOBase):
         return None
 
 
+# Shown when itch-dl "succeeds" (exit 0 / no return value) but nothing actually
+# downloaded. Since ~2025 itch.io fronts its game pages with a Cloudflare bot
+# challenge that returns HTTP 403 to non-browser clients, so itch-dl can no
+# longer scrape the page (or its data.json) to find the uploads — the itch.io
+# *API* still works (the key validates and download keys are fetched), only the
+# page/site fetch is blocked. This affects every itch-dl version (0.7.2 is the
+# latest) regardless of user-agent, so the practical workaround is a manual
+# browser download.
+ITCHIO_BLOCKED_MSG = (
+    "itch.io blocked the automated download: its game pages are now behind a "
+    "Cloudflare bot challenge that returns HTTP 403 to itch-dl, so the page "
+    "can't be read and nothing was downloaded. Open the item's itch.io page in "
+    "your browser and download the file manually.")
+
+
+def _itchdl_failure_from_output(text):
+    """Return a user-facing message when itch-dl's captured output reports that a
+    game download failed, otherwise "".
+
+    itch-dl exits 0 and ``drive_downloads`` returns ``None`` even when a game
+    fails — it merely prints ``Download failed for <url>:`` followed by the
+    reason — so the exit code / return value cannot be trusted to detect
+    failure. The Cloudflare 403 block gets a tailored, actionable message; any
+    other failure surfaces itch-dl's own reason line."""
+    if not text:
+        return ""
+    low = text.lower()
+    reported = ("download failed for" in low
+                or "could not download the game site" in low
+                or "game data fetching failed" in low)
+    if not reported:
+        return ""
+    if "403" in low or "forbidden" in low or "cloudflare" in low:
+        return ITCHIO_BLOCKED_MSG
+    for ln in text.splitlines():
+        s = ln.strip()
+        if s.startswith("- ") and s[2:].strip():
+            return s[2:].strip()
+    return "itch-dl reported the download failed; nothing was downloaded."
+
+
+def _download_produced_files(game, dest_dir):
+    """True when a real file (not just an empty game folder) was downloaded for
+    *game* under *dest_dir*.
+
+    itch-dl creates the per-game folder even when the download fails, so an
+    existing-but-empty folder must count as 'nothing downloaded'. Used as a
+    catch-all backstop so a silently failed install is never reported as
+    success regardless of how itch-dl signalled it."""
+    path = installed_path(game, dest_dir)
+    if not path or not os.path.isdir(path):
+        return False
+    for _root, _dirs, files in os.walk(path):
+        if files:
+            return True
+    return False
+
+
 def _install_in_process(game_url, api_key, dest_dir, log_cb=None):
     """Run itch-dl entirely in-process (no subprocess).
 
@@ -335,7 +393,13 @@ def _install_in_process(game_url, api_key, dest_dir, log_cb=None):
     *log_cb*. Returns ``(ok, message)``; runs synchronously — call from a worker
     thread."""
 
+    # Capture forwarded lines too: drive_downloads() prints "Download failed
+    # for <url>:" and returns None even on failure, so scanning the output is
+    # how the failure is actually detected below.
+    _captured = []
+
     def _log(line):
+        _captured.append(line)
         if log_cb:
             try:
                 log_cb(line)
@@ -394,6 +458,11 @@ def _install_in_process(game_url, api_key, dest_dir, log_cb=None):
 
             keys = get_download_keys(client)
             drive_downloads(jobs, settings, keys)
+            # drive_downloads never raises on a per-game failure; detect it from
+            # the output it printed (e.g. the Cloudflare 403 page block).
+            fail = _itchdl_failure_from_output("\n".join(_captured))
+            if fail:
+                return False, fail
             return True, f"Installed to {dest_dir}"
     except SystemExit as exc:
         # itch-dl internals call exit()/sys.exit() on fatal config problems.
@@ -405,12 +474,184 @@ def _install_in_process(game_url, api_key, dest_dir, log_cb=None):
         root.removeHandler(handler)
 
 
-def install_game(game, api_key, dest_dir, log_cb=None, timeout=3600):
-    """Download/install a single game via itch-dl into *dest_dir*.
+def _canonical_itch_url(url):
+    """Normalise an itch.io URL for equality checks (drop scheme, trailing slash,
+    case)."""
+    if not url:
+        return ""
+    return re.sub(r"^https?://", "", url.strip().lower()).rstrip("/")
 
-    Returns ``(ok, message)``. *log_cb*, when given, receives streamed output
-    lines so the UI can show progress. Runs synchronously — call from a worker
-    thread."""
+
+def _author_slug_from_url(url):
+    """Return ``(author, game_slug)`` parsed from an itch.io URL such as
+    ``https://mdf200.itch.io/cspect`` → ``("mdf200", "cspect")``. Mirrors the
+    ``<author>/<game>`` layout itch-dl uses under the download dir, so the API
+    download lands where ``installed_path`` / the emulator scan already look.
+    Falls back to ``("itchio", <slug>)`` when the subdomain can't be parsed."""
+    m = re.search(r"https?://([^./]+)\.itch\.io/([^/?#]+)", url or "")
+    if m:
+        return m.group(1), m.group(2)
+    return "itchio", (_game_slug({"url": url}) or "item")
+
+
+def _owned_key_for_game(game, api_key):
+    """Locate *game* among the user's owned itch.io download keys and return
+    ``(game_id, download_key_id)``, or ``(None, None)`` when it isn't owned.
+
+    itch.io now fronts its game *pages* with a Cloudflare bot challenge (HTTP
+    403), which is what breaks itch-dl, but the ``api.itch.io`` endpoints — incl.
+    ``/profile/owned-keys`` — are unaffected. So for anything the user owns
+    (bought, or claimed for free like CSpect) this yields the download key
+    needed to fetch the uploads directly, no page scrape required."""
+    want_url = _canonical_itch_url((game or {}).get("url"))
+    want_id = str((game or {}).get("id") or "")
+    for page in range(1, ITCH_MAX_PAGES + 1):
+        data = _api_get("/profile/owned-keys", api_key, params={"page": page})
+        keys = (data or {}).get("owned_keys") or []
+        if not keys:
+            break
+        for k in keys:
+            g = k.get("game") or {}
+            if (want_id and str(g.get("id")) == want_id) or \
+               (want_url and _canonical_itch_url(g.get("url")) == want_url):
+                return g.get("id"), k.get("id")
+        # owned-keys is paginated; stop once a short page is returned.
+        if len(keys) < int(data.get("per_page") or len(keys) or 1):
+            break
+    return None, None
+
+
+def _stream_response_to_file(resp, dest_path, log_cb=None):
+    """Stream an open HTTP response body to *dest_path* (via a .part temp file
+    that is renamed on completion). Returns the byte count."""
+    tmp = dest_path + ".part"
+    total = 0
+    with open(tmp, "wb") as fh:
+        while True:
+            chunk = resp.read(65536)
+            if not chunk:
+                break
+            fh.write(chunk)
+            total += len(chunk)
+    os.replace(tmp, dest_path)
+    if log_cb:
+        try:
+            log_cb(f"Downloaded {total} bytes → {os.path.basename(dest_path)}")
+        except Exception:
+            pass
+    return total
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that refuses to auto-follow, so we can read the 302
+    ``Location`` ourselves and fetch the signed CDN URL without re-sending the
+    itch.io ``Authorization`` header (the CDN rejects it with HTTP 400)."""
+
+    def redirect_request(self, *_args, **_kw):
+        return None
+
+
+def _download_api_upload(upload_id, download_key_id, api_key, dest_path, log_cb=None):
+    """Download one owned upload to *dest_path* via the itch.io API.
+
+    ``/uploads/{id}/download`` 302-redirects to a signed CDN URL that rejects the
+    ``Authorization`` header, so the redirect is resolved first (authenticated,
+    not auto-followed) and the CDN URL then fetched with a clean request."""
+    api_url = (ITCH_API_BASE + f"/uploads/{upload_id}/download"
+               f"?download_key_id={download_key_id}")
+    req = urllib.request.Request(api_url, headers={
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": ITCH_USER_AGENT,
+    })
+    opener = urllib.request.build_opener(_NoRedirect)
+    cdn_url = None
+    try:
+        with opener.open(req, timeout=60) as resp:
+            # No redirect: the API streamed the file itself.
+            _stream_response_to_file(resp, dest_path, log_cb)
+            return
+    except urllib.error.HTTPError as exc:
+        if exc.code in (301, 302, 303, 307, 308):
+            cdn_url = exc.headers.get("Location")
+        else:
+            raise
+    if not cdn_url:
+        raise RuntimeError("itch.io did not return a download URL.")
+    req2 = urllib.request.Request(cdn_url, headers={"User-Agent": ITCH_USER_AGENT})
+    with urllib.request.urlopen(req2, timeout=300) as resp2:
+        _stream_response_to_file(resp2, dest_path, log_cb)
+
+
+def install_via_api(game, api_key, dest_dir, log_cb=None):
+    """Download an *owned* itch.io item straight from the itch.io API, bypassing
+    the Cloudflare-blocked game-page scrape that itch-dl relies on.
+
+    Returns ``(ok, message)`` when the item is owned (so the API path applies),
+    or ``None`` when it isn't among the user's owned keys — signalling the caller
+    to fall back to itch-dl. The newest upload (by version-sorted filename) is
+    saved under ``<dest>/<author>/<game>/files/`` so the existing post-install
+    extract step unpacks it into a build-numbered folder and the emulator scan
+    can discover it."""
+    def _log(line):
+        if log_cb:
+            try:
+                log_cb(line)
+            except Exception:
+                pass
+
+    game_id, key_id = _owned_key_for_game(game, api_key)
+    if not game_id or not key_id:
+        return None  # not owned / no download key — let the caller fall back
+
+    _log("Downloading via the itch.io API (bypassing the Cloudflare page block)…")
+    data = _api_get(f"/games/{game_id}/uploads", api_key,
+                    params={"download_key_id": key_id})
+    uploads = [u for u in ((data or {}).get("uploads") or []) if u.get("id")]
+    if not uploads:
+        return False, "itch.io returned no downloadable files for this item."
+
+    # Newest build first (CSpect3_1_4_0 > CSpect3_1_3_0 > CSpect3_0_15_2).
+    uploads.sort(key=lambda u: _version_sort_key(u.get("filename") or ""),
+                 reverse=True)
+    upload = uploads[0]
+    filename = upload.get("filename") or f"upload-{upload['id']}"
+
+    author, slug = _author_slug_from_url((game or {}).get("url"))
+    files_dir = os.path.join(dest_dir, author, slug, "files")
+    os.makedirs(files_dir, exist_ok=True)
+    zip_path = os.path.join(files_dir, filename)
+
+    _log(f"Fetching {filename} …")
+    _download_api_upload(upload["id"], key_id, api_key, zip_path, log_cb=log_cb)
+    return True, f"Installed to {os.path.join(dest_dir, author, slug)}"
+
+
+def manual_install_zip(game, zip_path, dest_dir):
+    """Install a manually-downloaded itch.io ``.zip`` (the browser fallback used
+    when the automated download is Cloudflare-blocked).
+
+    Copies *zip_path* into the item's ``<dest>/<author>/<game>/files/`` folder —
+    the same layout an API / itch-dl install uses, so ``installed_path`` and the
+    emulator scan find it — then extracts it into a build-numbered subfolder
+    (via :func:`extract_zip`). Returns the extracted directory path."""
+    author, slug = _author_slug_from_url((game or {}).get("url"))
+    files_dir = os.path.join(dest_dir, author, slug, "files")
+    os.makedirs(files_dir, exist_ok=True)
+    target = os.path.join(files_dir, os.path.basename(zip_path))
+    if os.path.abspath(zip_path) != os.path.abspath(target):
+        import shutil
+        shutil.copy2(zip_path, target)
+    return extract_zip(target)
+
+
+def install_game(game, api_key, dest_dir, log_cb=None, timeout=3600):
+    """Download/install a single game into *dest_dir*.
+
+    Prefers the itch.io API (works for owned items, and bypasses the Cloudflare
+    bot challenge that now blocks itch-dl's page scrape); falls back to itch-dl
+    for items the user doesn't own. Returns ``(ok, message)``. *log_cb*, when
+    given, receives streamed output lines so the UI can show progress. Runs
+    synchronously — call from a worker thread."""
     api_key = (api_key or "").strip()
     game_url = (game or {}).get("url") or ""
     if not api_key:
@@ -426,17 +667,44 @@ def install_game(game, api_key, dest_dir, log_cb=None, timeout=3600):
             except Exception:
                 pass
 
-    # In a PyInstaller-frozen build, sys.executable is the GUI executable rather
-    # than a Python interpreter, so a "[sys.executable, -m, itch_dl, …]"
-    # subprocess just relaunches the app instead of running itch-dl (the folder
-    # is created but nothing is downloaded). Run itch-dl in-process there — it is
-    # bundled into the exe and importable. The subprocess path below is kept for
-    # the source/venv build, where it stays nicely isolated and already works.
+    # 1) Preferred: the itch.io API. itch-dl scrapes the game page, which itch.io
+    #    now Cloudflare-blocks (HTTP 403), but the API is unaffected — so this is
+    #    what actually restores installs for owned items (e.g. CSpect).
+    try:
+        api_result = install_via_api(game, api_key, dest_dir, log_cb=_log)
+    except Exception as exc:
+        _log(f"itch.io API download failed: {exc}")
+        api_result = (False, f"itch.io API download failed: {exc}")
+    if api_result is not None:
+        ok, msg = api_result
+        if ok and not _download_produced_files(game, dest_dir):
+            return False, ITCHIO_BLOCKED_MSG
+        return ok, msg
+
+    # 2) Not owned: fall back to itch-dl. In a PyInstaller-frozen build,
+    #    sys.executable is the GUI exe (a "-m itch_dl" subprocess would relaunch
+    #    the app), so itch-dl is driven in-process there; the source/venv build
+    #    uses the isolated subprocess path.
     if getattr(sys, "frozen", False):
         _log("Running bundled itch-dl in-process (frozen build)…")
-        return _install_in_process(game_url, api_key, dest_dir, log_cb=_log)
+        ok, msg = _install_in_process(game_url, api_key, dest_dir, log_cb=_log)
+    else:
+        ok, msg = _run_itchdl_subprocess(game_url, api_key, dest_dir, _log, timeout)
 
-    # Try `python -m itch_dl` first, then the `itch-dl` console script.
+    # Backstop: itch-dl can report success (exit 0 / no return) while itch.io
+    # blocked the actual download, leaving an empty game folder. If nothing
+    # landed on disk, override the phantom success with a clear message.
+    if ok and not _download_produced_files(game, dest_dir):
+        return False, ITCHIO_BLOCKED_MSG
+    return ok, msg
+
+
+def _run_itchdl_subprocess(game_url, api_key, dest_dir, _log, timeout):
+    """Run itch-dl as a subprocess (source/venv build) and return ``(ok, msg)``.
+
+    Tries ``python -m itch_dl`` first, then the ``itch-dl`` console script.
+    Because itch-dl exits 0 even when a game download fails, the captured output
+    is scanned for a failure report before success is declared."""
     attempts = [
         _itchdl_command(game_url, api_key, dest_dir),
         ["itch-dl", game_url, "--api-key", api_key, "--download-to", dest_dir],
@@ -456,11 +724,15 @@ def install_game(game, api_key, dest_dir, log_cb=None, timeout=3600):
         out = (proc.stdout or "") + (proc.stderr or "")
         for ln in out.splitlines():
             _log(ln)
+        # itch-dl exits 0 even when a game fails to download (it just prints
+        # "Download failed for …"), so check the output before trusting success.
+        fail = _itchdl_failure_from_output(out)
+        if fail:
+            return False, fail
         if proc.returncode == 0:
             return True, f"Installed to {dest_dir}"
-        last_err = f"itch-dl exited with code {proc.returncode}"
         # A non-zero exit is a real failure (not a missing executable): stop.
-        return False, last_err
+        return False, f"itch-dl exited with code {proc.returncode}"
     return False, f"Could not launch itch-dl: {last_err}"
 
 


### PR DESCRIPTION
Three related SD-card / emulator improvements.

## itch.io CSpect install — fixed (was silently broken)
itch.io now fronts its game pages with a **Cloudflare bot challenge** (`Cf-Mitigated: challenge`), so itch-dl's page/`data.json` scrape gets **HTTP 403** and downloads nothing. itch-dl also **exits 0 on failure**, so the app reported a phantom "Installed" and the CSpect group never appeared. (Latest itch-dl 0.7.2 is affected; not a user-agent issue. The itch.io *API* is unaffected.)

- **API-based installer** (`install_via_api`): match the owned download key via `/profile/owned-keys` → list uploads → download the newest build via `/uploads/{id}/download` (follow the 302 to the signed CDN, dropping the auth header). Bypasses Cloudflare. Preferred path; itch-dl remains the fallback for non-owned items. Verified end-to-end against the live API (downloads the real CSpect zip).
- **Build number kept in the extracted path** (`files/CSpect3_1_4_0/`) as the basis for future "new build available" detection.
- **Surface swallowed failures**: detect itch-dl's per-game failure (subprocess + in-process) plus a "did any file land on disk" backstop; clear, actionable message instead of fake success.
- **Broadened detection**: `find_emulators_in_downloads` now scans all of `downloads/itchio`, so an owned CSpect from any author/slug — or a manually dropped build — is found (also picks up the bundled hdfmonkey).
- **Manual browser fallback**: on failure, offer to open the itch.io page and to install from a downloaded `.zip` (copied into place, extracted, re-detected).

## MAME sound output method
New **Sound** combo in the MAME group — `Sound On` (default) / `WASAPI` / `XAudio2` / `PortAudio` / `Sound Off` (`-sound none`) — mirroring the CSpect options and ordering. `-sound` is stripped from hand-edited params so the combo stays authoritative.

## OpenAL notice (Windows only)
After a CSpect install, the detection toast appends a **clickable** reminder to install **OpenAL 1.1** ([openal.org](https://www.openal.org/)) for CSpect sound, shown for **≥ 1 minute**. Fires only after a fresh install (one-shot flag), never on ordinary startup detection. `_show_toast` gained an opt-in rich (clickable-link) mode.

## Verification
All files compile; the app constructs and runs offscreen with no errors. The itch.io API installer, extraction (build-numbered path), broadened detection, and the rich toast (clickable link, 65 s duration) were each verified against the live API / in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)