### PR TITLE
v8.7: itch.io CSpect startup update check, version picker & hdfmonkey fix

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2612,6 +2612,12 @@ class MainWindow(QMainWindow):
         # by _show_emulator_detection_toast so it never fires on a plain startup
         # detection.
         self._cspect_openal_notice_pending = False
+        # One-shot guard for the startup itch.io CSpect update check: it can be
+        # kicked from two places (the startup timer and the itch.io post-login
+        # callback), and _cspect_update_installing guards against overlapping
+        # download+install jobs. See _check_cspect_update_async.
+        self._cspect_update_checked = False
+        self._cspect_update_installing = False
 
         # Live QColor instances for the image explorer — updated by Settings pickers
         self.img_color_up_directory = hex_to_qcolor(DEFAULT_COLOR_UP_DIRECTORY)
@@ -3470,6 +3476,17 @@ class MainWindow(QMainWindow):
                     self.settings_mame_update_check_checkbox.blockSignals(True)
                     self.settings_mame_update_check_checkbox.setChecked(_mame_upd_on)
                     self.settings_mame_update_check_checkbox.blockSignals(False)
+
+                # CSpect "check for a newer version on itch.io at startup" toggle
+                # (default on). Always present as a widget (unlike MAME's, which
+                # is gated on detection).
+                if hasattr(self, "settings_cspect_update_check_checkbox"):
+                    _cspect_upd = configuration_dictionary.get(
+                        SETTING_CSPECT_UPDATE_CHECK, "").strip().lower()
+                    _cspect_upd_on = _cspect_upd not in ("false", "0", "no")  # default on
+                    self.settings_cspect_update_check_checkbox.blockSignals(True)
+                    self.settings_cspect_update_check_checkbox.setChecked(_cspect_upd_on)
+                    self.settings_cspect_update_check_checkbox.blockSignals(False)
 
                 # CSpect additional launch parameters (editable text). Always
                 # present; empty means "no extra parameters".
@@ -4683,6 +4700,231 @@ class MainWindow(QMainWindow):
         # Expose so the startup sequence can kick the check once the config
         # (enable flag + installed tag) has been loaded.
         self._check_mame_update_async = _check_mame_update_async
+
+        # ── CSpect update check (itch.io) ──────────────────────────────────
+        # Mirrors the MAME startup update check above, but sources the build
+        # from the user's *owned* itch.io CSpect item instead of GitHub. The
+        # closures below resolve add_main_log_window / getit_run_in_thread /
+        # configuration_dictionary at call time (late binding), exactly as the
+        # MAME check does — they are defined later in this same scope but the
+        # functions here only run after startup completes.
+
+        def _cspect_update_dest_dir():
+            """Absolute downloads/itchio root where itch.io CSpect installs land
+            (and where an update is downloaded + extracted)."""
+            return os.path.join(
+                os.path.dirname(os.path.abspath(sys.argv[0])),
+                DOWNLOADS_CSPECT_DIRNAME)
+
+        def _start_cspect_update_install(info):
+            """Download + extract the newer CSpect build found by the startup
+            check, logging every phase (download %, extraction, final extracted
+            path) to the SD Card log window. On success re-runs emulator
+            detection so the new build is adopted without a restart; on failure a
+            detailed reason is logged and shown in a dialog."""
+            if getattr(self, "_cspect_update_installing", False):
+                return
+            self._cspect_update_installing = True
+            game = info.get("game") or {"url": CSPECT_ITCH_URL, "title": "CSpect"}
+            api_key = (configuration_dictionary.get(SETTING_ITCHIO_API_KEY, "")
+                       or "").strip()
+            latest_name = info.get("version_name") or "the latest build"
+            filename = info.get("filename") or ""
+            dest_dir = _cspect_update_dest_dir()
+
+            add_main_log_window(
+                f"CSpect update ▸ Starting download + install of {latest_name} "
+                f"({filename or 'archive'}) from itch.io into {dest_dir}.")
+
+            # Marshal worker-thread log lines to the UI thread. Reuses
+            # MameInstallSignals (its 'status' str signal); kept on self so the
+            # queued emits survive until delivered (same rationale as the MAME
+            # install worker). add_main_log_window touches the QListWidget so it
+            # MUST run on the UI thread — hence the queued connection.
+            sig = MameInstallSignals()
+            sig.status.connect(lambda line: add_main_log_window(line),
+                               Qt.QueuedConnection)
+            self._cspect_update_signals = sig
+
+            def _log_cb(line):
+                try:
+                    sig.status.emit(str(line))
+                except RuntimeError:
+                    pass
+
+            def _progress_cb(read, total):
+                try:
+                    if total:
+                        pct = min(100, int(read * 100 / total))
+                        sig.status.emit(
+                            f"CSpect update ▸ downloading… {pct}% "
+                            f"({read / 1048576:.1f}/{total / 1048576:.1f} MB)")
+                    else:
+                        sig.status.emit(
+                            "CSpect update ▸ downloading… "
+                            f"{read / 1048576:.1f} MB")
+                except RuntimeError:
+                    pass
+
+            # Install exactly the build the update check identified (itch.io
+            # lists several CSpect versions; info carries the newest upload + its
+            # download key), so there's no second lookup and no chance of a
+            # mismatch with the version named in the prompt.
+            _chosen_upload = (info.get("uploads") or [None])[0]
+            _chosen_key_id = info.get("key_id")
+
+            def _job():
+                return zxnu_itchio.install_cspect_update(
+                    game, api_key, dest_dir,
+                    log_cb=_log_cb, progress_cb=_progress_cb,
+                    upload=_chosen_upload, key_id=_chosen_key_id)
+
+            def _ok(extracted):
+                self._cspect_update_installing = False
+                add_main_log_window(
+                    f"CSpect update ▸ SUCCESS — {latest_name} extracted to: "
+                    f"{extracted}")
+                # Adopt the freshly-installed build: drop the current CSpect path
+                # so the rescan re-selects the newest one (find_emulators_in_
+                # downloads now prefers the highest version folder). Also re-picks
+                # up the hdfmonkey bundled with the new CSpect.
+                self._cspect_executable_path = None
+                self._cspect_from_downloads = False
+                _rescan = getattr(self, "_rescan_emulators_after_install", None)
+                if _rescan is not None:
+                    try:
+                        _rescan()
+                    except Exception as exc:
+                        logging.info(f"CSpect update rescan failed: {exc}")
+                try:
+                    self._show_toast(
+                        "✅  CSpect updated",
+                        f"CSpect {latest_name} is installed — no restart "
+                        f"needed.\r\n{extracted}",
+                        variant="green", duration_ms=9000)
+                except Exception:
+                    pass
+
+            def _err(err):
+                self._cspect_update_installing = False
+                detail = (err[1] if isinstance(err, (tuple, list)) and len(err) > 1
+                          else err)
+                add_main_log_window(f"CSpect update ▸ FAILED — {detail}")
+                logging.error(f"CSpect update failed: {detail}")
+                try:
+                    QMessageBox.warning(
+                        self, "CSpect update failed",
+                        "The CSpect update could not be completed.\n\n"
+                        f"{detail}\n\n"
+                        "You can retry later, or install CSpect manually from the "
+                        "itch.io tab (https://mdf200.itch.io/cspect).")
+                except Exception:
+                    pass
+
+            getit_run_in_thread(_job, _ok, _err)
+
+        def _prompt_cspect_update(info):
+            """UI-thread dialog offering to update CSpect to the newer itch.io
+            build found by the startup check. 'Yes' downloads + installs it;
+            'Cancel' leaves the current build untouched."""
+            installed_name = info.get("installed_name") or "the current build"
+            latest_name = info.get("version_name") or "a newer build"
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Question)
+            box.setWindowTitle("CSpect update available")
+            box.setText(
+                "A newer version of CSpect is available on itch.io.\n\n"
+                f"Installed: {installed_name}\n"
+                f"Latest: {latest_name}\n\n"
+                "Download and install the newest version now?")
+            yes = box.addButton("Yes", QMessageBox.AcceptRole)
+            box.addButton("Cancel", QMessageBox.RejectRole)
+            box.setDefaultButton(yes)
+            box.exec()
+            if box.clickedButton() is yes:
+                add_main_log_window(
+                    f"CSpect update ▸ user chose to update to {latest_name}.")
+                _start_cspect_update_install(info)
+            else:
+                add_main_log_window("CSpect update ▸ user cancelled the update.")
+
+        def _check_cspect_update_async():
+            """At startup — once an itch.io API key is configured and the check is
+            enabled — ask itch.io for the newest CSpect build and, when it is
+            newer than the installed one, offer to download + install it.
+
+            Self-gates and never disrupts startup: any failure is logged to the
+            SD Card log window / Python log and swallowed. Runs once per session
+            (self._cspect_update_checked), so the two triggers — the startup timer
+            and the itch.io post-login callback — don't both fire it. The slow
+            parts (the installed-build disk scan and the itch.io API lookup) run
+            off the UI thread; the prompt runs back on the UI thread."""
+            if getattr(self, "_cspect_update_checked", False):
+                return
+            if getattr(self, "_cspect_update_installing", False):
+                return
+            pref = configuration_dictionary.get(
+                SETTING_CSPECT_UPDATE_CHECK, "").strip().lower()
+            if pref in ("false", "0", "no"):
+                return  # user disabled the check in Settings
+            api_key = (configuration_dictionary.get(SETTING_ITCHIO_API_KEY, "")
+                       or "").strip()
+            if not api_key:
+                return  # no itch.io account configured — nothing to check
+            # Passed the cheap gates. Mark done so the other trigger no-ops, then
+            # do the heavier work (disk scan + authenticated itch.io lookup) on a
+            # worker thread. The authenticated lookup doubles as the "login
+            # succeeded" confirmation — nothing is offered unless it returns.
+            self._cspect_update_checked = True
+            app_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+
+            def _job():
+                installed_name, installed_exe = find_installed_cspect_version(app_dir)
+                if not installed_name:
+                    return {"skip": "no itch.io CSpect install was found to update"}
+                info = zxnu_itchio.latest_cspect_upload(api_key)
+                if not info:
+                    return {"skip": "itch.io lists no CSpect download for this "
+                                    "account (not owned, or no download key)"}
+                info = dict(info)
+                info["installed_name"] = installed_name
+                info["installed_exe"] = installed_exe
+                info["newer"] = cspect_version_newer(
+                    info.get("version_name") or "", installed_name)
+                return info
+
+            def _on_result(info):
+                try:
+                    skip = info.get("skip")
+                    if skip:
+                        add_main_log_window(f"CSpect update check: {skip}.")
+                        return
+                    installed_name = info.get("installed_name")
+                    latest_name = info.get("version_name")
+                    if not info.get("newer"):
+                        add_main_log_window(
+                            f"CSpect is up to date (installed {installed_name}, "
+                            f"latest {latest_name}).")
+                        return
+                    add_main_log_window(
+                        f"CSpect update ▸ newer build available: installed "
+                        f"{installed_name}, latest {latest_name}.")
+                    _prompt_cspect_update(info)
+                except Exception as exc:
+                    logging.info(f"CSpect update check result handling failed: {exc}")
+
+            def _on_error(err):
+                detail = (err[1] if isinstance(err, (tuple, list)) and len(err) > 1
+                          else err)
+                add_main_log_window(f"CSpect update check skipped: {detail}")
+                logging.info(f"CSpect update check skipped: {detail}")
+
+            add_main_log_window("Checking itch.io for a newer CSpect release…")
+            getit_run_in_thread(_job, _on_result, _on_error)
+
+        # Expose so the startup sequence (and the itch.io post-login callback)
+        # can kick the check once the config (enable flag + API key) has loaded.
+        self._check_cspect_update_async = _check_cspect_update_async
 
 
         # Expose the emulator launch helpers so other UI surfaces (e.g. the
@@ -19217,9 +19459,9 @@ class MainWindow(QMainWindow):
                     _itchio_enable_download(_viewer, False)
                     _itchio_label_button(_viewer, "download", "⬇  Installing…")
                     _itchio_set_status(f"Installing “{title}”…")
-                    def _fn(_g=_e, _k=key):
-                        return zxnu_itchio.install_game(
-                            _g, _k, dest, log_cb=lambda ln: None)
+
+                    # Shared completion handlers for whichever download path runs
+                    # (the chosen-version API download, or the itch-dl fallback).
                     def _ok(res, _v=_viewer):
                         ok, msg = res
                         # The status label lives on the persistent tab, so it is
@@ -19253,7 +19495,63 @@ class MainWindow(QMainWindow):
                         _itchio_enable_download(_v, True)
                         _itchio_label_button(_v, "download", "⬇  Install")
                         _itchio_offer_manual_fallback(_e, f"Install failed: {e}")
-                    getit_run_in_thread(_fn, _ok, _err)
+
+                    def _reset_idle(_v=_viewer, status=None):
+                        # The user cancelled the version picker: restore the idle
+                        # Install button without treating it as a failure.
+                        try: _v._itchio_busy = False
+                        except RuntimeError: pass
+                        _itchio_enable_download(_v, True)
+                        _itchio_label_button(_v, "download", "⬇  Install")
+                        if status:
+                            _itchio_set_status(status)
+
+                    # Phase 1 (worker): list this item's downloadable files. itch.io
+                    # can expose several — CSpect ships every build (CSpect3_1_4_0,
+                    # CSpect3_1_3_0, …) side by side — so we may need to ask which to
+                    # fetch. Returns None for non-owned items (→ itch-dl fallback).
+                    def _list_fn(_g=_e, _k=key):
+                        return zxnu_itchio.list_owned_uploads(_g, _k)
+
+                    def _list_ok(listed, _v=_viewer, _k=key):
+                        if listed is None:
+                            # Not owned via the API — fall back to the full
+                            # install_game flow (itch-dl page scrape / backstop).
+                            def _fb_fn(_g=_e, _kk=_k):
+                                return zxnu_itchio.install_game(
+                                    _g, _kk, dest, log_cb=lambda ln: None)
+                            getit_run_in_thread(_fb_fn, _ok, _err)
+                            return
+                        _game_id, key_id, uploads = listed
+                        if len(uploads) == 1:
+                            chosen = uploads[0]
+                        else:
+                            # Several downloadable versions — let the user pick,
+                            # defaulting to the newest (index 0). This restores the
+                            # version chooser that the single-upload API download
+                            # otherwise bypassed.
+                            names = [u["filename"] for u in uploads]
+                            name, picked = QInputDialog.getItem(
+                                self, "Choose version to install",
+                                f"itch.io offers several versions of “{title}”.\n"
+                                "Choose which one to download and install\n"
+                                "(the newest is selected by default):",
+                                names, 0, False)
+                            if not picked:
+                                _reset_idle(status=f"Install of “{title}” cancelled.")
+                                return
+                            chosen = uploads[names.index(name)]
+                        _itchio_set_status(f"Downloading {chosen['filename']} …")
+                        # Phase 2 (worker): download the chosen upload. A successful
+                        # return means the file is on disk (download_owned_upload
+                        # raises on any network failure), so no extra backstop is
+                        # needed for this direct-API path.
+                        def _dl_fn(_g=_e, _kk=_k, _u=chosen, _kid=key_id):
+                            return zxnu_itchio.download_owned_upload(
+                                _g, _kk, dest, _u, _kid, log_cb=lambda ln: None)
+                        getit_run_in_thread(_dl_fn, _ok, _err)
+
+                    getit_run_in_thread(_list_fn, _list_ok, _err)
 
                 def _itchio_uninstall(_=False, _e=entry, _viewer=viewer):
                     """Delete this item's locally-downloaded copy — its install
@@ -19458,6 +19756,16 @@ class MainWindow(QMainWindow):
                     # purchases) in the background so the first Unite! search is
                     # instant rather than triggering the heavy fetch on demand.
                     self._itchio_prebuild_library()
+                    # Login succeeded — this is the moment to check itch.io for a
+                    # newer CSpect build (the check self-gates and runs once per
+                    # session; the startup timer is the no-tab fallback).
+                    _check_cspect = getattr(
+                        self, "_check_cspect_update_async", None)
+                    if _check_cspect is not None:
+                        try:
+                            _check_cspect()
+                        except Exception:
+                            pass
                 def _err(e):
                     _itchio_set_connecting(False)
                     _itchio_set_status(f"itch.io: {e}")
@@ -22100,6 +22408,29 @@ class MainWindow(QMainWindow):
             lambda _s: _settings_itchio_tab_changed())
         grid_tab_Settings.addWidget(self.settings_show_itchio_tab_checkbox, 33, 0, 1, 2)
 
+        # ── CSpect: check itch.io for a newer version at startup (default on) ──
+        def settings_cspect_update_check_changed():
+            on = self.settings_cspect_update_check_checkbox.isChecked()
+            configuration_dictionary[SETTING_CSPECT_UPDATE_CHECK] = (
+                "true" if on else "false")
+            save_configuration_file()
+
+        self.settings_cspect_update_check_checkbox = QCheckBox(
+            "Check for CSpect update on itch.io on startup")
+        _cspect_upd_pref = configuration_dictionary.get(
+            SETTING_CSPECT_UPDATE_CHECK, "").strip().lower()
+        self.settings_cspect_update_check_checkbox.setChecked(
+            _cspect_upd_pref not in ("false", "0", "no"))  # default on
+        self.settings_cspect_update_check_checkbox.setToolTip(
+            "When an itch.io API key is configured and CSpect was installed from\n"
+            "itch.io, check at startup whether a newer CSpect build is available\n"
+            "and, if so, offer to download and install it (into the downloads\n"
+            "folder). On by default. Saved to the configuration file.")
+        self.settings_cspect_update_check_checkbox.stateChanged.connect(
+            lambda _s: settings_cspect_update_check_changed())
+        grid_tab_Settings.addWidget(
+            self.settings_cspect_update_check_checkbox, 34, 0, 1, 2)
+
         # ── NextSync: what to do when a received file/dir already exists locally ──
         def _settings_nextsync_send_conflict_changed():
             val = self.settings_nextsync_send_conflict_combo.currentData() or DEFAULT_NEXTSYNC_SEND_CONFLICT
@@ -22171,7 +22502,7 @@ class MainWindow(QMainWindow):
         # width rather than stretching across both columns.
         self.button_open_config_file = QPushButton("Open config file", self)
         self.button_open_config_file.clicked.connect(open_cspect_configuration_file)
-        grid_tab_Settings.addWidget(self.button_open_config_file, 34, 0, 1, 2, Qt.AlignLeft)
+        grid_tab_Settings.addWidget(self.button_open_config_file, 35, 0, 1, 2, Qt.AlignLeft)
 
         grid_tab_Settings.setColumnStretch(2, 1)
         zxnextunite_Settings_tab.setLayout(grid_tab_Settings)
@@ -22814,6 +23145,17 @@ class MainWindow(QMainWindow):
         # emulator-detection toast appear first so the two don't collide.
         QTimer.singleShot(1800, self._check_mame_update_async)
 
+        # Likewise check itch.io for a newer CSpect build. This self-gates (needs
+        # the check enabled, an API key configured, and an existing itch.io CSpect
+        # install) and runs once per session. The itch.io tab's post-login
+        # callback triggers the same check the moment a connection succeeds; this
+        # timer is the fallback that also covers the case where the tab isn't
+        # present but a key is saved. The later delay keeps it clear of the MAME
+        # check and the emulator-detection toast.
+        _check_cspect = getattr(self, "_check_cspect_update_async", None)
+        if _check_cspect is not None:
+            QTimer.singleShot(2600, _check_cspect)
+
         # Expose the nested save function so closeEvent (a class method) can call it.
         self._save_configuration_file = save_configuration_file
 
@@ -22903,17 +23245,41 @@ class MainWindow(QMainWindow):
             except (TypeError, ValueError):
                 cspect_path = hdfmonkey_path = None
 
-            if cspect_path and not self._cspect_executable_path:
+            # Adopt a downloads/itchio CSpect when none is set yet, OR switch to a
+            # newer one when the build currently in use also came from downloads
+            # (find_emulators_in_downloads always returns the highest version, so
+            # a differing path means a newer build appeared — e.g. after a CSpect
+            # update). A PATH/app-dir CSpect (_cspect_from_downloads False) is left
+            # alone so the standalone setup keeps working.
+            _adopt_cspect = False
+            if cspect_path:
+                if not self._cspect_executable_path:
+                    _adopt_cspect = True
+                elif self._cspect_from_downloads and \
+                        os.path.abspath(cspect_path) != \
+                        os.path.abspath(self._cspect_executable_path):
+                    _adopt_cspect = True
+            if _adopt_cspect:
                 self._cspect_executable_path = cspect_path
                 self._cspect_from_downloads = True
                 # The CSpect group was hidden at construction because no emulator
                 # was found; reveal it now that a bundled copy exists.
                 self.cspect_group.setVisible(True)
-                add_main_log_window(f"Found CSpect under downloads/cspect: {cspect_path}")
+                add_main_log_window(f"Using CSpect under downloads/cspect: {cspect_path}")
+                # Bind hdfmonkey to the copy bundled with THIS (newest) CSpect
+                # build. Each itch.io CSpect ships its own hdfmonkey under
+                # <build>/hdfmonkey/<platform>/, so after an update the matching
+                # new hdfmonkey must replace the older build's lingering copy
+                # (the reported bug). Only override when this build actually ships
+                # one; otherwise keep whatever hdfmonkey was already found.
+                _bundled_hdf = find_hdfmonkey_near_cspect(cspect_path)
+                if _bundled_hdf and _bundled_hdf != self._hdfmonkey_executable_path:
+                    self._hdfmonkey_executable_path = None  # let the block below adopt it
+                    hdfmonkey_path = _bundled_hdf
 
             if hdfmonkey_path and not self._hdfmonkey_executable_path:
                 self._hdfmonkey_executable_path = hdfmonkey_path
-                add_main_log_window(f"Found hdfmonkey under downloads/cspect: {hdfmonkey_path}")
+                add_main_log_window(f"Using hdfmonkey bundled with CSpect: {hdfmonkey_path}")
                 # A bundled hdfmonkey makes the download/install wizard
                 # unnecessary; hide it and restore the image controls.
                 self.download_and_install_hdfmonkey_button.setVisible(False)
@@ -22941,8 +23307,14 @@ class MainWindow(QMainWindow):
             """Re-run CSpect / hdfmonkey detection on demand (used after an
             itch.io CSpect install) so a freshly downloaded emulator becomes
             usable without restarting the app. Reuses _on_emulator_scan_done to
-            apply results and show the detection toast."""
-            need_cspect = self._cspect_executable_path is None
+            apply results and show the detection toast.
+
+            When the CSpect in use already came from downloads/itchio we re-scan
+            even though one is set, so installing/updating to a newer build
+            switches to it (and to that build's bundled hdfmonkey) — a PATH/
+            app-dir CSpect is left untouched so standalone setups keep working."""
+            need_cspect = (self._cspect_executable_path is None
+                           or self._cspect_from_downloads)
             need_hdfmonkey = (self._hdfmonkey_executable_path is None
                               and not is_hdfmonkey_present(silent=True))
             # CSpect ships an hdfmonkey build alongside itself; prefer that cheap

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "8.6"
+ZX_NEXT_UNITE_VERSION = "8.7"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False
@@ -65,6 +65,11 @@ ZXART_PAGE_SIZE = 20
 ITCH_API_BASE = "https://api.itch.io"
 ITCH_USER_AGENT = f"ZX-Next-Unite/{ZX_NEXT_UNITE_VERSION}"
 ITCH_PAGE_SIZE = 30
+# Canonical itch.io page for CSpect (Mike Dailly's emulator). The startup
+# update check builds a minimal game dict from this URL to look up the account's
+# owned CSpect download key and the newest available build (see
+# zxnu_itchio.latest_cspect_upload / install_cspect_update).
+CSPECT_ITCH_URL = "https://mdf200.itch.io/cspect"
 # Safety bound on how many API pages the owned-games / collection / library
 # walks will follow. The walks stop naturally on the last (short) page; this is
 # only a runaway guard. Set high so large libraries (a user with 1000s of
@@ -172,6 +177,7 @@ SETTING_HELP_PYGAME_LOG        = "help_pygame_log"         # "true" => retro 8-b
 SETTING_ITCHIO_API_KEY         = "itchio_api_key"          # str: personal itch.io API key (https://itch.io/user/settings/api-keys)
 SETTING_SHOW_ITCHIO_TAB        = "show_itchio_tab"         # "false" => hide the itch.io tab (default shown when itch-dl is installed)
 SETTING_ITCHIO_VIEW_MODE       = "itchio_view_mode"        # "gallery" (default) or "table"
+SETTING_CSPECT_UPDATE_CHECK    = "cspect_update_check"     # "false" => skip the startup itch.io CSpect update check (default on)
 # Per-pane item-viewer mode: "true" => open items in the Retro (pygame) viewer
 # (renders .txt/instruction pages as a log console), else the Classic Qt viewer.
 SETTING_GETIT_ITEM_RETRO       = "getit_item_retro"
@@ -713,7 +719,7 @@ SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVO
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
 SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_SDCARD_PYGAME_LOG, SETTING_HELP_PYGAME_LOG,
-SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE,
+SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
 
 IMAGE_BUTTONS_SIZE = 190
@@ -1086,16 +1092,84 @@ def ensure_hdfmonkey_executable(hdfmonkey_path):
         return False
 
 
+def cspect_version_key(name):
+    """Natural-order sort key for a CSpect build name so versioned names compare
+    numerically rather than lexically (``CSpect3_1_4_0`` > ``CSpect3_1_3_0`` >
+    ``CSpect3_0_15_2``).
+
+    Any file extension (e.g. the ``.zip`` on an itch.io upload filename) is
+    stripped first, so the key computed for an installed build folder
+    (``CSpect3_1_4_0``) equals the one for its source archive
+    (``CSpect3_1_4_0.zip``) — otherwise the trailing ``.zip`` token would make an
+    identical version compare as *newer* and trigger a spurious update. Digit
+    runs compare as ints, other runs as lower-case text."""
+    stem = os.path.splitext(os.path.basename(name or ""))[0]
+    return [int(tok) if tok.isdigit() else tok.lower()
+            for tok in re.split(r"(\d+)", stem)]
+
+
+def cspect_version_newer(candidate_name, installed_name):
+    """True when the CSpect build *candidate_name* is a newer version than
+    *installed_name* (both compared with :func:`cspect_version_key`).
+
+    Heterogeneous names can leave an int token opposite a str token at the same
+    position, which raises ``TypeError`` on comparison; that falls back to a
+    plain case-insensitive string comparison of the stems so the check never
+    crashes the startup flow."""
+    ck = cspect_version_key(candidate_name)
+    ik = cspect_version_key(installed_name)
+    try:
+        return ck > ik
+    except TypeError:
+        a = os.path.splitext(os.path.basename(candidate_name or ""))[0].lower()
+        b = os.path.splitext(os.path.basename(installed_name or ""))[0].lower()
+        return a > b
+
+
+def find_installed_cspect_version(base_dir):
+    """Return ``(version_name, cspect_exe_path)`` for the newest CSpect build
+    installed under ``<base_dir>/downloads/itchio``, or ``(None, None)`` when no
+    itch.io CSpect install is present.
+
+    The version is taken from the executable's parent folder name (e.g.
+    ``CSpect3_1_4_0``), which is exactly how the itch.io archive extracts (see
+    ``zxnu_itchio.extract_zip``: ``files/CSpect3_1_4_0.zip`` →
+    ``files/CSpect3_1_4_0/CSpect.exe``). Used by the startup update check to know
+    which build to compare against the latest itch.io upload. The recursive walk
+    can be slow, so callers run it on a background thread."""
+    search_root = os.path.join(base_dir, DOWNLOADS_CSPECT_DIRNAME)
+    if not os.path.isdir(search_root):
+        return (None, None)
+    target = (CSPECT_EXECUTABLE_NAME + ".exe").lower()
+    best_name = None
+    best_path = None
+    for dirpath, _dirnames, filenames in os.walk(search_root):
+        for filename in filenames:
+            if filename.lower() != target:
+                continue
+            folder = os.path.basename(dirpath)
+            if best_name is None or cspect_version_newer(folder, best_name):
+                best_name = folder
+                best_path = os.path.join(dirpath, filename)
+    return (best_name, best_path)
+
+
 def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonkey=True):
     """Recursively search ``<base_dir>/downloads/itchio`` for a CSpect.exe and a
     bundled hdfmonkey executable built for the current platform.
 
     Returns ``(cspect_path, hdfmonkey_path)`` where each element is the full path
-    to the first matching executable found, or ``None`` if not found / not
-    searched for. This is the fallback used when neither tool is present in the
+    to the matching executable found, or ``None`` if not found / not searched
+    for. This is the fallback used when neither tool is present in the
     application directory or on PATH — itch.io CSpect installs land under
     ``downloads/itchio`` in a per-author/game/version sub-folder (and a manually
     downloaded build dropped anywhere under that tree is picked up too).
+
+    When several CSpect builds are installed side by side (e.g. an earlier
+    ``CSpect3_1_3_0`` left in place next to a freshly updated ``CSpect3_1_4_0``),
+    the *newest* one is returned — chosen by the version encoded in each
+    executable's parent folder name (see ``cspect_version_key``) — so the app
+    always launches the latest available build.
 
     The hdfmonkey search now covers Windows, Linux and macOS (Intel + Apple
     Silicon): the itch.io CSpect package ships an hdfmonkey build for each of
@@ -1124,13 +1198,22 @@ def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonk
                     for rank, (sp, _exe) in enumerate(hdf_candidates)]
 
     cspect_path = None
+    cspect_best_name = None  # parent-folder name of the best CSpect match so far
     hdfmonkey_path = None
     hdf_best_rank = None  # priority rank of the best hdfmonkey match so far
     for dirpath, _dirnames, filenames in os.walk(search_root):
         for filename in filenames:
             low = filename.lower()
-            if want_cspect and cspect_path is None and low == cspect_target:
-                cspect_path = os.path.join(dirpath, filename)
+            if want_cspect and low == cspect_target:
+                # Keep the newest build when multiple versions coexist: compare
+                # the version encoded in each exe's parent folder name so a
+                # freshly-updated CSpect3_1_4_0 wins over a lingering
+                # CSpect3_1_3_0, regardless of os.walk() visit order.
+                folder = os.path.basename(dirpath)
+                if cspect_best_name is None or \
+                   cspect_version_newer(folder, cspect_best_name):
+                    cspect_path = os.path.join(dirpath, filename)
+                    cspect_best_name = folder
                 continue
             # Keep looking for hdfmonkey until the top-priority (rank 0) build is
             # found, so a native build wins over a lower-priority fallback.
@@ -1143,10 +1226,24 @@ def find_emulators_in_downloads(base_dir, scan_for_cspect=True, scan_for_hdfmonk
                         hdfmonkey_path = full
                         hdf_best_rank = rank
                         break
-        cspect_done = (not want_cspect) or cspect_path is not None
+        # When scanning for CSpect we can't stop at the first hit — a newer build
+        # may sit in a later-visited folder — so only the hdfmonkey search can
+        # short-circuit the walk (and only when CSpect isn't wanted).
+        cspect_done = not want_cspect
         hdf_done = (not want_hdfmonkey) or hdf_best_rank == 0
         if cspect_done and hdf_done:
             break  # everything we were asked to find has been located
+
+    # Tie hdfmonkey to the *newest* CSpect we selected. Each itch.io CSpect build
+    # ships its own hdfmonkey under <build>/hdfmonkey/<platform>/, so the generic
+    # walk above can hand back an older lingering build's copy. When we have a
+    # winning CSpect, prefer the hdfmonkey bundled with it so updating CSpect also
+    # switches to that build's hdfmonkey. Fall back to the walk result only when
+    # the newest build ships none.
+    if want_hdfmonkey and cspect_path:
+        near = find_hdfmonkey_near_cspect(cspect_path)
+        if near:
+            hdfmonkey_path = near
     return (cspect_path, hdfmonkey_path)
 
 

--- a/zxnu_itchio.py
+++ b/zxnu_itchio.py
@@ -29,7 +29,8 @@ import urllib.parse
 import urllib.request
 import zipfile
 
-from zxnu_config import ITCH_API_BASE, ITCH_USER_AGENT, ITCH_PAGE_SIZE, ITCH_MAX_PAGES
+from zxnu_config import (ITCH_API_BASE, ITCH_USER_AGENT, ITCH_PAGE_SIZE,
+                         ITCH_MAX_PAGES, CSPECT_ITCH_URL, cspect_version_key)
 
 
 # ── optional-dependency detection ──────────────────────────────────────────
@@ -521,11 +522,21 @@ def _owned_key_for_game(game, api_key):
     return None, None
 
 
-def _stream_response_to_file(resp, dest_path, log_cb=None):
+def _stream_response_to_file(resp, dest_path, log_cb=None, progress_cb=None):
     """Stream an open HTTP response body to *dest_path* (via a .part temp file
-    that is renamed on completion). Returns the byte count."""
+    that is renamed on completion). Returns the byte count.
+
+    When *progress_cb* is given it is called as ``progress_cb(read, total)`` as
+    the download proceeds (``total`` is the ``Content-Length`` in bytes, or 0 if
+    the server didn't advertise one). Callbacks are throttled to roughly one per
+    512 KB so the UI log isn't flooded, plus a final 100% call on completion."""
     tmp = dest_path + ".part"
     total = 0
+    try:
+        content_length = int(resp.headers.get("Content-Length") or 0)
+    except (TypeError, ValueError):
+        content_length = 0
+    last_emit = 0
     with open(tmp, "wb") as fh:
         while True:
             chunk = resp.read(65536)
@@ -533,7 +544,18 @@ def _stream_response_to_file(resp, dest_path, log_cb=None):
                 break
             fh.write(chunk)
             total += len(chunk)
+            if progress_cb and (total - last_emit >= 524288):
+                last_emit = total
+                try:
+                    progress_cb(total, content_length)
+                except Exception:
+                    pass
     os.replace(tmp, dest_path)
+    if progress_cb:
+        try:
+            progress_cb(total, content_length or total)
+        except Exception:
+            pass
     if log_cb:
         try:
             log_cb(f"Downloaded {total} bytes → {os.path.basename(dest_path)}")
@@ -551,12 +573,15 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def _download_api_upload(upload_id, download_key_id, api_key, dest_path, log_cb=None):
+def _download_api_upload(upload_id, download_key_id, api_key, dest_path,
+                         log_cb=None, progress_cb=None):
     """Download one owned upload to *dest_path* via the itch.io API.
 
     ``/uploads/{id}/download`` 302-redirects to a signed CDN URL that rejects the
     ``Authorization`` header, so the redirect is resolved first (authenticated,
-    not auto-followed) and the CDN URL then fetched with a clean request."""
+    not auto-followed) and the CDN URL then fetched with a clean request.
+    *progress_cb* (see :func:`_stream_response_to_file`) is forwarded so callers
+    can report download progress."""
     api_url = (ITCH_API_BASE + f"/uploads/{upload_id}/download"
                f"?download_key_id={download_key_id}")
     req = urllib.request.Request(api_url, headers={
@@ -568,7 +593,7 @@ def _download_api_upload(upload_id, download_key_id, api_key, dest_path, log_cb=
     try:
         with opener.open(req, timeout=60) as resp:
             # No redirect: the API streamed the file itself.
-            _stream_response_to_file(resp, dest_path, log_cb)
+            _stream_response_to_file(resp, dest_path, log_cb, progress_cb)
             return
     except urllib.error.HTTPError as exc:
         if exc.code in (301, 302, 303, 307, 308):
@@ -579,19 +604,60 @@ def _download_api_upload(upload_id, download_key_id, api_key, dest_path, log_cb=
         raise RuntimeError("itch.io did not return a download URL.")
     req2 = urllib.request.Request(cdn_url, headers={"User-Agent": ITCH_USER_AGENT})
     with urllib.request.urlopen(req2, timeout=300) as resp2:
-        _stream_response_to_file(resp2, dest_path, log_cb)
+        _stream_response_to_file(resp2, dest_path, log_cb, progress_cb)
 
 
-def install_via_api(game, api_key, dest_dir, log_cb=None):
-    """Download an *owned* itch.io item straight from the itch.io API, bypassing
-    the Cloudflare-blocked game-page scrape that itch-dl relies on.
+def list_owned_uploads(game, api_key):
+    """List the downloadable files (uploads) for an *owned* itch.io item.
 
-    Returns ``(ok, message)`` when the item is owned (so the API path applies),
-    or ``None`` when it isn't among the user's owned keys — signalling the caller
-    to fall back to itch-dl. The newest upload (by version-sorted filename) is
-    saved under ``<dest>/<author>/<game>/files/`` so the existing post-install
-    extract step unpacks it into a build-numbered folder and the emulator scan
-    can discover it."""
+    itch.io can offer several uploads for one game — CSpect in particular ships
+    every build side by side (``CSpect3_1_4_0.zip``, ``CSpect3_1_3_0.zip``,
+    ``CSpect3_0_15_2.zip`` …) — so a caller that wants to let the user pick a
+    specific version needs the full list, not just the newest.
+
+    Returns ``(game_id, key_id, uploads)`` where *uploads* is a list of dicts
+    sorted **newest/highest-version first** so index 0 is the sensible default::
+
+        {"id", "filename", "size", "version_name", "version_key"}
+
+    or ``None`` when the item isn't among the user's owned keys / has no download
+    key / lists no uploads (the caller then falls back to itch-dl). Raises on a
+    network/API error. Runs synchronously — call from a worker thread."""
+    game_id, key_id = _owned_key_for_game(game, api_key)
+    if not game_id or not key_id:
+        return None  # not owned / no download key — let the caller fall back
+    data = _api_get(f"/games/{game_id}/uploads", api_key,
+                    params={"download_key_id": key_id})
+    raw = [u for u in ((data or {}).get("uploads") or []) if u.get("id")]
+    if not raw:
+        return None
+    # Newest build first (CSpect3_1_4_0 > CSpect3_1_3_0 > CSpect3_0_15_2).
+    raw.sort(key=lambda u: _version_sort_key(u.get("filename") or ""),
+             reverse=True)
+    uploads = []
+    for u in raw:
+        filename = u.get("filename") or f"upload-{u['id']}"
+        uploads.append({
+            "id": u["id"],
+            "filename": filename,
+            "size": u.get("size"),
+            "version_name": os.path.splitext(os.path.basename(filename))[0],
+            "version_key": cspect_version_key(filename),
+        })
+    return game_id, key_id, uploads
+
+
+def download_owned_upload(game, api_key, dest_dir, upload, key_id,
+                          log_cb=None, progress_cb=None):
+    """Download one specific *upload* dict (from :func:`list_owned_uploads`) of an
+    owned item straight from the itch.io API.
+
+    The file is saved under ``<dest>/<author>/<game>/files/`` so the existing
+    post-install extract step unpacks it into a build-numbered folder and the
+    emulator scan can discover it. Returns ``(True, message)``. *progress_cb*
+    (``progress_cb(read, total)``), when given, is forwarded to the byte stream
+    so callers can show download progress. Runs synchronously — call from a
+    worker thread."""
     def _log(line):
         if log_cb:
             try:
@@ -599,31 +665,136 @@ def install_via_api(game, api_key, dest_dir, log_cb=None):
             except Exception:
                 pass
 
-    game_id, key_id = _owned_key_for_game(game, api_key)
-    if not game_id or not key_id:
-        return None  # not owned / no download key — let the caller fall back
-
-    _log("Downloading via the itch.io API (bypassing the Cloudflare page block)…")
-    data = _api_get(f"/games/{game_id}/uploads", api_key,
-                    params={"download_key_id": key_id})
-    uploads = [u for u in ((data or {}).get("uploads") or []) if u.get("id")]
-    if not uploads:
-        return False, "itch.io returned no downloadable files for this item."
-
-    # Newest build first (CSpect3_1_4_0 > CSpect3_1_3_0 > CSpect3_0_15_2).
-    uploads.sort(key=lambda u: _version_sort_key(u.get("filename") or ""),
-                 reverse=True)
-    upload = uploads[0]
     filename = upload.get("filename") or f"upload-{upload['id']}"
-
     author, slug = _author_slug_from_url((game or {}).get("url"))
     files_dir = os.path.join(dest_dir, author, slug, "files")
     os.makedirs(files_dir, exist_ok=True)
     zip_path = os.path.join(files_dir, filename)
 
     _log(f"Fetching {filename} …")
-    _download_api_upload(upload["id"], key_id, api_key, zip_path, log_cb=log_cb)
+    _download_api_upload(upload["id"], key_id, api_key, zip_path,
+                         log_cb=log_cb, progress_cb=progress_cb)
     return True, f"Installed to {os.path.join(dest_dir, author, slug)}"
+
+
+def install_via_api(game, api_key, dest_dir, log_cb=None, progress_cb=None,
+                    upload=None, key_id=None):
+    """Download an *owned* itch.io item straight from the itch.io API, bypassing
+    the Cloudflare-blocked game-page scrape that itch-dl relies on.
+
+    Returns ``(ok, message)`` when the item is owned (so the API path applies),
+    or ``None`` when it isn't among the user's owned keys — signalling the caller
+    to fall back to itch-dl. By default the newest upload (by version-sorted
+    filename) is downloaded; pass *upload* (a dict from :func:`list_owned_uploads`
+    — and, ideally, its *key_id*) to download a specific version the user chose
+    instead. *progress_cb* (``progress_cb(read, total)``), when given, is
+    forwarded to the byte stream so callers can show download progress."""
+    def _log(line):
+        if log_cb:
+            try:
+                log_cb(line)
+            except Exception:
+                pass
+
+    # When the caller already picked an upload we still need a download key; only
+    # re-fetch the listing when we have to choose the newest ourselves.
+    if upload is None or not key_id:
+        listed = list_owned_uploads(game, api_key)
+        if listed is None:
+            # No listing available. If a specific upload was requested but the
+            # item isn't owned, surface that; otherwise let the caller fall back.
+            if upload is not None:
+                return False, "itch.io returned no download key for this item."
+            return None
+        _game_id, key_id, uploads = listed
+        if upload is None:
+            upload = uploads[0]  # newest/highest version
+
+    _log("Downloading via the itch.io API (bypassing the Cloudflare page block)…")
+    return download_owned_upload(game, api_key, dest_dir, upload, key_id,
+                                 log_cb=log_cb, progress_cb=progress_cb)
+
+
+# ── CSpect startup update check (itch.io) ──────────────────────────────────
+
+def latest_cspect_upload(api_key, game=None):
+    """Look up the newest CSpect build available to this itch.io account.
+
+    Builds a minimal game dict from :data:`CSPECT_ITCH_URL` (unless *game* is
+    supplied) and reuses :func:`list_owned_uploads` — CSpect exposes several
+    builds at once, so this walks the full version list and reports the newest
+    (index 0). Returns a dict describing the newest upload plus the whole list::
+
+        {"game", "game_id", "key_id", "uploads",
+         "filename", "version_name", "version_key"}
+
+    or ``None`` when the account doesn't own CSpect / has no download key / the
+    API lists no uploads (the caller then skips the update check quietly). Raises
+    on a network/API error so the caller can log the reason. Runs synchronously —
+    call from a worker thread."""
+    game = game or {"url": CSPECT_ITCH_URL, "title": "CSpect"}
+    listed = list_owned_uploads(game, api_key)
+    if listed is None:
+        return None  # not owned / no download key / no uploads
+    game_id, key_id, uploads = listed
+    newest = uploads[0]
+    return {
+        "game": game,
+        "game_id": game_id,
+        "key_id": key_id,
+        "uploads": uploads,
+        "filename": newest["filename"],
+        "version_name": newest["version_name"],
+        "version_key": newest["version_key"],
+    }
+
+
+def install_cspect_update(game, api_key, dest_dir, log_cb=None, progress_cb=None,
+                          upload=None, key_id=None):
+    """Download a specific owned CSpect build from itch.io and extract it.
+
+    Reuses :func:`install_via_api`, then extracts the downloaded archive into its
+    build-numbered folder (``files/CSpect3_1_4_0/``) so the emulator scan can
+    discover it. CSpect exposes several builds at once; by default the newest is
+    fetched, but the caller can pass the *upload* dict (and its *key_id*) that the
+    update check already identified so exactly that build is downloaded — no
+    second version lookup, and no risk of a mismatch with what the user was told.
+    Returns the full path to the extracted build folder. Raises ``RuntimeError``
+    with a human-readable reason on any failure so the caller can surface it in
+    the log. Runs synchronously — call from a worker thread."""
+    def _log(line):
+        if log_cb:
+            try:
+                log_cb(line)
+            except Exception:
+                pass
+
+    result = install_via_api(game, api_key, dest_dir,
+                             log_cb=log_cb, progress_cb=progress_cb,
+                             upload=upload, key_id=key_id)
+    if result is None:
+        raise RuntimeError(
+            "this itch.io account does not own CSpect (no download key was "
+            "found), so it can't be downloaded via the API.")
+    ok, msg = result
+    if not ok:
+        raise RuntimeError(msg)
+
+    install_dir = installed_path(game, dest_dir)
+    if not install_dir:
+        author, slug = _author_slug_from_url((game or {}).get("url"))
+        install_dir = os.path.join(dest_dir, author, slug)
+    # include_extracted=True: the archive we just downloaded is the newest one,
+    # and re-extracting an already-present folder is a harmless overwrite.
+    zips = find_extractable_zips(install_dir, include_extracted=True)
+    if not zips:
+        raise RuntimeError(
+            f"the CSpect archive was downloaded but could not be located under "
+            f"{install_dir} to extract.")
+    newest = zips[0]
+    _log(f"Extracting {os.path.basename(newest)} …")
+    extracted = extract_zip(newest)
+    return extracted
 
 
 def manual_install_zip(game, zip_path, dest_dir):


### PR DESCRIPTION
## Summary

Adds an itch.io-driven **CSpect update check** at startup and restores the **version picker** for CSpect installs, plus fixes hdfmonkey version tracking. Bumps the app version **8.6 → 8.7**.

## What''s new

### Startup CSpect update check (itch.io)
- When an itch.io API key is configured and the check is enabled, the app asks itch.io for the newest owned CSpect build, compares it to the installed one, and — if newer — prompts **Yes / Cancel** to download + install it. Waits for a successful itch.io login (triggered from the post-login callback, with a startup-timer fallback), self-gates, and never disrupts startup.
- Detailed **SD Card log** output for every phase: checking, newer/up-to-date result, user choice, throttled download progress, extraction, the full extracted path on success, and a specific failure reason (plus a dialog) on error.
- New Settings toggle **"Check for CSpect update on itch.io on startup"** (default on), mirroring the MAME update-check option.

### Version picker restored for itch.io CSpect installs
- itch.io can expose several CSpect builds; the API download path had been silently grabbing only the newest. The **"Choose version to install"** dialog is back — it lists the available versions and defaults to the highest. The updater is likewise multi-version aware.

### hdfmonkey now tracks the newest CSpect build
- hdfmonkey ships inside each CSpect build folder. After updating CSpect, detection could keep using the **old** build''s hdfmonkey. Detection now always selects the newest installed CSpect and binds hdfmonkey to that build''s bundled copy (covering both the auto-updater and the tab install). Standalone/PATH CSpect + hdfmonkey discovery is unchanged.

## Testing
- Verified end-to-end against the **live itch.io API**: auth, ownership, the full 3-version upload list, up-to-date detection (no false prompt), and downloading + extracting a chosen non-newest build.
- Synthetic multi-version trees confirm newest-CSpect and its bundled hdfmonkey are always selected regardless of walk order, with a safe fallback when a build ships no hdfmonkey.
- Offscreen (headless) app startup runs clean with no tracebacks across all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)