### PR TITLE
CSpect/MAME launch tweaks: ESC-key combos, default-params consistency, UI cleanup

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2545,10 +2545,11 @@ class MainWindow(QMainWindow):
         # entry, so default to 0 ("Mouse On" — no parameter passed) to avoid a
         # KeyError when the CSpect settings are restored below.
         configuration_dictionary[SETTING_MOUSE] = ""
-        # CSpect additional launch parameters (free-text, editable in Settings).
-        # Seeded empty so the key always exists — launch_cspect and the config
-        # writer both index it directly.
-        configuration_dictionary[SETTING_CUSTOM] = ""
+        # CSpect default launch parameters (free-text, editable in Settings).
+        # Seeded with the built-in default so a first-run cfg persists a value the
+        # user can tweak later; launch_cspect appends the SD Card group options on
+        # top (mirroring the MAME default-command-line handling).
+        configuration_dictionary[SETTING_CUSTOM] = CSPECT_DEFAULT_LAUNCH_PARAMETERS
         # Startup "is a newer MAME available?" check (default on; "false" to skip)
         # and the release tag of the MAME build installed via the app (used to
         # compare against the latest release without re-running the binary).
@@ -2844,6 +2845,7 @@ class MainWindow(QMainWindow):
             self.cspect_joystick.setDisabled(True)
             self.cspect_mouse.setDisabled(True)
             self.cspect_frequency.setDisabled(True)
+            self.cspect_esc.setDisabled(True)
 
         def set_all_buttons_enabled():
             self.imageinput.setDisabled(False)
@@ -2867,6 +2869,7 @@ class MainWindow(QMainWindow):
             self.cspect_joystick.setDisabled(False)
             self.cspect_mouse.setDisabled(False)
             self.cspect_frequency.setDisabled(False)
+            self.cspect_esc.setDisabled(False)
 
         def _update_mame_launch_button():
             """Enable the 'Launch Mame' button whenever MAME is available and a
@@ -3321,6 +3324,7 @@ class MainWindow(QMainWindow):
                 self.cspect_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_JOYSTICK]))
                 self.cspect_mouse.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MOUSE]))
                 self.cspect_frequency.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_HERTZ]))
+                self.cspect_esc.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_ESC]))
                 # MAME option combos (aspect / sound / mouse / joystick). Stored
                 # as combo indices; an absent value ("") maps to index 0 (the
                 # default, i.e. "Sound On" for audio).
@@ -3329,6 +3333,7 @@ class MainWindow(QMainWindow):
                     self.mame_sound.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_SOUND]))
                     self.mame_mouse.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_MOUSE]))
                     self.mame_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_JOYSTICK]))
+                    self.mame_esc.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_ESC]))
 
                 if configuration_dictionary[SETTING_DEFAULT_TAB_WHEN_OPENING]== "":
                     # First run (no previously saved tab): default to the
@@ -3488,10 +3493,19 @@ class MainWindow(QMainWindow):
                     self.settings_cspect_update_check_checkbox.setChecked(_cspect_upd_on)
                     self.settings_cspect_update_check_checkbox.blockSignals(False)
 
-                # CSpect additional launch parameters (editable text). Always
-                # present; empty means "no extra parameters".
+                # CSpect default launch parameters (editable text). Empty falls
+                # back to the built-in default, mirroring the MAME params handling.
                 if hasattr(self, "settings_cspect_params_edit"):
                     _cspect_params = configuration_dictionary.get(SETTING_CUSTOM, "")
+                    if not _cspect_params:
+                        _cspect_params = CSPECT_DEFAULT_LAUNCH_PARAMETERS
+                    # Migrate an older cfg that stored only *additional* params here
+                    # (the base "-basickeys -zxnext" used to be applied separately):
+                    # prepend the base so those users keep it now that this field
+                    # holds the full default command line.
+                    elif "-zxnext" not in _cspect_params:
+                        _cspect_params = (CSPECT_DEFAULT_LAUNCH_PARAMETERS
+                                          + " " + _cspect_params)
                     self.settings_cspect_params_edit.blockSignals(True)
                     self.settings_cspect_params_edit.setText(_cspect_params)
                     self.settings_cspect_params_edit.blockSignals(False)
@@ -3978,6 +3992,7 @@ class MainWindow(QMainWindow):
             configuration_dictionary[SETTING_JOYSTICK] = self.cspect_joystick.currentIndex()
             configuration_dictionary[SETTING_MOUSE] = self.cspect_mouse.currentIndex()
             configuration_dictionary[SETTING_HERTZ] = self.cspect_frequency.currentIndex()
+            configuration_dictionary[SETTING_ESC] = self.cspect_esc.currentIndex()
             # Persist the full history as a '|'-delimited string (each entry tidied).
             history_items = []
             for i in range(self.imageinput.count()):
@@ -4011,6 +4026,10 @@ class MainWindow(QMainWindow):
             configuration_dictionary[SETTING_HERTZ] = self.cspect_frequency.currentIndex()
             save_configuration_file()
 
+        def set_cspect_esc():
+            configuration_dictionary[SETTING_ESC] = self.cspect_esc.currentIndex()
+            save_configuration_file()
+
         # MAME per-launch option combos (aspect / sound / mouse / joystick).
         # Persisted as combo indices, mirroring the CSpect option setters above.
         def set_mame_aspect():
@@ -4029,6 +4048,10 @@ class MainWindow(QMainWindow):
             configuration_dictionary[SETTING_MAME_JOYSTICK] = self.mame_joystick.currentIndex()
             save_configuration_file()
 
+        def set_mame_esc():
+            configuration_dictionary[SETTING_MAME_ESC] = self.mame_esc.currentIndex()
+            save_configuration_file()
+
         def open_cspect_configuration_file():
             if platform.system() == "Windows":
                 execute_shell_command("notepad", ZX_NEXT_UNITE_CONFIG_FILE_NAME)
@@ -4040,7 +4063,15 @@ class MainWindow(QMainWindow):
             if right_disk_image_explorer_content:  # check that we have an image content first
                 set_all_buttons_disabled()
 
-                cspect_arguments = " " + CSPECT_BASE_ARGUMENTS + " "
+                # Editable "CSpect default launch parameters" from the Settings
+                # tab (persisted in SETTING_CUSTOM), falling back to the built-in
+                # default. The SD Card group options are appended on top below,
+                # mirroring how launch_mame handles its default command line.
+                cspect_default_params = configuration_dictionary.get(
+                    SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS)
+                if not cspect_default_params:
+                    cspect_default_params = CSPECT_DEFAULT_LAUNCH_PARAMETERS
+                cspect_arguments = " " + cspect_default_params + " "
                 cspect_screensize_text = self.cspect_screensize.currentText()
                 cspect_sound_text = self.cspect_sound.currentText()
                 cspect_vsync_text = self.cspect_vsync.currentText()
@@ -4054,12 +4085,9 @@ class MainWindow(QMainWindow):
                 cspect_arguments += get_tuple_value(CSPECT_JOYSTICK, cspect_joystick_text) + " "
                 cspect_arguments += get_tuple_value(CSPECT_MOUSE, cspect_mouse_text) + " "
                 cspect_arguments += get_tuple_value(CSPECT_FREQUENCY, cspect_frequency_text) + " "
-
-                if configuration_dictionary[SETTING_ESC] != "":
-                    cspect_arguments += " -esc "
-
-                if configuration_dictionary[SETTING_CUSTOM] != "":
-                    cspect_arguments += " " + configuration_dictionary[SETTING_CUSTOM] + " "
+                # ESC-key disable ("-esc"); "Disable ESC Key Off" (default) passes
+                # nothing so ESC still exits.
+                cspect_arguments += get_tuple_value(CSPECT_ESC, self.cspect_esc.currentText()) + " "
 
                 # When the CSpect copy in use is a bundled itch.io install under
                 # downloads/cspect, it must be launched from its own folder so its
@@ -4177,6 +4205,7 @@ class MainWindow(QMainWindow):
                 (getattr(self, "mame_sound", None), MAME_SOUND),
                 (getattr(self, "mame_mouse", None), MAME_MOUSE),
                 (getattr(self, "mame_joystick", None), MAME_JOYSTICK),
+                (getattr(self, "mame_esc", None), MAME_ESC),
             ):
                 if _mame_combo is None:
                     continue
@@ -4452,7 +4481,8 @@ class MainWindow(QMainWindow):
                 for _mame_combo in (getattr(self, "mame_aspect", None),
                                     getattr(self, "mame_sound", None),
                                     getattr(self, "mame_mouse", None),
-                                    getattr(self, "mame_joystick", None)):
+                                    getattr(self, "mame_joystick", None),
+                                    getattr(self, "mame_esc", None)):
                     if _mame_combo is not None:
                         _mame_combo.setVisible(True)
             except RuntimeError:
@@ -9876,9 +9906,18 @@ class MainWindow(QMainWindow):
         self.mame_joystick.currentIndexChanged.connect(set_mame_joystick)
         self.mame_group_layout.addWidget(self.mame_joystick)
 
+        self.mame_esc = QComboBox()
+        for _me in MAME_ESC:
+            self.mame_esc.addItem(_me[0])
+        self.mame_esc.setToolTip(
+            "Disable the ESC key from quitting MAME (-esc). 'Disable ESC Key Off'\n"
+            "(default) leaves ESC working; 'Disable ESC Key On' passes -esc.")
+        self.mame_esc.currentIndexChanged.connect(set_mame_esc)
+        self.mame_group_layout.addWidget(self.mame_esc)
+
         # Hide the option combos until MAME is actually installed (the group can
         # still be visible to host the "Install MAME" button).
-        for _mame_combo in (self.mame_aspect, self.mame_sound, self.mame_mouse, self.mame_joystick):
+        for _mame_combo in (self.mame_aspect, self.mame_sound, self.mame_mouse, self.mame_joystick, self.mame_esc):
             _mame_combo.setVisible(_mame_available)
 
         self.mame_group_layout.addStretch(1)
@@ -9965,6 +10004,20 @@ class MainWindow(QMainWindow):
         self.cspect_frequency.currentIndexChanged.connect(set_cspect_display_frequency)
 
         self.cspect_group_layout.addWidget(self.cspect_frequency)
+
+        # Populate ESC-key disable combo ("Disable ESC Key On" passes -esc)
+        self.cspect_esc = QComboBox()
+
+        for ec in CSPECT_ESC:
+             self.cspect_esc.addItem(ec[0])
+
+        self.cspect_esc.setToolTip(
+            "Disable the ESC key from quitting CSpect (-esc). 'Disable ESC Key Off'\n"
+            "(default) leaves ESC working; 'Disable ESC Key On' passes -esc.")
+        self.cspect_esc.show()
+        self.cspect_esc.currentIndexChanged.connect(set_cspect_esc)
+
+        self.cspect_group_layout.addWidget(self.cspect_esc)
 
         self.cspect_group_layout.addStretch(1)
 
@@ -22110,7 +22163,7 @@ class MainWindow(QMainWindow):
                 configuration_dictionary[SETTING_MAME_COMMAND_LINE_PARAMETERS] = self.settings_mame_params_edit.text()
                 save_configuration_file()
 
-            mame_params_lbl = QLabel("MAME launch parameters:")
+            mame_params_lbl = QLabel("MAME default launch parameters:")
             mame_params_lbl.setToolTip(
                 "Command-line parameters passed to MAME. The '{MAME_EXECUTABLE_NAME}'\n"
                 "placeholder resolves to the detected executable. The ROM/system above\n"
@@ -22152,27 +22205,31 @@ class MainWindow(QMainWindow):
                 lambda _s: settings_mame_update_check_changed())
             grid_tab_Settings.addWidget(self.settings_mame_update_check_checkbox, 27, 0, 1, 2)
 
-        # ── CSpect additional launch parameters ────────────────────────────
+        # ── CSpect default launch parameters ───────────────────────────────
         # Shown unconditionally (unlike the MAME block above, which is gated on
         # MAME being detected) so the box is available even when CSpect is only
-        # found later via the async downloads scan. Edits persist to SETTING_CUSTOM
-        # and are appended to the CSpect command line by launch_cspect.
+        # found later via the async downloads scan. Edits persist to SETTING_CUSTOM;
+        # launch_cspect uses this as the base command line and appends the SD Card
+        # group options (screen size, sound, VSync, joystick, mouse, frequency,
+        # ESC) on top — mirroring the MAME default-launch-parameters handling.
         def settings_cspect_params_changed():
             configuration_dictionary[SETTING_CUSTOM] = self.settings_cspect_params_edit.text()
             save_configuration_file()
 
-        cspect_params_lbl = QLabel("CSpect additional launch parameters:")
+        cspect_params_lbl = QLabel("CSpect default launch parameters:")
         cspect_params_lbl.setToolTip(
-            "Extra command-line parameters appended to the CSpect launch command,\n"
-            "on top of the options chosen on the SD Card Utility tab (screen size,\n"
-            "sound, VSync, joystick, mouse, frequency). Leave empty for none.\n"
-            "Saved to the configuration file."
+            "The base command-line parameters CSpect is launched with (default:\n"
+            f"'{CSPECT_DEFAULT_LAUNCH_PARAMETERS}'). Tweak them freely; the options\n"
+            "chosen in the CSpect group on the SD Card Utility tab (screen size,\n"
+            "sound, VSync, joystick, mouse, frequency, ESC) are appended on top at\n"
+            "launch. Leave empty to restore the built-in default. Saved to the\n"
+            "configuration file."
         )
         grid_tab_Settings.addWidget(cspect_params_lbl, 28, 0)
 
         self.settings_cspect_params_edit = QLineEdit()
         self.settings_cspect_params_edit.setText(
-            configuration_dictionary.get(SETTING_CUSTOM, ""))
+            configuration_dictionary.get(SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS))
         self.settings_cspect_params_edit.setToolTip(cspect_params_lbl.toolTip())
         self.settings_cspect_params_edit.editingFinished.connect(settings_cspect_params_changed)
         grid_tab_Settings.addWidget(self.settings_cspect_params_edit, 28, 1)
@@ -22195,7 +22252,7 @@ class MainWindow(QMainWindow):
                     pass
 
         self.settings_pygame_anim_checkbox = QCheckBox(
-            "Unite! — Space Invaders background animation (Retro/pygame mode)")
+            "Unite! — Invaders background animation (Retro/pygame mode)")
         self.settings_pygame_anim_checkbox.setChecked(True)
         self.settings_pygame_anim_checkbox.setToolTip(
             "When the Unite! tab is in Retro/pygame visualization mode, play an animated\n"
@@ -22204,7 +22261,7 @@ class MainWindow(QMainWindow):
         )
         self.settings_pygame_anim_checkbox.stateChanged.connect(
             lambda _s: _settings_pygame_anim_changed())
-        grid_tab_Settings.addWidget(self.settings_pygame_anim_checkbox, 29, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_pygame_anim_checkbox, 30, 0, 1, 2)
 
         # ── NextSync retro-log starfield animation toggle ──────────────────
         def _settings_nextsync_anim_changed():
@@ -22236,7 +22293,7 @@ class MainWindow(QMainWindow):
         )
         self.settings_nextsync_pygame_anim_checkbox.stateChanged.connect(
             lambda _s: _settings_nextsync_anim_changed())
-        grid_tab_Settings.addWidget(self.settings_nextsync_pygame_anim_checkbox, 32, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_nextsync_pygame_anim_checkbox, 33, 0, 1, 2)
 
         # ── Alien Floyd's: optional pygame-ce animated background everywhere ──
         # A Pink Floyd homage. When on, a pygame-ce "Alien Floyd's" animation
@@ -22291,7 +22348,7 @@ class MainWindow(QMainWindow):
             "file. Requires the optional 'pygame-ce' package.")
         self.settings_alien_floyd_bg_checkbox.stateChanged.connect(
             lambda _s: _settings_alien_bg_changed())
-        grid_tab_Settings.addWidget(self.settings_alien_floyd_bg_checkbox, 30, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_alien_floyd_bg_checkbox, 31, 0, 1, 2)
 
         # ── Alien Floyd's: optional dedicated full-window tab ────────────────
         self._alien_floyd_tab_widget = None
@@ -22363,7 +22420,7 @@ class MainWindow(QMainWindow):
             "configuration file. Requires the optional 'pygame-ce' package.")
         self.settings_alien_floyd_tab_checkbox.stateChanged.connect(
             lambda _s: _settings_alien_tab_changed())
-        grid_tab_Settings.addWidget(self.settings_alien_floyd_tab_checkbox, 31, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_alien_floyd_tab_checkbox, 32, 0, 1, 2)
 
         # ── itch.io: optional online tab (driven by the 'itch-dl' package) ───
         def _itchio_tab_set_visible(on):
@@ -22406,7 +22463,7 @@ class MainWindow(QMainWindow):
                 "configuration file. Requires the optional 'itch-dl' package.")
         self.settings_show_itchio_tab_checkbox.stateChanged.connect(
             lambda _s: _settings_itchio_tab_changed())
-        grid_tab_Settings.addWidget(self.settings_show_itchio_tab_checkbox, 33, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_show_itchio_tab_checkbox, 34, 0, 1, 2)
 
         # ── CSpect: check itch.io for a newer version at startup (default on) ──
         def settings_cspect_update_check_changed():
@@ -22429,7 +22486,7 @@ class MainWindow(QMainWindow):
         self.settings_cspect_update_check_checkbox.stateChanged.connect(
             lambda _s: settings_cspect_update_check_changed())
         grid_tab_Settings.addWidget(
-            self.settings_cspect_update_check_checkbox, 34, 0, 1, 2)
+            self.settings_cspect_update_check_checkbox, 29, 0, 1, 2)
 
         # ── NextSync: what to do when a received file/dir already exists locally ──
         def _settings_nextsync_send_conflict_changed():

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -119,7 +119,7 @@ SETTING_JOYSTICK = "joy"
 SETTING_MOUSE = "mouse"
 SETTING_CSPECT = "cspect"
 SETTING_CUSTOM = "custom"
-SETTING_ESC = "esc"
+SETTING_ESC = "esc"                                                # combo index into CSPECT_ESC (ESC-exit disable on/off; default 0 = off, no -esc)
 SETTING_MAME_COMMAND_LINE_PARAMETERS = "mame_command_line_parameters"
 SETTING_MAME_ROM_CHOICE              = "mame_rom_choice"            # MAME system/ROM, e.g. "tbblue" (default)
 SETTING_MAME_UPDATE_CHECK            = "mame_update_check"          # "false" => skip the startup MAME update check (default on)
@@ -128,6 +128,7 @@ SETTING_MAME_ASPECT                  = "mame_aspect"               # combo index
 SETTING_MAME_SOUND                   = "mame_sound"                # combo index into MAME_SOUND (audio on/off)
 SETTING_MAME_MOUSE                   = "mame_mouse"                # combo index into MAME_MOUSE (mouse capture on/off)
 SETTING_MAME_JOYSTICK                = "mame_joystick"             # combo index into MAME_JOYSTICK (joystick input on/off)
+SETTING_MAME_ESC                     = "mame_esc"                  # combo index into MAME_ESC (ESC-exit disable on/off; default 0 = off, no -esc)
 SETTING_DISABLE_NO_EMULATOR_TOAST  = "disable_no_emulator_toast"   # bool (default False)
 SETTING_NEXTSYNC_EXPLORERPATH = "nextsync_explorerpath"
 SETTING_NEXTSYNC_SYNCONCE = "nextsync_synconce"
@@ -717,7 +718,7 @@ SETTING_COLOR_FILE_EXT, SETTING_COLOR_FILE_SIZE, SETTING_COLOR_GENERAL_TEXT, SET
 SETTING_GALLERY_ROWS_PER_PAGE, SETTING_GALLERY_COLS, SETTING_GALLERY_IMG_SIZE, SETTING_GALLERY_SLIDESHOW_SECS, SETTING_GETIT_VIEW_MODE, SETTING_ZXDB_VIEW_MODE,
 SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVORITES_VIEW_MODE,
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
-SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
+SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_MAME_ESC, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_SDCARD_PYGAME_LOG, SETTING_HELP_PYGAME_LOG,
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
@@ -733,7 +734,15 @@ CSPECT_JOYSTICK = (("Joystick On", "-joystick"),("Joystick Off", ""))
 # "Mouse On" (default) passes nothing and "Mouse Off" passes "-mouse".
 CSPECT_MOUSE = (("Mouse On", ""),("Mouse Off", "-mouse"))
 CSPECT_FREQUENCY = (("50Hz", ""),("60Hz", "-60"))
-CSPECT_BASE_ARGUMENTS = "-basickeys -zxnext -nextrom"
+# CSpect "-esc" *disables* the ESC key from quitting the emulator. By default it
+# is not passed, so ESC still exits: "Disable ESC Key Off" (index 0, default)
+# passes nothing; "Disable ESC Key On" passes "-esc".
+CSPECT_ESC = (("Disable ESC Key Off", ""),("Disable ESC Key On", "-esc"))
+# Default CSpect command-line parameters, editable in the Settings tab ("CSpect
+# default launch parameters") and persisted to hdfg.cfg (SETTING_CUSTOM). Mirrors
+# MAME_DEFAULT_COMMAND_LINE: the SD Card Utility group options (screen size,
+# sound, VSync, joystick, mouse, frequency, ESC) are appended on top at launch.
+CSPECT_DEFAULT_LAUNCH_PARAMETERS = "-basickeys -zxnext"
 
 FONT_GREEN = QColor(0, 255, 0)
 FONT_BLUE = QColor(0, 0, 255)
@@ -770,12 +779,16 @@ MAME_SOUND = (
 )
 MAME_MOUSE = (("Mouse Off", "-mouse_device none"), ("Mouse On", "-mouse"))
 MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovider none"))
+# "-esc" disables the ESC key from quitting the emulator. Not passed by default,
+# so ESC still exits: "Disable ESC Key Off" (index 0, default) passes nothing;
+# "Disable ESC Key On" passes "-esc".
+MAME_ESC = (("Disable ESC Key Off", ""), ("Disable ESC Key On", "-esc"))
 
 # Options now driven by the MAME group combos above. They are stripped from any
 # user-edited command-line params at launch so the combo selections are the
 # single source of truth (never duplicated or in conflict). Flag options take no
 # value; value options consume the following token.
-MAME_COMBO_FLAG_OPTIONS = frozenset({"-mouse", "-nomouse", "-joystick", "-nojoystick"})
+MAME_COMBO_FLAG_OPTIONS = frozenset({"-mouse", "-nomouse", "-joystick", "-nojoystick", "-esc"})
 MAME_COMBO_VALUE_OPTIONS = frozenset({"-aspect", "-sound", "-mouse_device", "-joystickprovider"})
 
 def strip_mame_combo_options(tokens):


### PR DESCRIPTION
## Summary

A set of emulator launch-option and Settings-tab refinements for CSpect and MAME.

## Changes

### CSpect launch defaults
- **Removed** the default `-nextrom` startup parameter (no longer needed).
- Renamed the Settings field **"CSpect additional launch parameters" → "CSpect default launch parameters"**. It now holds the full, editable base command line (default `-basickeys -zxnext`), and the SD Card Utility group options are appended on top at launch — consistent with how MAME works. Empty falls back to the built-in default; older cfg values that stored only *additional* params are migrated by prepending the base so nothing is lost. Persisted to `hdfg.cfg`.

### ESC-key disable option (both emulators)
- Added an **ESC-key disable combo** to both the MAME and CSpect groups on the SD Card Utility tab. Selecting "Disable ESC Key On" passes `-esc`; the default is **off**, so ESC still exits. Persisted per emulator (`SETTING_ESC` / `SETTING_MAME_ESC`), and `-esc` is stripped from the editable MAME params so the combo stays the single source of truth.

### Settings-tab wording & order
- Renamed **"MAME launch parameters" → "MAME default launch parameters"**.
- Moved **"Check for CSpect update on itch.io on startup"** up to sit directly above the Unite! background-animation toggle.
- Renamed that toggle from **"Space Invaders background animation" → "Invaders background animation"**.

## Testing
- Offscreen (headless) app startup runs clean with no tracebacks across all changes.
- Verified config round-trips the new/renamed settings: ESC combos persist as `esc` / `mame_esc` (default index 0 = off), and the CSpect default-params field migrates an empty `custom=` to `custom=-basickeys -zxnext`, preserving all other settings.
- Confirmed `-esc` is stripped from user-supplied MAME params so the combo is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)