### PR TITLE
v8.7.1: MAME -confirm_quit ESC handling, CSpect ESC default on, launch hint

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2822,6 +2822,25 @@ class MainWindow(QMainWindow):
             self.nextsync_cancel_server.setVisible(False)
 
 
+        def _update_cspect_launch_tooltip():
+            """Hint on the greyed-out 'Launch CSpect' button that a disk image
+            must be loaded first, and clear it once one is. The button is only
+            enabled after a successful hdfmonkey listing populates
+            right_disk_image_explorer_content, so key the tooltip off that same
+            state — that keeps the hint absent during transfers (an image is
+            already loaded; the button is only transiently disabled). Qt still
+            delivers tooltip help events to disabled widgets, so the hint shows
+            while the button is greyed out."""
+            try:
+                if right_disk_image_explorer_content:
+                    self.button_start_cspect.setToolTip("")
+                else:
+                    self.button_start_cspect.setToolTip(
+                        "Load a ZX Spectrum Next disk image first — then CSpect "
+                        "can boot it from the mounted SD card.")
+            except (RuntimeError, AttributeError):
+                pass
+
         def set_all_buttons_disabled():
 
             self.imageinput.setDisabled(True)
@@ -2846,6 +2865,7 @@ class MainWindow(QMainWindow):
             self.cspect_mouse.setDisabled(True)
             self.cspect_frequency.setDisabled(True)
             self.cspect_esc.setDisabled(True)
+            _update_cspect_launch_tooltip()
 
         def set_all_buttons_enabled():
             self.imageinput.setDisabled(False)
@@ -2870,6 +2890,7 @@ class MainWindow(QMainWindow):
             self.cspect_mouse.setDisabled(False)
             self.cspect_frequency.setDisabled(False)
             self.cspect_esc.setDisabled(False)
+            _update_cspect_launch_tooltip()
 
         def _update_mame_launch_button():
             """Enable the 'Launch Mame' button whenever MAME is available and a
@@ -3460,12 +3481,13 @@ class MainWindow(QMainWindow):
                         SETTING_MAME_COMMAND_LINE_PARAMETERS, "")
                     if not _params:
                         _params = MAME_DEFAULT_COMMAND_LINE
-                    # Migrate the legacy default that hard-coded "-aspect 2:1" to
-                    # the new default now that aspect is a combo box, so the
+                    # Migrate a legacy default (the one that hard-coded
+                    # "-aspect 2:1", or the one that hard-coded "-confirm_quit")
+                    # to the new default now that both are combo boxes, so the
                     # editable command-line box no longer shows a stale, now
                     # combo-controlled option. (Launch-time stripping still handles
                     # any other custom occurrences — see launch_mame.)
-                    elif _params.strip() == MAME_DEFAULT_COMMAND_LINE_LEGACY:
+                    elif _params.strip() in MAME_DEFAULT_COMMAND_LINE_LEGACY_ALL:
                         _params = MAME_DEFAULT_COMMAND_LINE
                     self.settings_mame_params_edit.blockSignals(True)
                     self.settings_mame_params_edit.setText(_params)
@@ -9144,6 +9166,12 @@ class MainWindow(QMainWindow):
         for c in CONFIG_FILE_SETTINGS:
             configuration_dictionary[c] = ""
 
+        # CSpect ESC-key disable defaults to On ("-esc"): seed index 1 after the
+        # reset above so a cfg that predates this option (no "esc=" line) still
+        # restores as On. A cfg that carries an explicit "esc=" value overrides
+        # this when read in load_configuration_file.
+        configuration_dictionary[SETTING_ESC] = "1"
+
         def _persist_retro(key, checked):
             """Persist a pane's Classic/Retro item-viewer choice to the config
             file. Skips the file write while restoring saved settings (the value
@@ -9910,8 +9938,9 @@ class MainWindow(QMainWindow):
         for _me in MAME_ESC:
             self.mame_esc.addItem(_me[0])
         self.mame_esc.setToolTip(
-            "Disable the ESC key from quitting MAME (-esc). 'Disable ESC Key Off'\n"
-            "(default) leaves ESC working; 'Disable ESC Key On' passes -esc.")
+            "Stop the ESC key from instantly quitting MAME by requiring a quit\n"
+            "confirmation (-confirm_quit). 'Disable ESC Key Off' (default) leaves\n"
+            "ESC quitting immediately; 'Disable ESC Key On' passes -confirm_quit.")
         self.mame_esc.currentIndexChanged.connect(set_mame_esc)
         self.mame_group_layout.addWidget(self.mame_esc)
 
@@ -10011,9 +10040,16 @@ class MainWindow(QMainWindow):
         for ec in CSPECT_ESC:
              self.cspect_esc.addItem(ec[0])
 
+        # Default to "Disable ESC Key On" (index 1) so a fresh install (no cfg
+        # file, where load_configuration_file never reaches the restore below)
+        # ships with ESC-to-quit disabled. Set before the currentIndexChanged
+        # connection below so no save is triggered; a saved cfg value still wins.
+        self.cspect_esc.setCurrentIndex(1)
+
         self.cspect_esc.setToolTip(
-            "Disable the ESC key from quitting CSpect (-esc). 'Disable ESC Key Off'\n"
-            "(default) leaves ESC working; 'Disable ESC Key On' passes -esc.")
+            "Disable the ESC key from quitting CSpect (-esc). 'Disable ESC Key On'\n"
+            "(default) passes -esc so ESC won't quit; 'Disable ESC Key Off' leaves\n"
+            "ESC working.")
         self.cspect_esc.show()
         self.cspect_esc.currentIndexChanged.connect(set_cspect_esc)
 

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "8.7"
+ZX_NEXT_UNITE_VERSION = "8.7.1"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False
@@ -119,7 +119,7 @@ SETTING_JOYSTICK = "joy"
 SETTING_MOUSE = "mouse"
 SETTING_CSPECT = "cspect"
 SETTING_CUSTOM = "custom"
-SETTING_ESC = "esc"                                                # combo index into CSPECT_ESC (ESC-exit disable on/off; default 0 = off, no -esc)
+SETTING_ESC = "esc"                                                # combo index into CSPECT_ESC (ESC-exit disable on/off; default 1 = on, passes -esc)
 SETTING_MAME_COMMAND_LINE_PARAMETERS = "mame_command_line_parameters"
 SETTING_MAME_ROM_CHOICE              = "mame_rom_choice"            # MAME system/ROM, e.g. "tbblue" (default)
 SETTING_MAME_UPDATE_CHECK            = "mame_update_check"          # "false" => skip the startup MAME update check (default on)
@@ -128,7 +128,7 @@ SETTING_MAME_ASPECT                  = "mame_aspect"               # combo index
 SETTING_MAME_SOUND                   = "mame_sound"                # combo index into MAME_SOUND (audio on/off)
 SETTING_MAME_MOUSE                   = "mame_mouse"                # combo index into MAME_MOUSE (mouse capture on/off)
 SETTING_MAME_JOYSTICK                = "mame_joystick"             # combo index into MAME_JOYSTICK (joystick input on/off)
-SETTING_MAME_ESC                     = "mame_esc"                  # combo index into MAME_ESC (ESC-exit disable on/off; default 0 = off, no -esc)
+SETTING_MAME_ESC                     = "mame_esc"                  # combo index into MAME_ESC (ESC-exit disable on/off; default 0 = off, no -confirm_quit)
 SETTING_DISABLE_NO_EMULATOR_TOAST  = "disable_no_emulator_toast"   # bool (default False)
 SETTING_NEXTSYNC_EXPLORERPATH = "nextsync_explorerpath"
 SETTING_NEXTSYNC_SYNCONCE = "nextsync_synconce"
@@ -734,9 +734,10 @@ CSPECT_JOYSTICK = (("Joystick On", "-joystick"),("Joystick Off", ""))
 # "Mouse On" (default) passes nothing and "Mouse Off" passes "-mouse".
 CSPECT_MOUSE = (("Mouse On", ""),("Mouse Off", "-mouse"))
 CSPECT_FREQUENCY = (("50Hz", ""),("60Hz", "-60"))
-# CSpect "-esc" *disables* the ESC key from quitting the emulator. By default it
-# is not passed, so ESC still exits: "Disable ESC Key Off" (index 0, default)
-# passes nothing; "Disable ESC Key On" passes "-esc".
+# CSpect "-esc" *disables* the ESC key from quitting the emulator. On by default
+# (index 1) so ESC does not accidentally quit CSpect: "Disable ESC Key On"
+# (default) passes "-esc"; "Disable ESC Key Off" (index 0) passes nothing so ESC
+# still exits.
 CSPECT_ESC = (("Disable ESC Key Off", ""),("Disable ESC Key On", "-esc"))
 # Default CSpect command-line parameters, editable in the Settings tab ("CSpect
 # default launch parameters") and persisted to hdfg.cfg (SETTING_CUSTOM). Mirrors
@@ -779,16 +780,18 @@ MAME_SOUND = (
 )
 MAME_MOUSE = (("Mouse Off", "-mouse_device none"), ("Mouse On", "-mouse"))
 MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovider none"))
-# "-esc" disables the ESC key from quitting the emulator. Not passed by default,
-# so ESC still exits: "Disable ESC Key Off" (index 0, default) passes nothing;
-# "Disable ESC Key On" passes "-esc".
-MAME_ESC = (("Disable ESC Key Off", ""), ("Disable ESC Key On", "-esc"))
+# MAME has no "-esc" option. "-confirm_quit" makes MAME prompt for confirmation
+# before quitting, so pressing ESC no longer instantly exits — effectively
+# disabling the ESC-to-quit behaviour. Not passed by default, so ESC still exits:
+# "Disable ESC Key Off" (index 0, default) passes nothing; "Disable ESC Key On"
+# passes "-confirm_quit".
+MAME_ESC = (("Disable ESC Key Off", ""), ("Disable ESC Key On", "-confirm_quit"))
 
 # Options now driven by the MAME group combos above. They are stripped from any
 # user-edited command-line params at launch so the combo selections are the
 # single source of truth (never duplicated or in conflict). Flag options take no
 # value; value options consume the following token.
-MAME_COMBO_FLAG_OPTIONS = frozenset({"-mouse", "-nomouse", "-joystick", "-nojoystick", "-esc"})
+MAME_COMBO_FLAG_OPTIONS = frozenset({"-mouse", "-nomouse", "-joystick", "-nojoystick", "-confirm_quit", "-noconfirm_quit"})
 MAME_COMBO_VALUE_OPTIONS = frozenset({"-aspect", "-sound", "-mouse_device", "-joystickprovider"})
 
 def strip_mame_combo_options(tokens):
@@ -814,11 +817,20 @@ def strip_mame_combo_options(tokens):
 # default: the ROM is chosen by the user (SETTING_MAME_ROM_CHOICE), the combo
 # options are appended at launch, and "-hard1 <image>" is appended dynamically
 # so the image is always the last argument passed to MAME.
-MAME_DEFAULT_COMMAND_LINE = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -video bgfx -bgfx_screen_chains unfiltered -window -skip_gameinfo -confirm_quit"
-# Previous default that hard-coded "-aspect 2:1"; a saved cfg still carrying this
-# exact string is migrated to MAME_DEFAULT_COMMAND_LINE on load so the Settings
-# command-line box no longer duplicates the now combo-controlled aspect option.
+MAME_DEFAULT_COMMAND_LINE = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -video bgfx -bgfx_screen_chains unfiltered -window -skip_gameinfo"
+# Previous defaults a saved cfg may still carry verbatim; each is migrated to
+# MAME_DEFAULT_COMMAND_LINE on load so the Settings command-line box no longer
+# shows now combo-controlled options — the hard-coded "-aspect 2:1" (aspect is a
+# combo) and "-confirm_quit" (the ESC-confirm combo owns it). Launch-time
+# stripping still handles any other custom occurrences (see launch_mame).
 MAME_DEFAULT_COMMAND_LINE_LEGACY = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -aspect 2:1 -video bgfx  -bgfx_screen_chains unfiltered -window -skip_gameinfo -confirm_quit"
+# The prior default that hard-coded "-confirm_quit" before it became combo-driven.
+MAME_DEFAULT_COMMAND_LINE_LEGACY_CONFIRM_QUIT = "{MAME_EXECUTABLE_NAME} -ui_active -nounevenstretch -video bgfx -bgfx_screen_chains unfiltered -window -skip_gameinfo -confirm_quit"
+# Every legacy default that should migrate to MAME_DEFAULT_COMMAND_LINE on load.
+MAME_DEFAULT_COMMAND_LINE_LEGACY_ALL = (
+    MAME_DEFAULT_COMMAND_LINE_LEGACY,
+    MAME_DEFAULT_COMMAND_LINE_LEGACY_CONFIRM_QUIT,
+)
 # Appended right before the image path at launch time.
 MAME_HARD_DISK_PARAMETER = "-hard1"
 # Setup guide for the ZX Spectrum Next MAME support. Notably it documents the


### PR DESCRIPTION
@
## Summary
Version bump **8.7 → 8.7.1** with three fixes:

### MAME — `-confirm_quit` instead of `-esc`
MAME has no `-esc` option. The "Disable ESC Key" combo now passes **`-confirm_quit`** (prompts for confirmation before quitting, so pressing ESC no longer instantly exits). Removed the hard-coded `-confirm_quit` from the default launch parameters — it is now owned by the combo (off by default). `-confirm_quit`/`-noconfirm_quit` are stripped from user-edited params so the combo stays authoritative, and saved cfgs still carrying the old default are migrated.

### CSpect — ESC-disable On by default
The CSpect "Disable ESC Key" combo now defaults to **On (`-esc`)** for fresh installs and for cfgs that predate the option (no `esc=` line). An explicit saved value still wins.

### CSpect — "load an image first" hint
The **Launch CSpect** button is greyed out until a disk image is loaded (it boots the mounted SD image). It now shows a tooltip explaining a disk image must be loaded first; the tooltip is cleared once an image loads successfully. Keyed off the real "image loaded" state so it does not appear during transfers.

## Testing
- Both modules byte-compile.
- Verified load-flow ordering so the tooltip is accurate on success and failure paths.
- CSpect launch-hint behavior manually confirmed (button hint appears with no image, disappears after loading one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@