### PR TITLE
v8.7.2: MAME ESC-disable default on + MAME group greys out until an image is loaded

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2841,6 +2841,25 @@ class MainWindow(QMainWindow):
             except (RuntimeError, AttributeError):
                 pass
 
+        def _update_mame_launch_tooltip():
+            """Mirror _update_cspect_launch_tooltip for the MAME group: hint on
+            the greyed-out 'Launch Mame' button that a disk image must be
+            selected first, cleared once one is. Keyed off a valid image *file*
+            being selected (not the hdfmonkey listing) — MAME boots the image
+            directly without hdfmonkey, so that is exactly when it is launchable.
+            Qt still delivers tooltip help events to disabled widgets, so the
+            hint shows while the button is greyed out."""
+            try:
+                img = (self.imageinput.currentText() or "").strip().strip('"')
+                if img and os.path.isfile(img):
+                    self.button_start_mame.setToolTip("")
+                else:
+                    self.button_start_mame.setToolTip(
+                        "Select a ZX Spectrum Next disk image (.img/.hdf) first "
+                        "— then MAME can boot it as the Next's hard disk.")
+            except (RuntimeError, AttributeError):
+                pass
+
         def set_all_buttons_disabled():
 
             self.imageinput.setDisabled(True)
@@ -2865,7 +2884,15 @@ class MainWindow(QMainWindow):
             self.cspect_mouse.setDisabled(True)
             self.cspect_frequency.setDisabled(True)
             self.cspect_esc.setDisabled(True)
+            for _mame_combo in (getattr(self, "mame_aspect", None),
+                                getattr(self, "mame_sound", None),
+                                getattr(self, "mame_mouse", None),
+                                getattr(self, "mame_joystick", None),
+                                getattr(self, "mame_esc", None)):
+                if _mame_combo is not None:
+                    _mame_combo.setDisabled(True)
             _update_cspect_launch_tooltip()
+            _update_mame_launch_tooltip()
 
         def set_all_buttons_enabled():
             self.imageinput.setDisabled(False)
@@ -2890,37 +2917,57 @@ class MainWindow(QMainWindow):
             self.cspect_mouse.setDisabled(False)
             self.cspect_frequency.setDisabled(False)
             self.cspect_esc.setDisabled(False)
+            for _mame_combo in (getattr(self, "mame_aspect", None),
+                                getattr(self, "mame_sound", None),
+                                getattr(self, "mame_mouse", None),
+                                getattr(self, "mame_joystick", None),
+                                getattr(self, "mame_esc", None)):
+                if _mame_combo is not None:
+                    _mame_combo.setDisabled(False)
             _update_cspect_launch_tooltip()
+            _update_mame_launch_tooltip()
 
-        def _update_mame_launch_button():
-            """Enable the 'Launch Mame' button whenever MAME is available and a
-            real disk-image file is selected — independent of hdfmonkey.
+        def _update_mame_controls():
+            """Enable the 'Launch Mame' button *and* the MAME option combos
+            together whenever MAME is available and a real disk-image file is
+            selected — independent of hdfmonkey.
 
             Launching MAME boots the Next with the selected HDF as its hard disk
             and never calls hdfmonkey (the SD-card file-explorer tool). So a
-            missing hdfmonkey must not keep the button disabled: without this,
-            set_all_buttons_enabled() (which re-enables the launch button) only
-            ever runs after a successful image *listing*, which needs hdfmonkey —
-            so with hdfmonkey absent the MAME button stayed disabled even though
-            MAME was installed and ready. The button is still hidden outright when
-            MAME isn't installed (setVisible(_mame_available)), and still disabled
-            during transfers/loads via set_all_buttons_disabled()."""
+            missing hdfmonkey must not keep the group disabled: without this,
+            set_all_buttons_enabled() (which re-enables the group) only ever runs
+            after a successful image *listing*, which needs hdfmonkey — so with
+            hdfmonkey absent the MAME group stayed disabled even though MAME was
+            installed and ready. Mirrors the CSpect group: with no image ready
+            the whole MAME group is greyed out and the launch button shows a
+            'select an image first' hint (see _update_mame_launch_tooltip). The
+            controls are still hidden outright when MAME isn't installed
+            (setVisible(_mame_available)) and still hard-disabled during
+            transfers/loads via set_all_buttons_disabled()."""
             try:
                 available = getattr(self, "_mame_executable_path", None) is not None
                 img = (self.imageinput.currentText() or "").strip().strip('"')
-                self.button_start_mame.setEnabled(
-                    available and bool(img) and os.path.isfile(img))
+                ready = available and bool(img) and os.path.isfile(img)
+                self.button_start_mame.setEnabled(ready)
+                for _mame_combo in (getattr(self, "mame_aspect", None),
+                                    getattr(self, "mame_sound", None),
+                                    getattr(self, "mame_mouse", None),
+                                    getattr(self, "mame_joystick", None),
+                                    getattr(self, "mame_esc", None)):
+                    if _mame_combo is not None:
+                        _mame_combo.setEnabled(ready)
+                _update_mame_launch_tooltip()
             except (RuntimeError, AttributeError):
                 pass
 
         def enable_image_selection():
             self.imageinput.setDisabled(False)
             self.selectimage.setDisabled(False)
-            # The MAME launch button is gated on MAME + a valid image, not on
-            # hdfmonkey — so refresh it here, the resting state used when the
-            # image explorer is unavailable (e.g. hdfmonkey missing or a failed
-            # load). Keeps 'Launch Mame' usable without hdfmonkey.
-            _update_mame_launch_button()
+            # The MAME group is gated on MAME + a valid image, not on hdfmonkey —
+            # so refresh it here, the resting state used when the image explorer
+            # is unavailable (e.g. hdfmonkey missing or a failed load). Keeps
+            # 'Launch Mame' and its option combos usable without hdfmonkey.
+            _update_mame_controls()
 
         def disable_image_selection():
             self.imageinput.setDisabled(True)
@@ -3239,9 +3286,9 @@ class MainWindow(QMainWindow):
             _start_hdfmonkey_button_animation()
             # hdfmonkey is confirmed missing here, so the file explorer stays
             # disabled — but MAME doesn't need hdfmonkey, so make sure its launch
-            # button reflects (MAME present + a valid image) rather than staying
-            # stuck disabled.
-            _update_mame_launch_button()
+            # button and option combos reflect (MAME present + a valid image)
+            # rather than staying stuck disabled.
+            _update_mame_controls()
 
         def _hdfmonkey_binary_found():
             """True if the hdfmonkey executable can be located (PATH, current
@@ -4507,6 +4554,9 @@ class MainWindow(QMainWindow):
                                     getattr(self, "mame_esc", None)):
                     if _mame_combo is not None:
                         _mame_combo.setVisible(True)
+                # Now that MAME is present, set the just-revealed group's
+                # enabled state (and the launch hint) from the current image.
+                _update_mame_controls()
             except RuntimeError:
                 pass
             add_main_log_window(f"MAME install ▸ SUCCESS — MAME detected at: {detected}")
@@ -9171,6 +9221,10 @@ class MainWindow(QMainWindow):
         # restores as On. A cfg that carries an explicit "esc=" value overrides
         # this when read in load_configuration_file.
         configuration_dictionary[SETTING_ESC] = "1"
+        # MAME ESC-key disable likewise defaults to On ("-confirm_quit"); seed
+        # index 1 so a cfg without a "mame_esc" line restores as On, while an
+        # explicit saved value still wins in load_configuration_file.
+        configuration_dictionary[SETTING_MAME_ESC] = "1"
 
         def _persist_retro(key, checked):
             """Persist a pane's Classic/Retro item-viewer choice to the config
@@ -9937,10 +9991,15 @@ class MainWindow(QMainWindow):
         self.mame_esc = QComboBox()
         for _me in MAME_ESC:
             self.mame_esc.addItem(_me[0])
+        # Default to "Disable ESC Key On" (index 1) so a fresh install (no cfg
+        # file, where load_configuration_file never reaches the restore above)
+        # ships with quit-confirmation enabled. Set before the currentIndexChanged
+        # connection below so no save is triggered; a saved cfg value still wins.
+        self.mame_esc.setCurrentIndex(1)
         self.mame_esc.setToolTip(
             "Stop the ESC key from instantly quitting MAME by requiring a quit\n"
-            "confirmation (-confirm_quit). 'Disable ESC Key Off' (default) leaves\n"
-            "ESC quitting immediately; 'Disable ESC Key On' passes -confirm_quit.")
+            "confirmation (-confirm_quit). 'Disable ESC Key On' (default) passes\n"
+            "-confirm_quit; 'Disable ESC Key Off' lets ESC quit immediately.")
         self.mame_esc.currentIndexChanged.connect(set_mame_esc)
         self.mame_group_layout.addWidget(self.mame_esc)
 
@@ -23277,10 +23336,10 @@ class MainWindow(QMainWindow):
             self.button_delete_files.setVisible(False)
             # MAME doesn't need hdfmonkey: with hdfmonkey absent load_image()
             # isn't run at startup, so nothing would otherwise enable the MAME
-            # launch button even when MAME is present. Refresh it here (the
-            # background scan re-affirms via show_hdf_monkey_download_and_install
-            # once detection completes).
-            _update_mame_launch_button()
+            # group even when MAME is present. Refresh it here (the background
+            # scan re-affirms via show_hdf_monkey_download_and_install once
+            # detection completes).
+            _update_mame_controls()
 
         # Background scan of downloads/cspect for an itch.io CSpect bundle. Run
         # only when CSpect or hdfmonkey (either, any platform) is still missing —

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "8.7.1"
+ZX_NEXT_UNITE_VERSION = "8.7.2"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False
@@ -128,7 +128,7 @@ SETTING_MAME_ASPECT                  = "mame_aspect"               # combo index
 SETTING_MAME_SOUND                   = "mame_sound"                # combo index into MAME_SOUND (audio on/off)
 SETTING_MAME_MOUSE                   = "mame_mouse"                # combo index into MAME_MOUSE (mouse capture on/off)
 SETTING_MAME_JOYSTICK                = "mame_joystick"             # combo index into MAME_JOYSTICK (joystick input on/off)
-SETTING_MAME_ESC                     = "mame_esc"                  # combo index into MAME_ESC (ESC-exit disable on/off; default 0 = off, no -confirm_quit)
+SETTING_MAME_ESC                     = "mame_esc"                  # combo index into MAME_ESC (ESC-exit disable on/off; default 1 = on, passes -confirm_quit)
 SETTING_DISABLE_NO_EMULATOR_TOAST  = "disable_no_emulator_toast"   # bool (default False)
 SETTING_NEXTSYNC_EXPLORERPATH = "nextsync_explorerpath"
 SETTING_NEXTSYNC_SYNCONCE = "nextsync_synconce"
@@ -782,9 +782,9 @@ MAME_MOUSE = (("Mouse Off", "-mouse_device none"), ("Mouse On", "-mouse"))
 MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovider none"))
 # MAME has no "-esc" option. "-confirm_quit" makes MAME prompt for confirmation
 # before quitting, so pressing ESC no longer instantly exits — effectively
-# disabling the ESC-to-quit behaviour. Not passed by default, so ESC still exits:
-# "Disable ESC Key Off" (index 0, default) passes nothing; "Disable ESC Key On"
-# passes "-confirm_quit".
+# disabling the ESC-to-quit behaviour. On by default (index 1) so ESC does not
+# accidentally quit MAME: "Disable ESC Key On" (default) passes "-confirm_quit";
+# "Disable ESC Key Off" (index 0) passes nothing so ESC still exits.
 MAME_ESC = (("Disable ESC Key Off", ""), ("Disable ESC Key On", "-confirm_quit"))
 
 # Options now driven by the MAME group combos above. They are stripped from any


### PR DESCRIPTION
## Summary
Version bump **8.7.1 → 8.7.2** with two MAME changes:

### MAME — ESC-disable On by default
The MAME "Disable ESC Key" combo now defaults to **On (`-confirm_quit`)** for fresh installs and for cfgs that predate the option (no `mame_esc=` line), so pressing ESC prompts for confirmation instead of instantly quitting. An explicit saved value still wins. (Mirrors the CSpect ESC default shipped in 8.7.1.)

### MAME — group greys out until an image is loaded
Previously, with no disk image loaded the CSpect group greyed out entirely but the MAME option combos (aspect/sound/mouse/joystick/ESC) stayed enabled. Now the MAME group mirrors CSpect:

- **Launch Mame** button + all option combos grey out together while no image is selected, and re-enable once one is.
- The greyed-out **Launch Mame** button shows a *"Select a ZX Spectrum Next disk image (.img/.hdf) first"* hint, cleared once an image is selected.
- The group is still hard-disabled during transfers/loads.

**Correctness note:** MAME's enable/tooltip is keyed off *a valid image file being selected* (not CSpect's hdfmonkey listing), because MAME boots the HDF directly without hdfmonkey. This preserves the existing "MAME works without hdfmonkey" behavior — otherwise a hdfmonkey-less setup would show a "load an image" hint on an enabled button.

## Testing
- Both modules byte-compile.
- Verified all three `button_start_mame` enable/disable paths now also drive the option combos (no out-of-sync states), and the post-install reveal refreshes the group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
