### PR TITLE
MAME Flatpak: use single-dash -rompath (not --rompath)

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -2565,7 +2565,7 @@ class MainWindow(QMainWindow):
         configuration_dictionary[SETTING_MAME_UPDATE_CHECK] = ""
         configuration_dictionary[SETTING_MAME_INSTALLED_TAG] = ""
         # "Launch Mame with Flatpak" (Linux): off by default. The rom directory
-        # passed to Flatpak MAME as --rompath is seeded with the per-user default
+        # passed to Flatpak MAME as -rompath is seeded with the per-user default
         # (~/roms) so a first-run cfg persists an editable value.
         configuration_dictionary[SETTING_MAME_FLATPAK] = "false"
         configuration_dictionary[SETTING_MAME_FLATPAK_ROMPATH] = default_mame_flatpak_rompath()
@@ -4352,14 +4352,14 @@ class MainWindow(QMainWindow):
                     mame_argv += shlex.split(_mame_arg)
 
             # Flatpak MAME is sandboxed and has no roms/ next to a binary, so the
-            # user's rom directory is passed explicitly as --rompath (before the
+            # user's rom directory is passed explicitly as -rompath (before the
             # -hard1 image, which must stay last).
             if _flatpak:
                 _rompath = (configuration_dictionary.get(
                     SETTING_MAME_FLATPAK_ROMPATH, "") or "").strip()
                 if not _rompath:
                     _rompath = default_mame_flatpak_rompath()
-                mame_argv += ["--rompath", _rompath]
+                mame_argv += ["-rompath", _rompath]
 
             if mame_image:
                 mame_argv += [MAME_HARD_DISK_PARAMETER, mame_image]
@@ -22451,7 +22451,7 @@ class MainWindow(QMainWindow):
                 "Launch MAME via 'flatpak run org.mamedev.MAME' instead of a local\n"
                 "binary — for Linux systems where MAME is installed from Flathub.\n"
                 "When on, every 'Launch Mame' button becomes 'Launch Mame (flatpak)'\n"
-                "and the rom folder below is passed to MAME as --rompath. Off by\n"
+                "and the rom folder below is passed to MAME as -rompath. Off by\n"
                 "default. Saved to the configuration file."
             )
             _flatpak_on = str(configuration_dictionary.get(
@@ -22467,7 +22467,7 @@ class MainWindow(QMainWindow):
             _rompath_row_layout.setContentsMargins(20, 0, 0, 0)
             _rompath_lbl = QLabel("Flatpak rom path:")
             _rompath_lbl.setToolTip(
-                "Directory passed to Flatpak MAME as --rompath. Put the boot ROM\n"
+                "Directory passed to Flatpak MAME as -rompath. Put the boot ROM\n"
                 "(tbblue.zip) and any other ROMs here. Defaults to ~/roms.")
             self.settings_mame_flatpak_rompath_edit = QLineEdit()
             self.settings_mame_flatpak_rompath_edit.setText(

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -130,7 +130,7 @@ SETTING_MAME_MOUSE                   = "mame_mouse"                # combo index
 SETTING_MAME_JOYSTICK                = "mame_joystick"             # combo index into MAME_JOYSTICK (joystick input on/off)
 SETTING_MAME_ESC                     = "mame_esc"                  # combo index into MAME_ESC (ESC-exit disable on/off; default 1 = on, passes -confirm_quit)
 SETTING_MAME_FLATPAK                 = "mame_flatpak"              # bool (Linux): launch MAME via `flatpak run org.mamedev.MAME` instead of a local binary (default off)
-SETTING_MAME_FLATPAK_ROMPATH         = "mame_flatpak_rompath"      # rom directory passed as `--rompath` when launching MAME via Flatpak (default ~/roms)
+SETTING_MAME_FLATPAK_ROMPATH         = "mame_flatpak_rompath"      # rom directory passed as `-rompath` when launching MAME via Flatpak (default ~/roms)
 SETTING_DISABLE_NO_EMULATOR_TOAST  = "disable_no_emulator_toast"   # bool (default False)
 SETTING_NEXTSYNC_EXPLORERPATH = "nextsync_explorerpath"
 SETTING_NEXTSYNC_SYNCONCE = "nextsync_synconce"
@@ -845,7 +845,7 @@ MAME_INSTALL_WIKI_URL = "https://wiki.specnext.dev/MAME:Installing"
 # Flatpak launch support (Linux). When the user enables "Launch Mame with
 # Flatpak" (SETTING_MAME_FLATPAK), MAME is started via the Flatpak CLI instead of
 # a local binary — handy on distros where MAME is only available from Flathub
-# (org.mamedev.MAME). The user-provided rom directory is appended as `--rompath`.
+# (org.mamedev.MAME). The user-provided rom directory is appended as `-rompath`.
 MAME_FLATPAK_APP_ID = "org.mamedev.MAME"
 MAME_FLATPAK_COMMAND = ("flatpak", "run", MAME_FLATPAK_APP_ID)
 
@@ -857,7 +857,7 @@ def mame_flatpak_supported():
 
 
 def default_mame_flatpak_rompath():
-    """Default ``--rompath`` for a Flatpak MAME launch: a ``roms`` folder in the
+    """Default ``-rompath`` for a Flatpak MAME launch: a ``roms`` folder in the
     user's home directory (e.g. ``/home/<user>/roms``). Flatpak MAME is
     sandboxed, so the user points it at a directory they control that holds the
     boot ROM (tbblue.zip) and any others."""


### PR DESCRIPTION
MAME's rom-path option is `-rompath`; the Flatpak launch was passing `--rompath`, which MAME didn't accept on Linux. Fix the launch argv plus the matching config comments and Settings tooltips.