### PR TITLE
MAME Flatpak: persist settings + re-run discovery on toggle

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -3465,6 +3465,27 @@ class MainWindow(QMainWindow):
                     self.mame_joystick.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_JOYSTICK]))
                     self.mame_esc.setCurrentIndex(get_int_value(configuration_dictionary[SETTING_MAME_ESC]))
 
+                # Flatpak launch toggle + rom path (Linux-only widgets). The
+                # Settings tab was built from the seeded defaults *before* this
+                # load ran, so re-apply the saved values here — otherwise the
+                # checkbox would always come up unchecked after a restart even
+                # though the cfg has it on. An empty saved rom path falls back to
+                # the per-user default. Finally re-affirm the SD Card MAME group
+                # so a saved "on" reveals the Launch button with no restart.
+                if not (configuration_dictionary.get(SETTING_MAME_FLATPAK_ROMPATH, "") or "").strip():
+                    configuration_dictionary[SETTING_MAME_FLATPAK_ROMPATH] = default_mame_flatpak_rompath()
+                if hasattr(self, "settings_mame_flatpak_checkbox"):
+                    _fp_on = str(configuration_dictionary.get(
+                        SETTING_MAME_FLATPAK, "")).strip().lower() in ("true", "1", "yes", "on")
+                    self.settings_mame_flatpak_checkbox.blockSignals(True)
+                    self.settings_mame_flatpak_checkbox.setChecked(_fp_on)
+                    self.settings_mame_flatpak_checkbox.blockSignals(False)
+                    self.settings_mame_flatpak_rompath_edit.setText(
+                        configuration_dictionary[SETTING_MAME_FLATPAK_ROMPATH])
+                    self.settings_mame_flatpak_rompath_row.setVisible(_fp_on)
+                    if hasattr(self, "_refresh_mame_launch_ui"):
+                        self._refresh_mame_launch_ui()
+
                 if configuration_dictionary[SETTING_DEFAULT_TAB_WHEN_OPENING]== "":
                     # First run (no previously saved tab): default to the
                     # AllInOne ("Unite!") tab so the user lands on the
@@ -22439,7 +22460,12 @@ class MainWindow(QMainWindow):
                 configuration_dictionary[SETTING_MAME_FLATPAK] = "true" if on else "false"
                 save_configuration_file()
                 self.settings_mame_flatpak_rompath_row.setVisible(on)
+                # Re-run MAME discovery so the change takes effect without a
+                # restart: refresh the SD Card tab's Launch button / relabel /
+                # group visibility, then re-report emulator availability (open
+                # gallery viewers pick the new state up when next opened).
                 self._refresh_mame_launch_ui()
+                self._show_emulator_detection_toast()
 
             _flatpak_box = QWidget()
             _flatpak_layout = QVBoxLayout(_flatpak_box)


### PR DESCRIPTION
Fixes two issues found testing the Flatpak launch option on Linux.

## Persistence
The "Launch Mame with Flatpak" checkbox and the "Flatpak rom path" were written to `hdfg.cfg` (both keys are in `CONFIG_FILE_SETTINGS`) but came back looking unset after a restart. Root cause: `load_configuration_file()` runs **after** the Settings widgets are built, so it loaded the saved values into the config dict but never re-applied them to the widgets or refreshed the MAME group.

- On load, restore the checkbox + rom-path edit from the cfg (Linux-guarded via `hasattr`, `blockSignals` so it doesn't re-fire the handler), show/hide the rom-path row, and call `_refresh_mame_launch_ui()` so a saved **on** reveals the "Launch Mame (flatpak)" button with no restart. An empty saved rom path falls back to `~/roms`.

## Re-run discovery on toggle
Flipping the checkbox now re-runs emulator discovery so the change takes effect without a restart: `_refresh_mame_launch_ui()` updates the SD Card tab's Launch button / relabel / group visibility, and `_show_emulator_detection_toast()` re-reports availability (open gallery viewers pick it up when next opened).

## Verification
- Compiles; config keys confirmed persisted.
- Windows relaunched — no regression (the widget-restore block is Linux-gated; the rest runs on all platforms).
- The Linux checkbox/rom-path round-trip should get a quick real test on Linux (toggle on → restart → still on; toggle off → button reverts, no restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)