### PR TITLE
NextSync: remote file explorer over .sync4 -listen (dot + server + app UI)

### DIFF
--- a/nextsync/sync/server/nextsync4.py
+++ b/nextsync/sync/server/nextsync4.py
@@ -24,6 +24,9 @@ import time
 import glob
 import sys
 import os
+import shlex
+import threading
+import queue
 
 assert sys.version_info >= (3, 6) # We need 3.6 for f"" strings.
 
@@ -44,6 +47,7 @@ MAX_PAYLOAD = 1024
 opt_drive = '/'
 opt_always_sync = False
 opt_sync_once = False
+opt_verbose = False   # -v: per-packet / per-command logging (off by default)
 # How to treat an incoming (-send) file/dir that already exists locally:
 #   "prompt"    - ask at the console (default)
 #   "overwrite" - always overwrite
@@ -131,7 +135,8 @@ def sendpacket(conn, payload, packetno):
         + (checksum1 & 0xff).to_bytes(1, byteorder="big")
         + (packetno & 0xff).to_bytes(1, byteorder="big"))
     conn.sendall(packet)
-    print(f'{timestamp()} | Packet sent: {len(packet)} bytes, payload: {len(payload)} bytes, checksums: {checksum0}, {checksum1}, packetno: {packetno & 0xff}')
+    if opt_verbose:
+        print(f'{timestamp()} | Packet sent: {len(packet)} bytes, payload: {len(payload)} bytes, checksums: {checksum0}, {checksum1}, packetno: {packetno & 0xff}')
 
 # ---- Sync4 upload (Next -> PC) helpers ----------------------------------
 # The Next frames each uploaded block exactly like sendpacket():
@@ -407,6 +412,282 @@ def receive_files(conn, stats):
         update_syncpoint(sp_known)
         print(f'{timestamp()} | Sync point updated with {len(received_paths)} received file(s)')
 
+# ---- Sync4 -listen (remote file server) ---------------------------------
+# COMPATIBILITY: only reached when the Next sends the NEW "Listen" handshake.
+# Every existing Sync3/Sync4/Send/download path and the block framing are
+# untouched, and an un-upgraded dot never emits "Listen".
+#
+# The Next keeps driving (it polls). We queue commands typed at the console and
+# answer each "Poll" with one command frame:
+#     'I'          idle           'M' <path>   mkdir
+#     'L' <path>   ls             'R' <path>   rmdir
+#     'G' <path>   get            'X' <path>   rm
+#     'P' <path>   put            'Q'          quit
+# ls/get/mkdir/rmdir/rm are answered by the Next PUSHING framed blocks back
+# (each acked "Ok"); put is answered by the Next PULLING data with "Get"
+# (served exactly like a normal download). See the protocol summary in the dot
+# source (nextsync/sync/z88dk/nextsync.c).
+
+LISTEN_HELP = """\
+  Remote file-server commands:
+    ls [path]                  list a directory (default: current)
+    get <path> [dest]          fetch a file or whole directory from the Next
+    put <localfile> [remote]   send a PC file to the Next
+    mkdir <path>               create a directory on the Next
+    rmdir <path>               remove a directory on the Next
+    rm <path>                  delete a file on the Next
+    help                       show this help
+    quit                       tell the Next to leave -listen and disconnect
+"""
+
+def _listen_recv_reply(conn, handler):
+    """Read the framed blocks the Next pushes in reply to a command, acking each
+    with "Ok". handler(payload) returns True to stop. Mirrors receive_files'
+    sequence/dedup handling. Returns True on clean completion, False on drop."""
+    expected = 0
+    while True:
+        blk = recv_block(conn)
+        if blk is None:
+            print(f'{timestamp()} | listen: connection closed mid-reply')
+            return False
+        if blk == 'BADCS':
+            sendpacket(conn, b"Resend", expected)
+            continue
+        payload, pktno = blk
+        if pktno == ((expected - 1) & 0xff):
+            sendpacket(conn, b"Ok", pktno)          # duplicate (lost ack)
+            continue
+        if pktno != expected:
+            sendpacket(conn, b"Err seq", pktno)
+            return False
+        stop = handler(payload)
+        sendpacket(conn, b"Ok", pktno)
+        expected = (expected + 1) & 0xff
+        if stop:
+            return True
+
+def _listen_ls(conn):
+    """Receive an 'ls' listing: 'D' blocks of packed [flags][size][namelen][name]
+    entries, ended by 'E'. Prints the result."""
+    entries = []
+    def handle(payload):
+        op = payload[0:1]
+        if op == b'E':
+            return True
+        if op == b'D':
+            i = 1
+            while i + 6 <= len(payload):
+                flags = payload[i]
+                size = (payload[i+1] | (payload[i+2] << 8) |
+                        (payload[i+3] << 16) | (payload[i+4] << 24))
+                nl = payload[i+5]
+                name = payload[i+6:i+6+nl].decode(errors='replace')
+                i += 6 + nl
+                entries.append((flags & 1, size, name))
+        return False
+    if not _listen_recv_reply(conn, handle):
+        return
+    entries.sort(key=lambda e: (0 if e[0] else 1, e[2].lower()))
+    print(f'{timestamp()} | Listing ({len(entries)} entries):')
+    for is_dir, size, name in entries:
+        print(f'   {"<DIR>":>12}  {name}' if is_dir else f'   {size:>12}  {name}')
+
+def _listen_get(conn, dest_root):
+    """Receive a 'get': 'N'/'D'/'E' per file then 'B'. Writes under dest_root."""
+    st = {'f': None, 'name': None, 'bytes': 0}
+    os.makedirs(dest_root, exist_ok=True)
+    def handle(payload):
+        op = payload[0:1]
+        if op == b'N':
+            namelen = payload[5] if len(payload) > 5 else 0
+            name = payload[6:6+namelen].decode(errors='replace')
+            path = sanitize_incoming_path(dest_root, name)
+            if st['f']:
+                st['f'].close()
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            st['f'] = open(path, 'wb')
+            st['name'] = name
+            st['bytes'] = 0
+            print(f'{timestamp()} | get: {name} -> {path}')
+        elif op == b'D':
+            if st['f']:
+                st['f'].write(payload[1:])
+                st['bytes'] += len(payload) - 1
+        elif op == b'E':
+            if st['f']:
+                st['f'].close()
+                st['f'] = None
+                print(f'{timestamp()} | get: wrote {st["name"]} ({st["bytes"]} bytes)')
+        elif op == b'B':
+            if st['f']:
+                st['f'].close()
+                st['f'] = None
+            return True
+        return False
+    _listen_get_result = _listen_recv_reply(conn, handle)
+    if st['f']:
+        st['f'].close()
+    return _listen_get_result
+
+def _listen_status(conn, what):
+    """Receive a single status block ('O' ok / 'F' fail) for mkdir/rmdir/rm."""
+    res = {'ok': None}
+    def handle(payload):
+        res['ok'] = (payload[0:1] == b'O')
+        return True
+    if _listen_recv_reply(conn, handle):
+        print(f'{timestamp()} | {what}: ' + ('OK' if res['ok'] else 'FAILED'))
+
+def listen_session(conn, stats, _test_commands=None):
+    """Sync4 -listen: the Next connected as a remote file server we drive from
+    the console. _test_commands (a list of (verb, arg1, arg2) tuples) is only
+    used by the test harness - it feeds the queue instead of the console CLI."""
+    global _in_transfer
+    sendpacket(conn, b"Listening", 0)          # ack the "Listen" handshake
+    stats['packets'] += 1
+
+    cmd_q = queue.Queue()
+
+    if _test_commands is not None:
+        for c in _test_commands:
+            cmd_q.put(c)
+        cmd_q.put(("quit", "", ""))
+    else:
+        print(f'{timestamp()} | The Next is in -listen mode (remote file server).')
+        print(LISTEN_HELP)
+
+    def _cli():
+        while True:
+            try:
+                line = input("listen> ").strip()
+            except EOFError:
+                cmd_q.put(("quit", "", ""))
+                return
+            if not line:
+                continue
+            try:
+                parts = shlex.split(line)
+            except ValueError:
+                print("  (bad quoting)")
+                continue
+            verb = parts[0].lower()
+            a1 = parts[1] if len(parts) > 1 else ""
+            a2 = parts[2] if len(parts) > 2 else ""
+            if verb in ("ls", "dir"):
+                cmd_q.put(("ls", a1, a2))
+            elif verb == "get":
+                cmd_q.put(("get", a1, a2))
+            elif verb == "put":
+                cmd_q.put(("put", a1, a2))
+            elif verb == "mkdir":
+                cmd_q.put(("mkdir", a1, a2))
+            elif verb == "rmdir":
+                cmd_q.put(("rmdir", a1, a2))
+            elif verb in ("rm", "del"):
+                cmd_q.put(("rm", a1, a2))
+            elif verb == "help":
+                print(LISTEN_HELP)
+            elif verb in ("quit", "exit", "bye"):
+                cmd_q.put(("quit", "", ""))
+                return
+            else:
+                print(f"  unknown command: {verb} (try 'help')")
+
+    if _test_commands is None:
+        threading.Thread(target=_cli, daemon=True, name="listen-cli").start()
+
+    put_data = b''
+    put_ofs = 0
+    put_pkt = 0
+    last_packet = b''
+    while True:
+        try:
+            data = conn.recv(1024)
+        except OSError:
+            break
+        if not data:
+            break
+
+        if data == b"Poll":
+            try:
+                op, a1, a2 = cmd_q.get_nowait()
+            except queue.Empty:
+                sendpacket(conn, b"I", 0)          # idle - the Next re-polls
+                continue
+            if op == "quit":
+                sendpacket(conn, b"Q", 0)
+                print(f'{timestamp()} | listen: sent quit')
+                break
+            elif op == "ls":
+                sendpacket(conn, b"L" + (a1 or ".").encode(), 0)
+                _listen_ls(conn)
+            elif op == "get":
+                if not a1:
+                    print("  usage: get <path> [dest]")
+                    continue
+                sendpacket(conn, b"G" + a1.encode(), 0)
+                _in_transfer = True
+                _listen_get(conn, a2 or ".")
+                _in_transfer = False
+            elif op == "put":
+                if not a1 or not os.path.isfile(a1):
+                    print(f"  put: local file not found: {a1}")
+                    continue
+                with open(a1, 'rb') as fh:
+                    put_data = fh.read()
+                put_ofs = 0
+                put_pkt = 0
+                remote = a2 or os.path.basename(a1)
+                # A remote ending in "/" (or "\") means "into that directory" -
+                # keep the local file's name, e.g. put bj.txt /ho/ -> /ho/bj.txt.
+                # (Without this the Next would try to create a file literally
+                # named "/ho/" and nothing would be written.)
+                if remote.endswith('/') or remote.endswith('\\'):
+                    remote = remote + os.path.basename(a1)
+                print(f'{timestamp()} | put: {a1} -> {remote} ({len(put_data)} bytes)')
+                sendpacket(conn, b"P" + remote.encode(), 0)
+                _in_transfer = True
+                # the Next now pulls the bytes with "Get" (served below)
+            elif op == "mkdir":
+                sendpacket(conn, b"M" + a1.encode(), 0)
+                _listen_status(conn, "mkdir")
+            elif op == "rmdir":
+                sendpacket(conn, b"R" + a1.encode(), 0)
+                _listen_status(conn, "rmdir")
+            elif op == "rm":
+                sendpacket(conn, b"X" + a1.encode(), 0)
+                _listen_status(conn, "rm")
+
+        elif data == b"Get" or data == b"Gee":
+            n = MAX_PAYLOAD
+            if n + put_ofs > len(put_data):
+                n = len(put_data) - put_ofs
+            last_packet = put_data[put_ofs:put_ofs + n]
+            sendpacket(conn, last_packet, put_pkt)
+            put_ofs += n
+            put_pkt += 1
+            if put_ofs >= len(put_data):
+                _in_transfer = False               # whole file delivered
+
+        elif data == b"Retry":
+            sendpacket(conn, last_packet, (put_pkt - 1) & 0xff)
+
+        elif data == b"Restart":
+            put_ofs = 0
+            put_pkt = 0
+            sendpacket(conn, b"Back", 0)
+
+        elif data == b"Bye":
+            sendpacket(conn, b"Later", 0)
+            break
+
+        else:
+            sendpacket(conn, b"I", 0)              # keep the Next moving
+
+    print(f'{timestamp()} | listen: session ended')
+
 def warnings():
     print()
     print(f"Note: Using {os.getcwd()} as sync root")
@@ -521,7 +802,8 @@ def main():
                     if not data:
                         break
                     decoded = data.decode(errors='replace')
-                    print(f'{timestamp()} | Data received: "{decoded}", {len(decoded)} bytes')
+                    if opt_verbose:
+                        print(f'{timestamp()} | Data received: "{decoded}", {len(decoded)} bytes')
                     if data == b"Sync3":
                         print(f'{timestamp()} | Using protocol version: {VERSION3}')
                         packet = str.encode(VERSION3)
@@ -541,6 +823,12 @@ def main():
                         # inbound blocks ourselves in receive_files() (the main
                         # recv(1024) loop can't frame length-prefixed data).
                         receive_files(conn, stats)
+                        talking = False
+                    elif data == b"Listen":
+                        # Sync4 -listen: the Next runs as a remote file server we
+                        # drive from the console. New keyword; old dots never send
+                        # it, so nothing else is affected.
+                        listen_session(conn, stats)
                         talking = False
                     elif data == b"Next" or data == b"Neex": # Really common mistransmit. Probably uart-esp..
                         if data == b"Neex":
@@ -588,7 +876,8 @@ def main():
                         if bytecount + fileofs > len(filedata):
                             bytecount = len(filedata) - fileofs
                         packet = filedata[fileofs:fileofs+bytecount]
-                        print(f"{timestamp()} | Sending {bytecount} bytes, offset {fileofs}/{len(filedata)}")
+                        if opt_verbose:
+                            print(f"{timestamp()} | Sending {bytecount} bytes, offset {fileofs}/{len(filedata)}")
                         stats['packets'] += 1
                         sendpacket(conn, packet, packetno)
                         stats['totalbytes'] += len(packet)
@@ -653,6 +942,8 @@ for x in sys.argv[1:]:
         opt_always_sync = True
     elif x == '-o':
         opt_sync_once = True
+    elif x == '-v' or x == '-verbose':
+        opt_verbose = True
     elif x == '-s':
         MAX_PAYLOAD = 256
     elif x == '-u':
@@ -676,6 +967,7 @@ for x in sys.argv[1:]:
         Optional parameters:
         -a  - Always sync, regardless of timestamps (doesn't skip ignore file)
         -o  - Sync once, then quit. Default is to keep the sync loop running.
+        -v  - Verbose: log every packet/command (off by default; noisy in -listen)
         -s  - Use safe payload size (256 bytes). Slower, but more robust.
               Use this if you get a lot of retries.
         -u  - To live on the edge, you can try to use really unsafe payload
@@ -692,4 +984,7 @@ for x in sys.argv[1:]:
         """)
         quit()
 
-main()
+# Guarded so the module can be imported (e.g. by tests) without launching the
+# server. Standalone `python nextsync4.py` behaviour is unchanged.
+if __name__ == "__main__":
+    main()

--- a/nextsync/sync/server/test_listen.py
+++ b/nextsync/sync/server/test_listen.py
@@ -1,0 +1,184 @@
+"""Localhost end-to-end test for the Sync4 -listen protocol.
+
+Drives nextsync4.listen_session() (the server) over a socketpair with a mock
+Next on the other end that implements the dot's half of the protocol, exactly
+as nextsync/sync/z88dk/nextsync.c does. Validates ls / get / put / mkdir /
+rmdir / rm framing without any hardware.
+"""
+import os, sys, socket, threading, tempfile, shutil, time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import nextsync4 as ns
+
+if os.environ.get("TL_DEBUG"):
+    _orig_sp = ns.sendpacket
+    def _sp(conn, payload, pktno):
+        sys.stderr.write(f"[SRV send] {bytes(payload)[:18]!r} pkt={pktno}\n"); sys.stderr.flush()
+        return _orig_sp(conn, payload, pktno)
+    ns.sendpacket = _sp
+    def _dbg(msg):
+        sys.stderr.write(msg + "\n"); sys.stderr.flush()
+else:
+    def _dbg(msg):
+        pass
+
+
+# --- framing (mirrors sendpacket / the dot's send_block) --------------------
+def _cs(payload):
+    c0 = c1 = 0
+    for x in payload:
+        c0 = (c0 ^ x) & 0xff
+        c1 = (c1 + c0) & 0xff
+    return c0, c1
+
+def frame(payload, pktno=0):
+    c0, c1 = _cs(payload)
+    return (len(payload) + 5).to_bytes(2, "big") + bytes(payload) + bytes([c0, c1, pktno & 0xff])
+
+def recv_exact(sock, n):
+    b = b''
+    while len(b) < n:
+        c = sock.recv(n - len(b))
+        if not c:
+            return None
+        b += c
+    return b
+
+def recv_payload(sock):
+    """Read one framed block, return just the payload (drop cs0/cs1/pktno)."""
+    hdr = recv_exact(sock, 2)
+    total = (hdr[0] << 8) | hdr[1]
+    rest = recv_exact(sock, total - 2)
+    return rest[:-3]
+
+
+# --- mock Next: the dot's side of -listen -----------------------------------
+# The real transport is an ESP link that delivers each command/frame as a
+# discrete +IPD message. A localhost socketpair is a raw byte stream that can
+# coalesce or split those, so this mock stays strictly lockstep (one message in
+# flight) and settles briefly between turns to emulate that discrete delivery.
+def _settle():
+    time.sleep(0.002)
+
+def mock_next(sock, fake_entries, fake_file, captured):
+    # NB: the test calls listen_session() directly, i.e. *after* the main
+    # dispatch loop would have consumed the "Listen" handshake keyword - so the
+    # mock does NOT send "Listen" here; it just reads the "Listening" ack that
+    # listen_session() emits on entry.
+    assert recv_payload(sock) == b"Listening"
+
+    def push(payload, pkt):
+        _settle()
+        sock.sendall(frame(payload, pkt))
+        assert recv_payload(sock)[0:1] == b'O'      # server acks "Ok"
+
+    while True:
+        _settle()
+        sock.sendall(b"Poll")
+        cmd = recv_payload(sock)
+        _dbg(f"[MOCK recv-cmd] {cmd[:18]!r}")
+        op, arg = cmd[0:1], cmd[1:].decode()
+        if op == b'Q':
+            break
+        if op == b'I':
+            continue
+        if op == b'L':                              # ls: push entries then 'E'
+            pkt = 0
+            payload = b'D'
+            for is_dir, size, name in fake_entries:
+                payload += (bytes([1 if is_dir else 0]) +
+                            int(size).to_bytes(4, "little") +
+                            bytes([len(name)]) + name.encode())
+            push(payload, pkt); pkt += 1
+            push(b'E', pkt)
+        elif op == b'G':                            # get: push one file then 'B'
+            pkt = 0
+            name = arg
+            push(b'N' + len(fake_file).to_bytes(4, "big") + bytes([len(name)]) + name.encode(), pkt); pkt += 1
+            push(b'D' + fake_file, pkt); pkt += 1
+            push(b'E', pkt); pkt += 1
+            push(b'B', pkt)
+        elif op == b'P':                            # put: pull the file the server sends
+            buf = b''
+            while True:
+                _settle()
+                sock.sendall(b"Get")
+                data = recv_payload(sock)
+                if len(data) == 0:
+                    break
+                buf += data
+            captured.setdefault('puts', []).append((arg, buf))
+        elif op in (b'M', b'R', b'X'):              # mkdir/rmdir/rm: status OK
+            push(b'O', 0)
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="listen_test_")
+    getdest = os.path.join(tmp, "getdest")
+    putfile = os.path.join(tmp, "upload.bin")
+    put_bytes = bytes(range(256)) * 10          # 2560 bytes, multi-packet
+    with open(putfile, "wb") as f:
+        f.write(put_bytes)
+
+    fake_entries = [(1, 0, "GAMES"), (0, 1234, "boot.bas"), (0, 49152, "screen.scr")]
+    fake_file = b"Hello from the ZX Spectrum Next!\r\n" * 4
+    captured = {}
+
+    srv, nxt = socket.socketpair()
+    for s in (srv, nxt):
+        try:
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except (OSError, AttributeError):
+            pass
+    stats = {'packets': 0, 'totalbytes': 0, 'payloadbytes': 0, 'retries': 0, 'restarts': 0, 'gee': 0}
+
+    cmds = [
+        ("mkdir", "/games/new", ""),
+        ("ls", "/", ""),
+        ("get", "boot.bas", getdest),
+        ("put", putfile, "c:/uploads/upload.bin"),  # explicit remote name
+        ("put", putfile, "/ho/"),                   # dir remote -> keep basename
+        ("rm", "/games/old.tap", ""),
+        ("rmdir", "/games/tmp", ""),
+    ]
+
+    t = threading.Thread(target=ns.listen_session, args=(srv, stats, cmds), daemon=True)
+    t.start()
+    try:
+        mock_next(nxt, fake_entries, fake_file, captured)
+    finally:
+        t.join(timeout=5)
+        srv.close(); nxt.close()
+
+    ok = True
+    # get: the fake file should have been written under getdest
+    got_path = os.path.join(getdest, "boot.bas")
+    if os.path.isfile(got_path) and open(got_path, "rb").read() == fake_file:
+        print("PASS get   : file received and bytes match")
+    else:
+        print("FAIL get   : file missing or mismatched"); ok = False
+    # put: the mock Next should have received the exact upload bytes
+    puts = captured.get('puts', [])
+    if len(puts) == 2 and all(p[1] == put_bytes for p in puts):
+        print(f"PASS put   : {len(put_bytes)} bytes delivered, remotes {[p[0] for p in puts]}")
+    else:
+        print("FAIL put   : bytes not delivered / mismatch"); ok = False
+    # a remote ending in "/" must get the local basename appended
+    if len(puts) == 2 and puts[1][0] == "/ho/upload.bin":
+        print("PASS put-dir: trailing-slash remote resolved to /ho/upload.bin")
+    else:
+        got = puts[1][0] if len(puts) == 2 else None
+        print(f"FAIL put-dir: expected /ho/upload.bin, got {got!r}"); ok = False
+    # the session must have run to completion (thread ended)
+    if not t.is_alive():
+        print("PASS session: ls/mkdir/rmdir/rm framed and completed cleanly")
+    else:
+        print("FAIL session: did not finish"); ok = False
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/nextsync/sync/server/test_remote_listen.py
+++ b/nextsync/sync/server/test_remote_listen.py
@@ -1,0 +1,131 @@
+"""Localhost test for zxnu_workers.run_remote_listen_server (the app-side
+-listen server worker). A mock Next connects over a real socket and speaks the
+dot's half of the protocol; we drive the worker via its command queue and check
+the emitted signals."""
+import os, sys, socket, threading, queue, tempfile, shutil, time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+from PySide6.QtCore import QCoreApplication, Qt
+from zxnu_workers import RemoteExplorerSignals, run_remote_listen_server
+
+PORT = 2049
+
+def cs(p):
+    c0 = c1 = 0
+    for x in p:
+        c0 = (c0 ^ x) & 0xff; c1 = (c1 + c0) & 0xff
+    return c0, c1
+
+def frame(payload, pkt=0):
+    c0, c1 = cs(payload)
+    return (len(payload)+5).to_bytes(2, "big") + bytes(payload) + bytes([c0, c1, pkt & 0xff])
+
+def rx_exact(s, n):
+    b = b''
+    while len(b) < n:
+        c = s.recv(n-len(b))
+        if not c: return None
+        b += c
+    return b
+
+def rx_payload(s):
+    hdr = rx_exact(s, 2); total = (hdr[0] << 8) | hdr[1]
+    return rx_exact(s, total-2)[:-3]
+
+def settle():
+    time.sleep(0.003)
+
+def mock_next(sock, entries, filebytes, cap):
+    sock.sendall(b"Listen")
+    assert rx_payload(sock) == b"Listening"
+    def push(payload, pkt):
+        settle(); sock.sendall(frame(payload, pkt))
+        assert rx_payload(sock)[0:1] == b'O'
+    while True:
+        settle(); sock.sendall(b"Poll")
+        cmd = rx_payload(sock)
+        op, arg = cmd[0:1], cmd[1:].decode()
+        if op == b'Q': break
+        if op == b'I': continue
+        if op == b'L':
+            pl = b'D'
+            for is_dir, size, name in entries:
+                pl += bytes([1 if is_dir else 0]) + int(size).to_bytes(4, "little") + bytes([len(name)]) + name.encode()
+            push(pl, 0); push(b'E', 1)
+        elif op == b'G':
+            name = os.path.basename(arg) or "f.bin"
+            push(b'N' + len(filebytes).to_bytes(4, "big") + bytes([len(name)]) + name.encode(), 0)
+            push(b'D' + filebytes, 1); push(b'E', 2); push(b'B', 3)
+        elif op == b'P':
+            buf = b''
+            while True:
+                settle(); sock.sendall(b"Get")
+                d = rx_payload(sock)
+                if not d: break
+                buf += d
+            cap['put'] = (arg, buf)
+        elif op in (b'M', b'R', b'X'):
+            push(b'O', 0)
+
+def main():
+    app = QCoreApplication(sys.argv)
+    tmp = tempfile.mkdtemp(prefix="re_test_")
+    getdir = os.path.join(tmp, "dl")
+    putfile = os.path.join(tmp, "up.bin"); put_bytes = bytes(range(256)) * 8
+    open(putfile, "wb").write(put_bytes)
+
+    entries = [(True, 0, "GAMES"), (False, 1234, "boot.bas")]
+    filebytes = b"Hello Next!\r\n" * 5
+    cap = {}
+    got = {'listing': None, 'got': None, 'put': None, 'ops': []}
+
+    sig = RemoteExplorerSignals()
+    sig.listing.connect(lambda p, e: got.update(listing=(p, e)), Qt.DirectConnection)
+    sig.got.connect(lambda r, l: got.update(got=(r, l)), Qt.DirectConnection)
+    sig.put_done.connect(lambda ok, r: got.update(put=(ok, r)), Qt.DirectConnection)
+    sig.op_done.connect(lambda ok, o, p: got['ops'].append((ok, o, p)), Qt.DirectConnection)
+
+    cmd_q = queue.Queue()
+    stop = threading.Event()
+    for c in [("mkdir", "/ho"), ("ls", "/"), ("get", "boot.bas", getdir),
+              ("put", putfile, "/ho/"), ("rm", "/x.tap"), ("rmdir", "/y"), ("quit",)]:
+        cmd_q.put(c)
+
+    t = threading.Thread(target=run_remote_listen_server, args=(sig, cmd_q, stop, PORT), daemon=True)
+    t.start()
+    time.sleep(0.3)  # let it bind/accept
+    s = socket.create_connection(("127.0.0.1", PORT), timeout=5)
+    try:
+        mock_next(s, entries, filebytes, cap)
+    finally:
+        stop.set(); t.join(timeout=5); s.close()
+
+    ok = True
+    if got['listing'] and got['listing'][0] == "/" and len(got['listing'][1]) == 2:
+        print("PASS ls   :", got['listing'][1])
+    else:
+        print("FAIL ls   :", got['listing']); ok = False
+    gp = got['got']
+    if gp and os.path.isfile(gp[1]) and open(gp[1], "rb").read() == filebytes:
+        print("PASS get  : wrote", gp[1])
+    else:
+        print("FAIL get  :", gp); ok = False
+    if cap.get('put') and cap['put'][1] == put_bytes and cap['put'][0] == "/ho/up.bin":
+        print("PASS put  : delivered to", cap['put'][0])
+    else:
+        print("FAIL put  :", cap.get('put', None), "sig:", got['put']); ok = False
+    if got['put'] and got['put'][0] and got['put'][1] == "/ho/up.bin":
+        print("PASS put-sig: put_done", got['put'])
+    else:
+        print("FAIL put-sig:", got['put']); ok = False
+    if any(o == (True, "mkdir", "/ho") for o in got['ops']) and any(o[1] == "rm" for o in got['ops']):
+        print("PASS ops  :", got['ops'])
+    else:
+        print("FAIL ops  :", got['ops']); ok = False
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
+    sys.exit(0 if ok else 1)
+
+if __name__ == "__main__":
+    main()

--- a/nextsync/sync/z88dk/README.md
+++ b/nextsync/sync/z88dk/README.md
@@ -59,8 +59,8 @@ $C000–$FFFF   (mmu6/7)              : NextZXOS (saved/restored by the crt)
 
 `CRT_ORG_MAIN=0x8000`, `REGISTER_SP=0xBF00`. The large buffers (`inbuf`,
 `scratch`, …) are file-scope statics so they land in the main bank and keep the
-stack small. Current layout: main-bank content ends at `~0xAC52`, leaving
-~4.7 KB of stack below `0xBF00`. This mirrors z88dk's own `ls`/`dzx7` dotN
+stack small. Current layout: main-bank content ends at `~0xB39A`, leaving
+~2.9 KB of stack below `0xBF00`. This mirrors z88dk's own `ls`/`dzx7` dotN
 examples (same `0xf0` allocation mask): the crt saves NextZXOS's bank/MMU state
 on entry and restores it on exit, and esxDOS file/dir calls work through divMMC
 regardless of what is paged at mmu6/7.
@@ -75,10 +75,53 @@ Console output goes through z88dk's ROM-print driver, which **ignores `\r`** and
 only newlines on `\n`; the app uses `\r` throughout, so `conprint()` translates
 `\r`→`\n`.
 
+## `-listen` — remote file server
+
+`.sync4 -listen` connects to the saved server and then acts as a small remote
+file server the PC drives. **Fully backward compatible:** it is only entered
+after a *new* handshake keyword `"Listen"`; every Sync3/Sync4/`-send` path and
+the block framing are untouched, and an un-upgraded dot never sends `"Listen"`
+(an old server just replies `"Error"` and the dot exits).
+
+Add `-v` (e.g. `.sync4 -listen -v`) to echo each received command and action on
+the Next screen (`> P /ho/bj.txt`, `open:`/`mkdir:`/`open ok`, `wrote N`,
+`put done`, `mkdir ok`, …) — handy for diagnosing a transfer on the hardware.
+On the PC side, `nextsync4.py -v` logs every packet.
+
+The Next keeps driving — it *polls* the server for the next command and runs it.
+All frames use the existing `[2B total][payload][cs0][cs1][packetno]` framing:
+
+```
+Next  -> server : "Poll"
+server-> Next   : one command frame, payload = opcode + optional path:
+     'I'          idle, nothing queued -> the Next re-polls (throttled)
+     'L' <path>   ls    : the Next pushes a directory listing back
+     'G' <path>   get   : the Next pushes the file / whole dir back
+     'P' <path>   put   : the Next pulls the file from the server
+     'M' <path>   mkdir      'R' <path>  rmdir      'X' <path>  rm
+     'Q'          quit  -> leave listen mode
+```
+
+`ls`/`get`/`mkdir`/`rmdir`/`rm` answer by pushing blocks (each acked `"Ok"`, like
+`-send`): `ls` sends `'D'` blocks of packed `[flags][size LE][namelen][name]`
+entries then `'E'`; `get` reuses `send_file`/`send_dir` (`'N'`/`'D'`/`'E'` then a
+final `'B'`); the status ops send one `'O'`/`'F'` block. `put` reuses `transfer()`
+— the Next pulls with `"Get"` and the server serves the bytes, exactly like a
+normal download.
+
+Server side: `nextsync4.py` gains a `listen_session()` (triggered by `"Listen"`)
+with a console CLI (`ls`/`get`/`put`/`mkdir`/`rmdir`/`rm`/`quit`). The whole wire
+protocol is covered by `server/test_listen.py`, which drives `listen_session()`
+over a socketpair with a mock Next — run it with `python test_listen.py`.
+
 ## Status / testing
 
-- Builds clean as a valid dotN (~11 KB of code+data past the old 8 KB page;
+- Builds clean as a valid dotN (~13 KB of code+data past the old 8 KB page;
   24 KB command file).
+- **Server `-listen` protocol is validated on localhost** by `test_listen.py`
+  (ls/get/put/mkdir/rmdir/rm all pass against a mock Next). The **dot** side
+  compiles clean and reuses the proven send/receive paths, but the Next half of
+  `-listen` still needs a real-Next run to confirm.
 - **Not yet run on hardware or a NextZXOS emulator card.** This environment has
   CSpect but no bootable NextZXOS system SD image, so a load test could not be
   performed here. To smoke-test: copy `syncdev` to your card's `C:/DOT/` folder

--- a/nextsync/sync/z88dk/nextsync.c
+++ b/nextsync/sync/z88dk/nextsync.c
@@ -46,6 +46,7 @@ __sfr __banked __at 0x153b UART_CTL;
 // exported framecounter/dbg/scr_x/scr_y/osiy - all unused here, so dropped.
 char *cmdline;
 unsigned short corever;
+char g_verbose = 0;   // -v: echo -listen commands/actions on the Next screen
 
 // See calc_prescalar.c for the prescalar calculation code
 static const unsigned short prescalar_values[] = {
@@ -110,6 +111,26 @@ void print(char * t)
 {
     *((unsigned char *)23692) = 255;
     conprint(t);
+    conprint("\r");
+}
+
+extern unsigned char uitoa(unsigned short v, char *b);  // defined in gfx.c
+
+// -v helpers: only emit when g_verbose is set (used to trace -listen on-screen).
+void vprint(char *t)
+{
+    if (g_verbose) print(t);
+}
+
+// Print "<label><number>" on one line (e.g. "wrote 512"), verbose only.
+void vlabelnum(char *label, unsigned short v)
+{
+    char b[8];
+    if (!g_verbose) return;
+    *((unsigned char *)23692) = 255;
+    conprint(label);
+    uitoa(v, b);
+    conprint(b);
     conprint("\r");
 }
 
@@ -319,8 +340,10 @@ unsigned char createfilewithpath(char * fn)
 {
     unsigned char filehandle;
     char * slash;
+    if (g_verbose) { vprint("open:"); vprint(fn); }
     filehandle = fopen(fn, 2 + 0x0c);  // write + create new file, delete existing
-    if (filehandle) return filehandle;
+    if (filehandle) { vprint("open ok"); return filehandle; }
+    vprint("open failed, mkdir path");
     // Okay, couldn't create the file, so let's try to make the path.
     // We need to call makepath for each directory in the tree to build
     // complex paths.
@@ -331,11 +354,14 @@ unsigned char createfilewithpath(char * fn)
         if (*slash == '/')
         {
             *slash = 0;      // esx_f_mkdir wants a 0-terminated path prefix
+            if (g_verbose) { vprint("mkdir:"); vprint(fn); }
             sync_mkdir(fn);  // make this directory level (ignore "exists")
             *slash = '/';
         }
     }
-    return fopen(fn, 2 + 0x0c); // if it still doesn't work, well, it doesn't.
+    filehandle = fopen(fn, 2 + 0x0c); // if it still doesn't work, well, it doesn't.
+    vprint(filehandle ? "open ok (2)" : "open still failed");
+    return filehandle;
 }
 
 char transfer(char *fn, unsigned char *inbuf)
@@ -599,6 +625,89 @@ void parse_speed_switches(char *dst)
     dst[di] = 0;
 }
 
+// ---------------------------------------------------------------------------
+// -listen mode: act as a small remote file server, driven by the PC over the
+// Sync protocol. COMPATIBILITY: this is only ever reached after a NEW handshake
+// keyword ("Listen"); every Sync3/Sync4/-send path and frame is untouched, so
+// old dots and old servers are completely unaffected.
+//
+// The Next keeps driving, as everywhere else: it polls the server for the next
+// command and runs it. All frames use the existing block framing
+// [2B total][payload][cs0][cs1][packetno]:
+//
+//   Next  -> server : "Poll"   (cipxfer)
+//   server-> Next   : one command frame, payload = opcode + optional path:
+//        'I'          idle, nothing queued  -> the Next just re-polls
+//        'L' <path>   ls    : the Next pushes a directory listing back
+//        'G' <path>   get   : the Next pushes the file/dir back (send_file/dir)
+//        'P' <path>   put   : the Next pulls the file from the server (transfer)
+//        'M' <path>   mkdir
+//        'R' <path>   rmdir
+//        'X' <path>   rm (unlink)
+//        'Q'          quit  -> leave listen mode
+//
+// ls/get/mkdir/rmdir/rm answer by PUSHING blocks to the server (each acked with
+// a framed "Ok", exactly like -send):
+//   ls  : 'D' blocks of packed entries, then 'E'.
+//         entry = [1B flags][4B size, little-endian][1B namelen][name],
+//         flags bit0 = directory.
+//   get : send_file / send_dir ('N'/'D'/'E' per file), then a final 'B'.
+//   mkdir/rmdir/rm : one status block, 'O' (ok) or 'F' (fail).
+//   put : reuses transfer() - the Next pulls data with "Get", server serves it.
+// ---------------------------------------------------------------------------
+
+// Push a one-byte status result ('O' ok / 'F' fail) for mkdir/rmdir/rm.
+void listen_status(char ok, unsigned char *inbuf, unsigned char *scratch)
+{
+    g_packetno = 0;
+    scratch[2] = ok ? 'O' : 'F';
+    send_block_rt(scratch, 1, inbuf);
+}
+
+// ls: enumerate 'path' and push the listing to the server as 'D' blocks of
+// packed [flags][size][namelen][name] entries, ended by an 'E' block. Only
+// readdir + network I/O happen while the handle is open (no esxDOS file I/O),
+// so the directory cursor is safe.
+void listen_ls(char *path, unsigned char *inbuf, unsigned char *scratch)
+{
+    unsigned char dh, i, nl;
+    sync_dirent_t ent;
+    unsigned short used = 0;   // entry bytes packed after the opcode (at scratch[3])
+
+    g_packetno = 0;
+
+    dh = opendir((unsigned char *)path);
+    if (dh == 0) { listen_status(0, inbuf, scratch); return; }  // 'F' - can't open
+
+    while (sync_readdir_entry(dh, &ent))
+    {
+        nl = 0;
+        while (ent.name[nl]) nl++;
+        if (used + 6 + nl > 1000)          // flush the current block first
+        {
+            scratch[2] = 'D';
+            send_block_rt(scratch, (unsigned short)(1 + used), inbuf);
+            used = 0;
+        }
+        scratch[3 + used++] = ent.is_dir ? 1 : 0;
+        scratch[3 + used++] = (unsigned char)(ent.size);
+        scratch[3 + used++] = (unsigned char)(ent.size >> 8);
+        scratch[3 + used++] = (unsigned char)(ent.size >> 16);
+        scratch[3 + used++] = (unsigned char)(ent.size >> 24);
+        scratch[3 + used++] = nl;
+        for (i = 0; i < nl; i++) scratch[3 + used++] = ent.name[i];
+    }
+    fclose(dh);
+
+    if (used)                              // flush remaining entries
+    {
+        scratch[2] = 'D';
+        send_block_rt(scratch, (unsigned short)(1 + used), inbuf);
+    }
+    scratch[2] = 'E';
+    send_block_rt(scratch, 1, inbuf);
+}
+
 // Big I/O buffers live in bss (main bank, mmu4/mmu5) rather than on the stack:
 // under the dotN model that keeps the stack small and forces those pages to be
 // allocated and mapped. They are only used from main() and its callees, one
@@ -618,6 +727,7 @@ int main(int arglen, char *rawcmd)
     const char *cipstart_postfix = "\",2048\r\n";
     const char *conffile         = "c:/sys/config/nextsync.cfg";
     char sendmode = 0;
+    char listenmode = 0;   // -listen: run as a remote file server for the PC
     unsigned char fnlen;
     unsigned char *dp;
     unsigned short len = 0;
@@ -681,7 +791,30 @@ int main(int arglen, char *rawcmd)
             sendmode = 1;
     }
 
-    if (!sendmode)
+    // Detect "-listen": run as a remote file server driven by the PC. Like
+    // -send, it connects to the saved server (from the config file).
+    if (!sendmode && len >= 7 &&
+        fn[0] == '-' && fn[1] == 'l' && fn[2] == 'i' && fn[3] == 's' &&
+        fn[4] == 't' && fn[5] == 'e' && fn[6] == 'n' && (fn[7] == 0 || fn[7] == ' '))
+    {
+        listenmode = 1;
+    }
+
+    // Detect "-v" as a standalone token anywhere on the (cleaned) command line:
+    // verbose on-screen trace of -listen commands/actions.
+    {
+        unsigned short vi = 0;
+        while (cmdline[vi])
+        {
+            if (cmdline[vi] == '-' && cmdline[vi + 1] == 'v' &&
+                (cmdline[vi + 2] == 0 || cmdline[vi + 2] == ' ' || cmdline[vi + 2] == 0xd) &&
+                (vi == 0 || cmdline[vi - 1] == ' '))
+                g_verbose = 1;
+            vi++;
+        }
+    }
+
+    if (!sendmode && !listenmode)
     {
         // Only treat the argument as a server name to save when it actually
         // looks like one (starts alphanumeric). Anything else - a flag, a stray
@@ -702,6 +835,7 @@ int main(int arglen, char *rawcmd)
                 ".SYNC [server] : save cfg\r"
                 ".SYNC : sync from PC\r"
                 ".SYNC -send <file|dir>\r"
+                ".SYNC -listen : file server\r"
                 ".SYNC -slow|-default|-fast\r"
                 "See nextsync.txt\r\r");
             goto terminate;
@@ -734,7 +868,7 @@ int main(int arglen, char *rawcmd)
     }
     else
     {
-        // Send mode: load the configured server name to connect to.
+        // Send / listen mode: load the configured server to connect to.
         filehandle = fopen((char*)conffile, 1);
         if (filehandle == 0)
         {
@@ -817,6 +951,78 @@ retryconnect:
     }
         
     retrycount = 0;
+
+    if (listenmode)
+    {
+        // Remote file server. New handshake keyword: only a NEW server answers
+        // "Listening"; an old server replies "Error" and we bail out (Sync3/
+        // Sync4 handshakes are never affected).
+        cipxfer("Listen", 6, inbuf, &len, &dp);
+        if (len < 12 || checksum(dp, len - 3) != 0 || memcmp(dp, "Listening", 9) != 0)
+        {
+            print("Server too old (-listen)");
+            goto closeconn;
+        }
+        print("Listening for commands");
+
+        // Poll the server for the next command and run it, until "Q" (quit).
+        for (;;)
+        {
+            cipxfer("Poll", 4, inbuf, &len, &dp);
+            if (len < 4 || checksum(dp, len - 3) != 0)
+            {
+                flush_uart_hard();          // bad/empty frame - re-poll
+                continue;
+            }
+
+            {
+                unsigned char op = dp[0];
+                unsigned short al = len - 3 - 1;   // path length (payload minus opcode)
+                if (al > 254) al = 254;
+                memcpy(fn, dp + 1, al);
+                fn[al] = 0;
+
+                // -v: echo the command opcode + path we received, e.g. "> P /ho/bj.txt".
+                if (g_verbose && op != 'I')
+                {
+                    char oc[3]; oc[0] = '>'; oc[1] = op; oc[2] = 0;
+                    *((unsigned char *)23692) = 255;
+                    conprint(oc); conprint(" "); conprint(fn); conprint("\r");
+                }
+
+                if (op == 'Q') break;               // quit listen mode
+                else if (op == 'I') { for (len = 0; len < 30000; len++); } // idle: throttle before re-polling
+                else if (op == 'L') listen_ls(fn, inbuf, scratch);
+                else if (op == 'G')
+                {
+                    // get: push the file, or the whole directory tree, then 'B'.
+                    unsigned char fh = fopen((unsigned char *)fn, 1);
+                    g_packetno = 0;
+                    if (fh)
+                    {
+                        fclose(fh);
+                        send_file(fn, fn, inbuf, scratch);
+                    }
+                    else
+                    {
+                        unsigned short plen = 0;
+                        while (fn[plen]) plen++;
+                        if (plen && fn[plen - 1] == '/') { plen--; fn[plen] = 0; }
+                        send_dir(fn, plen, inbuf, scratch, inbuf);
+                    }
+                    scratch[2] = 'B';
+                    send_block_rt(scratch, 1, inbuf);
+                    vprint("sent");
+                }
+                else if (op == 'P') { if (transfer(fn, inbuf)) vprint("put failed"); else vprint("put done"); } // put
+                else if (op == 'M') { unsigned char ok = sync_mkdir(fn)  != 0xFF; vprint(ok ? "mkdir ok" : "mkdir fail"); listen_status(ok, inbuf, scratch); }
+                else if (op == 'R') { unsigned char ok = sync_rmdir(fn)  != 0xFF; vprint(ok ? "rmdir ok" : "rmdir fail"); listen_status(ok, inbuf, scratch); }
+                else if (op == 'X') { unsigned char ok = sync_unlink(fn) != 0xFF; vprint(ok ? "rm ok" : "rm fail"); listen_status(ok, inbuf, scratch); }
+            }
+        }
+        print("Listen ended");
+        goto closeconn;
+    }
 
     if (sendmode)
     {

--- a/nextsync/sync/z88dk/syncsys.c
+++ b/nextsync/sync/z88dk/syncsys.c
@@ -10,6 +10,12 @@
 #include <arch/zxn.h>
 #include <arch/zxn/esxdos.h>
 
+/* Pull in the shared types (sync_dirent_t) and prototypes, but NOT the
+ * fopen/fread/... macros - we implement those wrappers here by their real
+ * names and call the C library / esx_f_* directly. */
+#define SYNCSYS_NO_MACROS
+#include "syncsys.h"
+
 /* --- esxDOS file / directory operations -------------------------------- */
 
 /* esx_f_open returns 0xFF (and sets errno) on error; the NextSync C code was
@@ -55,6 +61,44 @@ unsigned char sync_readdir(unsigned char handle, void *buf)
 unsigned char sync_mkdir(const char *path)
 {
    return esx_f_mkdir(path);
+}
+
+/* rmdir / rm for the -listen commands. esxDOS returns 0xFF (and sets errno) on
+ * error; callers treat "!= 0xFF" as success. */
+unsigned char sync_rmdir(const char *path)
+{
+   return esx_f_rmdir(path);
+}
+
+unsigned char sync_unlink(const char *path)
+{
+   return esx_f_unlink(path);
+}
+
+/* Read one directory entry, exposing its FAT attribute (directory flag) and
+ * size. esx_f_readdir fills a struct esx_dirent (attr, then ASCIIZ name, then
+ * date/time and size); esx_slice_dirent() locates the size that follows the
+ * variable-length name. Returns 1 on success, 0 at end of directory. */
+unsigned char sync_readdir_entry(unsigned char handle, sync_dirent_t *out)
+{
+   struct esx_dirent ent;
+   unsigned char i;
+
+   if (esx_f_readdir(handle, &ent) == 0)
+      return 0;                          /* end of directory */
+
+   out->is_dir = (ent.attr & 0x10) ? 1 : 0;
+
+   for (i = 0; ent.name[i] && i < sizeof(out->name) - 1; i++)
+      out->name[i] = ent.name[i];
+   out->name[i] = 0;
+
+   if (out->is_dir)
+      out->size = 0;
+   else
+      out->size = ((struct esx_dirent_slice *)esx_slice_dirent(&ent))->size;
+
+   return 1;
 }
 
 /* --- Next hardware registers ------------------------------------------- */

--- a/nextsync/sync/z88dk/syncsys.h
+++ b/nextsync/sync/z88dk/syncsys.h
@@ -33,13 +33,32 @@ extern unsigned short sync_read(unsigned char handle, void *buf, unsigned short 
 extern void           sync_write(unsigned char handle, void *buf, unsigned short bytes);
 extern unsigned char  sync_readdir(unsigned char handle, void *buf);
 extern unsigned char  sync_mkdir(const char *path);   /* create one directory */
+extern unsigned char  sync_rmdir(const char *path);   /* remove a directory    */
+extern unsigned char  sync_unlink(const char *path);  /* delete a file         */
 
+/* One directory entry with its size, for the -listen "ls" command. Enumerated
+ * with sync_opendir()/sync_readdir_entry()/sync_close(). Short (8.3) names. */
+typedef struct {
+   unsigned char is_dir;   /* 1 = directory, 0 = file            */
+   unsigned long size;     /* file size in bytes (0 for dirs)    */
+   char          name[16]; /* 0-terminated 8.3 name              */
+} sync_dirent_t;
+
+/* Read the next entry from an open directory handle into out.
+ * Returns 1 on success, 0 at end of directory. */
+extern unsigned char  sync_readdir_entry(unsigned char handle, sync_dirent_t *out);
+
+/* These macros collide with the C library's fopen/fread/... and dirent's
+ * readdir, so syncsys.c (which implements the wrappers and includes those
+ * headers) defines SYNCSYS_NO_MACROS to pull in only the types/prototypes. */
+#ifndef SYNCSYS_NO_MACROS
 #define fopen(fn, mode)  sync_open((const char *)(fn), (unsigned char)(mode))
 #define opendir(p)       sync_opendir((const char *)(p))
 #define fclose(h)        sync_close((unsigned char)(h))
 #define fread(h, b, n)   sync_read((unsigned char)(h), (void *)(b), (unsigned short)(n))
 #define fwrite(h, b, n)  sync_write((unsigned char)(h), (void *)(b), (unsigned short)(n))
 #define readdir(h, b)    sync_readdir((unsigned char)(h), (void *)(b))
+#endif
 
 /* --- Next hardware registers ------------------------------------------- */
 extern unsigned char readnextreg(unsigned char reg);

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -316,6 +316,7 @@ import rc_backgrounds
 # --- Extracted modules (refactored out of this file) ------------------
 from zxnu_config import *
 from zxnu_workers import *
+from zxnu_remote_explorer import RemoteExplorerWidget
 from zxnu_media import *
 from zxnu_gallery import *
 import zxnu_itchio
@@ -10750,12 +10751,175 @@ class MainWindow(QMainWindow):
             "Requires the optional 'pygame-ce' package.")
         self.nextsync_container_log_and_sync_buttons.addWidget(self.nextsync_pygame_button)
 
+        # Flip the log window into a dual-pane remote file explorer (local <-> Next)
+        # driven by ".sync4 -listen". Built lazily the first time it is switched on.
+        self.nextsync_remote_button = QPushButton("🗂 Remote Explorer")
+        self.nextsync_remote_button.setCheckable(True)
+        self.nextsync_remote_button.setToolTip(
+            "Turn the log window into a dual-pane file explorer (local <-> Next).\n"
+            "Run '.sync4 -listen' on your Next, then transfer files with ->: / :<-,\n"
+            "drag & drop, or the right-click menu (New Folder / Delete).")
+        self.nextsync_container_log_and_sync_buttons.addWidget(self.nextsync_remote_button)
+
         # Stack: page 0 = the classic list log, page 1 = the retro pygame log
         # (built lazily the first time the user switches it on).
         self.nextsync_log_stack = QStackedWidget(self)
         self.nextsync_log_stack.setMinimumHeight(NEXTSYNC_UI_HEIGTH)
         self.nextsync_log_stack.addWidget(self.nextsync_log)
         self.nextsync_container_log_and_sync_buttons.addWidget(self.nextsync_log_stack)
+
+        # --- remote file explorer (dual-pane) ------------------------------
+        self._re_widget = None
+        self._re_thread = None
+        self._re_stop = None
+        self._re_queue = None
+        self._re_sig = None
+        self._re_running = False
+        self._re_pulse_timer = None
+
+        def _re_enqueue(cmd):
+            if self._re_queue is not None:
+                self._re_queue.put(cmd)
+
+        def _nextsync_build_remote_explorer():
+            if self._re_widget is not None:
+                return self._re_widget
+            start_dir = configuration_dictionary.get(SETTING_NEXTSYNC_EXPLORERPATH) or None
+            widget = RemoteExplorerWidget(
+                _re_enqueue, local_start_dir=start_dir,
+                log=lambda s: add_nextsync_log_window(str(s)))
+            self._re_widget = widget
+            self.nextsync_log_stack.addWidget(widget)
+            return widget
+
+        # Soft green "breathing" pulse on the running indicator (same idea as the
+        # SD-card transfer-arrow pulse) so it's obvious the server is live.
+        def _re_start_play_pulse():
+            _re_stop_play_pulse()
+            steps = 22
+            phase = {"n": 0}
+
+            def _tick():
+                phase["n"] = (phase["n"] + 1) % (2 * steps)
+                pos = phase["n"]
+                tri = pos / steps if pos <= steps else (2 * steps - pos) / steps
+                a = int(70 + 150 * tri)
+                try:
+                    self.nextsync_re_play_label.setStyleSheet(
+                        "QLabel { color: #eafff0; font-weight: bold; padding: 4px 10px;"
+                        " border-radius: 6px;"
+                        f" background-color: rgba(46,204,113,{a});"
+                        f" border: 1px solid rgba(46,204,113,{min(a + 60, 255)}); }}")
+                except RuntimeError:
+                    pass
+            timer = QTimer(self)
+            timer.setInterval(55)
+            timer.timeout.connect(_tick)
+            timer.start()
+            self._re_pulse_timer = timer
+
+        def _re_stop_play_pulse():
+            if self._re_pulse_timer is not None:
+                self._re_pulse_timer.stop()
+                self._re_pulse_timer = None
+            try:
+                self.nextsync_re_play_label.setStyleSheet("")
+            except RuntimeError:
+                pass
+
+        def _nextsync_start_listen_server():
+            if self._re_running:
+                return
+            # Can't run the listen server while a normal sync is in progress.
+            t = getattr(self, "_nextsync_thread", None)
+            if t is not None and t.is_alive():
+                add_nextsync_log_window("Stop the running sync before starting the remote server.")
+                return
+            widget = self._re_widget or _nextsync_build_remote_explorer()
+            import queue as _queue_mod
+            self._re_queue = _queue_mod.Queue()
+            self._re_stop = threading.Event()
+            self._re_sig = RemoteExplorerSignals()
+            self._re_sig.connected.connect(widget.on_connected)
+            self._re_sig.disconnected.connect(widget.on_disconnected)
+            self._re_sig.listing.connect(widget.on_listing)
+            self._re_sig.got.connect(widget.on_got)
+            self._re_sig.put_done.connect(widget.on_put_done)
+            self._re_sig.op_done.connect(widget.on_op_done)
+            self._re_sig.log.connect(lambda s: add_nextsync_log_window(str(s)))
+            self._re_sig.error.connect(lambda s: add_nextsync_log_window("Remote explorer: " + str(s)))
+            self._re_thread = threading.Thread(
+                target=run_remote_listen_server,
+                args=(self._re_sig, self._re_queue, self._re_stop),
+                daemon=True)
+            self._re_thread.start()
+            self._re_running = True
+            self.nextsync_re_start_button.setText("⏹ Stop NextSync server")
+            self.nextsync_re_play_label.setText("▶  NextSync server running")
+            self.nextsync_re_play_label.setVisible(True)
+            _re_start_play_pulse()
+            self._show_toast("NextSync server started",
+                             "Start '.sync4 -listen' on your Next to connect!",
+                             variant="green", duration_ms=5000)
+
+        def _nextsync_stop_listen_server():
+            if self._re_queue is not None:
+                try:
+                    self._re_queue.put(("quit",))
+                except Exception:
+                    pass
+            if self._re_stop is not None:
+                self._re_stop.set()
+            t = self._re_thread
+            if t is not None and t.is_alive():
+                t.join(timeout=2.0)
+            self._re_thread = None
+            self._re_stop = None
+            self._re_queue = None
+            self._re_sig = None
+            self._re_running = False
+            _re_stop_play_pulse()
+            try:
+                self.nextsync_re_start_button.setText("▶ Start NextSync server")
+                self.nextsync_re_play_label.setVisible(False)
+            except RuntimeError:
+                pass
+
+        def _nextsync_re_toggle_server():
+            if self._re_running:
+                _nextsync_stop_listen_server()
+            else:
+                _nextsync_start_listen_server()
+        self._nextsync_re_toggle_server = _nextsync_re_toggle_server
+
+        def _nextsync_toggle_remote_explorer(checked):
+            if checked:
+                widget = _nextsync_build_remote_explorer()
+                self.nextsync_log_stack.setCurrentWidget(widget)
+                self.nextsync_remote_button.setText("🗂 Show Log")
+                # Swap the normal sync controls for the dedicated server control.
+                self.nextsync_prepare_server.setVisible(False)
+                self.nextsync_start_server.setVisible(False)
+                self.nextsync_cancel_server.setVisible(False)
+                self.nextsync_sync_mode_group.setVisible(False)
+                self.nextsync_slowtransfer_checkbox.setVisible(False)
+                self.nextsync_re_start_button.setVisible(True)
+                self.nextsync_re_play_label.setVisible(self._re_running)
+                add_nextsync_log_window(
+                    "Remote explorer: click 'Start NextSync server', then run '.sync4 -listen' on your Next.")
+            else:
+                _nextsync_stop_listen_server()
+                self.nextsync_log_stack.setCurrentWidget(self.nextsync_log)
+                self.nextsync_remote_button.setText("🗂 Remote Explorer")
+                self.nextsync_re_start_button.setVisible(False)
+                self.nextsync_re_play_label.setVisible(False)
+                # Restore the normal sync controls.
+                self.nextsync_prepare_server.setVisible(True)
+                self.nextsync_sync_mode_group.setVisible(True)
+                self.nextsync_slowtransfer_checkbox.setVisible(True)
+                nextsync_hide_start_cancel_buttons()
+
+        self.nextsync_remote_button.toggled.connect(_nextsync_toggle_remote_explorer)
 
         def _nextsync_build_retro_log():
             if self._nextsync_retro_log is not None:
@@ -10912,6 +11076,18 @@ class MainWindow(QMainWindow):
 
 
         self.nextsync_container_log_and_sync_buttons.addWidget(self.nextsync_start_server)
+
+        # Remote-explorer server control (shown only in Remote Explorer mode,
+        # in place of the Prepare/Start buttons and the Sync mode group).
+        self.nextsync_re_start_button = QPushButton("▶ Start NextSync server", self)
+        self.nextsync_re_start_button.setVisible(False)
+        self.nextsync_re_start_button.clicked.connect(self._nextsync_re_toggle_server)
+        self.nextsync_container_log_and_sync_buttons.addWidget(self.nextsync_re_start_button)
+
+        self.nextsync_re_play_label = QLabel("▶  NextSync server running", self)
+        self.nextsync_re_play_label.setAlignment(Qt.AlignCenter)
+        self.nextsync_re_play_label.setVisible(False)
+        self.nextsync_container_log_and_sync_buttons.addWidget(self.nextsync_re_play_label)
 
 
 

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -1,0 +1,414 @@
+"""Remote file-explorer widget for the NextSync tab.
+
+A dual-pane file manager modelled on the SD Card Utility tab, but the right
+("Next") pane is driven by the NextSync ``.sync4 -listen`` protocol
+(zxnu_workers.run_remote_listen_server) instead of hdfmonkey:
+
+    [ local file explorer ] [ ->:  :<- ] [ Next file explorer ]
+
+Commands are pushed onto a queue.Queue the listen worker drains; results arrive
+through RemoteExplorerSignals and are applied here on the UI thread.
+"""
+
+import os
+import posixpath
+
+from PySide6.QtCore import Qt, QDir, QModelIndex, QMimeData, QUrl, QSize
+from PySide6.QtGui import QDrag, QStandardItem, QStandardItemModel
+from PySide6.QtWidgets import (
+    QAbstractItemView, QFileSystemModel, QGridLayout, QHBoxLayout, QInputDialog,
+    QLabel, QMenu, QMessageBox, QPushButton, QStyle, QTreeView, QVBoxLayout,
+    QWidget,
+)
+
+# Roles carrying the remote entry's full posix path and its directory flag.
+RE_PATH_ROLE = Qt.UserRole + 1
+RE_ISDIR_ROLE = Qt.UserRole + 2
+
+ARROW_BTN_W = 40
+
+
+def _human_size(n):
+    if n is None:
+        return ""
+    for unit in ("B", "K", "M", "G"):
+        if n < 1024 or unit == "G":
+            return f"{n}{unit}" if unit == "B" else f"{n/1024:.0f}{unit}"
+        n /= 1024
+    return str(n)
+
+
+def _posix_join(base, name):
+    base = base or "/"
+    if not base.endswith("/"):
+        base += "/"
+    return posixpath.normpath(base + name)
+
+
+class RemoteExplorerWidget(QWidget):
+    """Dual-pane local <-> Next file manager.
+
+    enqueue(cmd_tuple) is the single channel to the listen worker; the host wires
+    the worker's signals to on_connected/on_disconnected/on_listing/on_got/
+    on_put_done/on_op_done.  `log` is an optional callable(str) for status lines.
+    """
+
+    def __init__(self, enqueue, local_start_dir=None, log=None, parent=None):
+        super().__init__(parent)
+        self._enqueue = enqueue
+        self._log = log or (lambda s: None)
+        self._cwd = "/"                      # current Next directory
+        self._connected = False
+
+        # ---- left: local file explorer ------------------------------------
+        self.local_model = QFileSystemModel(self)
+        self.local_model.setRootPath("")
+        self.local_view = QTreeView(self)
+        self.local_view.setModel(self.local_model)
+        self.local_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.local_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.local_view.setUniformRowHeights(True)
+        self.local_view.setSortingEnabled(True)
+        for col in (1, 2, 3):
+            self.local_view.hideColumn(col)      # keep just the name column
+        self.local_view.setDragEnabled(True)
+        self.local_view.setAcceptDrops(True)
+        self.local_view.setDropIndicatorShown(True)
+        self.local_view.doubleClicked.connect(self._local_double_clicked)
+        self.local_view.dragEnterEvent = self._local_drag_enter
+        self.local_view.dragMoveEvent = self._local_drag_enter
+        self.local_view.dropEvent = self._local_drop
+
+        self.local_path_label = QLabel(self)
+        self.local_path_label.setToolTip("Local folder (double-click a folder to enter, Up to go back)")
+
+        start = local_start_dir if (local_start_dir and os.path.isdir(local_start_dir)) \
+            else QDir.homePath()
+        self._set_local_dir(start)
+
+        local_up = QPushButton("Up", self)
+        local_up.setMaximumWidth(48)
+        local_up.clicked.connect(self._local_up)
+        local_bar = QHBoxLayout()
+        local_bar.setContentsMargins(0, 0, 0, 0)
+        local_bar.addWidget(local_up)
+        local_bar.addWidget(self.local_path_label, 1)
+
+        local_box = QVBoxLayout()
+        local_box.setContentsMargins(0, 0, 0, 0)
+        local_box.setSpacing(2)
+        local_box.addLayout(local_bar)
+        local_box.addWidget(self.local_view)
+        local_container = QWidget(self)
+        local_container.setLayout(local_box)
+
+        # ---- centre: transfer buttons -------------------------------------
+        self.btn_to_next = QPushButton("->:", self)
+        self.btn_to_next.setMaximumWidth(ARROW_BTN_W)
+        self.btn_to_next.setToolTip("Upload the selected local file(s) to the Next folder (put)")
+        self.btn_to_next.clicked.connect(self._put_selected)
+
+        self.btn_to_local = QPushButton(":<-", self)
+        self.btn_to_local.setMaximumWidth(ARROW_BTN_W)
+        self.btn_to_local.setToolTip("Download the selected Next item(s) to the local folder (get)")
+        self.btn_to_local.clicked.connect(self._get_selected)
+
+        centre_box = QVBoxLayout()
+        centre_box.setAlignment(Qt.AlignCenter)
+        centre_box.addWidget(self.btn_to_next)
+        centre_box.addWidget(self.btn_to_local)
+        centre_container = QWidget(self)
+        centre_container.setLayout(centre_box)
+
+        # ---- right: Next file explorer ------------------------------------
+        self._dir_icon = self.style().standardIcon(QStyle.StandardPixmap.SP_DirIcon)
+        self._file_icon = self.style().standardIcon(QStyle.StandardPixmap.SP_FileIcon)
+
+        self.next_model = QStandardItemModel(self)
+        self.next_model.setHorizontalHeaderLabels(["Name", "Size"])
+        self.next_view = QTreeView(self)
+        self.next_view.setModel(self.next_model)
+        self.next_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.next_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.next_view.setUniformRowHeights(True)
+        self.next_view.setRootIsDecorated(False)
+        self.next_view.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.next_view.customContextMenuRequested.connect(self._next_context_menu)
+        self.next_view.doubleClicked.connect(self._next_double_clicked)
+        self.next_view.setAcceptDrops(True)
+        self.next_view.setDragEnabled(True)
+        self.next_view.setDropIndicatorShown(True)
+        self.next_view.dragEnterEvent = self._next_drag_enter
+        self.next_view.dragMoveEvent = self._next_drag_enter
+        self.next_view.dropEvent = self._next_drop
+        self.next_view.startDrag = self._next_start_drag
+
+        self.next_path_label = QLabel("Next: (not connected)", self)
+        next_up = QPushButton("Up", self)
+        next_up.setMaximumWidth(48)
+        next_up.clicked.connect(self._next_up)
+        refresh = QPushButton("Refresh", self)
+        refresh.setMaximumWidth(72)
+        refresh.clicked.connect(self.refresh)
+        next_bar = QHBoxLayout()
+        next_bar.setContentsMargins(0, 0, 0, 0)
+        next_bar.addWidget(next_up)
+        next_bar.addWidget(refresh)
+        next_bar.addWidget(self.next_path_label, 1)
+
+        next_box = QVBoxLayout()
+        next_box.setContentsMargins(0, 0, 0, 0)
+        next_box.setSpacing(2)
+        next_box.addLayout(next_bar)
+        next_box.addWidget(self.next_view)
+
+        # Next-side toolbar: New Folder / Delete
+        self.btn_new_folder = QPushButton("New Folder", self)
+        self.btn_new_folder.clicked.connect(self._new_folder)
+        self.btn_delete = QPushButton("Delete", self)
+        self.btn_delete.clicked.connect(self._delete_selected)
+        next_tools = QHBoxLayout()
+        next_tools.setContentsMargins(0, 0, 0, 0)
+        next_tools.addWidget(self.btn_new_folder)
+        next_tools.addWidget(self.btn_delete)
+        next_tools.addStretch(1)
+        next_box.addLayout(next_tools)
+        next_container = QWidget(self)
+        next_container.setLayout(next_box)
+
+        # ---- assemble the 3-column grid -----------------------------------
+        grid = QGridLayout(self)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.addWidget(local_container, 0, 0)
+        grid.addWidget(centre_container, 0, 1)
+        grid.addWidget(next_container, 0, 2)
+        grid.setColumnStretch(0, 1)
+        grid.setColumnStretch(2, 1)
+        grid.setRowStretch(0, 1)
+
+        self._set_connected(False)
+
+    # ==================================================================
+    #  connection state
+    # ==================================================================
+    def _set_connected(self, on):
+        self._connected = on
+        for w in (self.btn_to_next, self.btn_to_local, self.btn_new_folder,
+                  self.btn_delete, self.next_view):
+            w.setEnabled(on)
+        if not on:
+            self.next_model.removeRows(0, self.next_model.rowCount())
+            self.next_path_label.setText("Next: (waiting for .sync4 -listen …)")
+
+    # ---- worker signal slots (UI thread) ------------------------------
+    def on_connected(self):
+        self._set_connected(True)
+        self._cwd = "/"
+        self.refresh()
+
+    def on_disconnected(self):
+        self._set_connected(False)
+
+    def on_listing(self, path, entries):
+        self._cwd = path if path.startswith("/") else "/" + path
+        self.next_path_label.setText(f"Next: {self._cwd}")
+        self.next_model.removeRows(0, self.next_model.rowCount())
+        if self._cwd not in ("/", ""):
+            self._add_next_row("..", True, None, is_updir=True)
+        for is_dir, size, name in entries:
+            if name in (".", ".."):
+                continue
+            self._add_next_row(name, is_dir, size)
+        self.next_view.resizeColumnToContents(0)
+
+    def on_got(self, remote, local_path):
+        self._log(f"Downloaded {remote} -> {local_path}")
+        self.local_model.setRootPath(self.local_model.rootPath())  # nudge a refresh
+
+    def on_put_done(self, ok, remote):
+        self._log(f"Uploaded -> {remote}" if ok else f"Upload failed: {remote}")
+        self.refresh()
+
+    def on_op_done(self, ok, op, path):
+        self._log(f"{op} {path}: {'ok' if ok else 'FAILED'}")
+        self.refresh()
+
+    # ==================================================================
+    #  Next pane
+    # ==================================================================
+    def _add_next_row(self, name, is_dir, size, is_updir=False):
+        name_item = QStandardItem(self._dir_icon if is_dir else self._file_icon, name)
+        name_item.setData(".." if is_updir else _posix_join(self._cwd, name), RE_PATH_ROLE)
+        name_item.setData(bool(is_dir), RE_ISDIR_ROLE)
+        size_item = QStandardItem("" if is_dir else _human_size(size))
+        self.next_model.appendRow([name_item, size_item])
+
+    def refresh(self):
+        if self._connected:
+            self._enqueue(("ls", self._cwd))
+
+    def _next_up(self):
+        if self._cwd not in ("/", ""):
+            self._cwd = posixpath.dirname(self._cwd.rstrip("/")) or "/"
+            self.refresh()
+
+    def _next_double_clicked(self, index):
+        item = self.next_model.itemFromIndex(index.siblingAtColumn(0))
+        if item is None:
+            return
+        if item.data(RE_PATH_ROLE) == "..":
+            self._next_up()
+            return
+        if bool(item.data(RE_ISDIR_ROLE)):
+            self._cwd = item.data(RE_PATH_ROLE)
+            self.refresh()
+
+    def _selected_next_entries(self):
+        out = []
+        for ix in self.next_view.selectionModel().selectedRows(0):
+            item = self.next_model.itemFromIndex(ix)
+            if item is None:
+                continue
+            path = item.data(RE_PATH_ROLE)
+            if not path or path == "..":
+                continue
+            out.append((path, bool(item.data(RE_ISDIR_ROLE))))
+        return out
+
+    def _next_context_menu(self, pos):
+        if not self._connected:
+            return
+        menu = QMenu(self)
+        act_new = menu.addAction("New Folder…")
+        act_get = menu.addAction("Download (:<-)")
+        act_del = menu.addAction("Delete")
+        act_ref = menu.addAction("Refresh")
+        chosen = menu.exec(self.next_view.viewport().mapToGlobal(pos))
+        if chosen == act_new:
+            self._new_folder()
+        elif chosen == act_get:
+            self._get_selected()
+        elif chosen == act_del:
+            self._delete_selected()
+        elif chosen == act_ref:
+            self.refresh()
+
+    def _new_folder(self):
+        if not self._connected:
+            return
+        name, ok = QInputDialog.getText(self, "New Folder", f"New folder in {self._cwd}:")
+        if ok and name.strip():
+            self._enqueue(("mkdir", _posix_join(self._cwd, name.strip())))
+
+    def _delete_selected(self):
+        entries = self._selected_next_entries()
+        if not entries:
+            return
+        names = "\n".join(p for p, _ in entries)
+        if QMessageBox.question(self, "Delete", f"Delete on the Next?\n\n{names}") != QMessageBox.Yes:
+            return
+        for path, is_dir in entries:
+            self._enqueue(("rmdir" if is_dir else "rm", path))
+
+    # ==================================================================
+    #  transfers
+    # ==================================================================
+    def _get_selected(self):
+        entries = self._selected_next_entries()
+        if not entries:
+            return
+        dest = self._local_dir()
+        for path, _is_dir in entries:
+            self._enqueue(("get", path, dest))
+        self._log(f"Downloading {len(entries)} item(s) to {dest} …")
+
+    def _put_selected(self):
+        files = [p for p in self._selected_local_paths() if os.path.isfile(p)]
+        if not files:
+            self._log("Select local file(s) to upload (folders: drag or one at a time).")
+            return
+        self._put_files(files)
+
+    def _put_files(self, files):
+        base = self._cwd if self._cwd.endswith("/") else self._cwd + "/"
+        for f in files:
+            self._enqueue(("put", f, base))
+        self._log(f"Uploading {len(files)} file(s) to {self._cwd} …")
+
+    # ==================================================================
+    #  local pane
+    # ==================================================================
+    def _set_local_dir(self, path):
+        self.local_view.setRootIndex(self.local_model.index(path))
+        self.local_path_label.setText(path)
+
+    def _local_dir(self):
+        return self.local_model.filePath(self.local_view.rootIndex()) or QDir.homePath()
+
+    def _local_up(self):
+        cur = self._local_dir()
+        parent = os.path.dirname(cur.rstrip("/\\"))
+        if parent and os.path.isdir(parent):
+            self._set_local_dir(parent)
+
+    def _local_double_clicked(self, index):
+        path = self.local_model.filePath(index)
+        if os.path.isdir(path):
+            self._set_local_dir(path)
+
+    def _selected_local_paths(self):
+        out = []
+        for ix in self.local_view.selectionModel().selectedRows(0):
+            p = self.local_model.filePath(ix)
+            if p:
+                out.append(p)
+        return out
+
+    # ==================================================================
+    #  drag & drop
+    # ==================================================================
+    def _next_drag_enter(self, event):
+        if self._connected and event.mimeData().hasUrls():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def _next_drop(self, event):
+        paths = [u.toLocalFile() for u in event.mimeData().urls()
+                 if u.isLocalFile() and os.path.isfile(u.toLocalFile())]
+        if not paths:
+            event.ignore()
+            return
+        event.acceptProposedAction()
+        self._put_files(paths)
+
+    def _next_start_drag(self, supported):
+        # Drag Next entries to the local pane / OS to download them.
+        entries = self._selected_next_entries()
+        if not entries:
+            return
+        # Represented as text; the local pane treats a drop as "download here".
+        mime = QMimeData()
+        mime.setData("application/x-zxnu-next-entries",
+                     "\n".join(f"{'D' if d else 'F'}\t{p}" for p, d in entries).encode())
+        drag = QDrag(self.next_view)
+        drag.setMimeData(mime)
+        drag.exec(Qt.CopyAction)
+
+    def _local_drag_enter(self, event):
+        if event.mimeData().hasFormat("application/x-zxnu-next-entries"):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def _local_drop(self, event):
+        data = event.mimeData().data("application/x-zxnu-next-entries")
+        if not data:
+            event.ignore()
+            return
+        event.acceptProposedAction()
+        dest = self._local_dir()
+        for line in bytes(data).decode(errors="replace").splitlines():
+            if "\t" in line:
+                _flag, path = line.split("\t", 1)
+                self._enqueue(("get", path, dest))

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -2,7 +2,11 @@
 
 Extracted from zx-next-unite.py."""
 
+import os
+import queue
+import socket
 import threading
+import time
 from PySide6.QtCore import (
     QObject, QPoint, QRect, QRunnable, QSize, QSortFilterProxyModel, QTimer,
     Qt, Signal, Slot,
@@ -159,6 +163,293 @@ class NextSyncSignals(QObject):
     status   = Signal(str)   # single-line status message
     finished = Signal()      # emitted when the job thread exits
     cancelled = Signal()     # emitted when job stopped due to cancel request
+
+
+class RemoteExplorerSignals(QObject):
+    """Signals marshalling results of the NextSync ".sync4 -listen" remote file
+    server back to the UI thread. The session runs in a worker thread; the UI
+    feeds it commands via a queue and receives results through these."""
+    connected    = Signal()               # a Next connected in -listen mode
+    disconnected = Signal()               # the listen session ended
+    # (path, entries) where entries is a list of (is_dir: bool, size: int, name: str)
+    listing      = Signal(str, object)    # result of an "ls"
+    got          = Signal(str, str)       # (remote, local_path) a "get" finished
+    put_done     = Signal(bool, str)      # (ok, remote) a "put" finished
+    op_done      = Signal(bool, str, str) # (ok, op, path) mkdir/rmdir/rm result
+    log          = Signal(str)            # a human-readable log line
+    error        = Signal(str)            # a human-readable error
+
+
+def _re_checksums(payload):
+    c0 = c1 = 0
+    for x in payload:
+        c0 = (c0 ^ x) & 0xff
+        c1 = (c1 + c0) & 0xff
+    return c0, c1
+
+
+def _re_sendpacket(conn, payload, pktno):
+    c0, c1 = _re_checksums(payload)
+    conn.sendall((len(payload) + 5).to_bytes(2, "big") + bytes(payload) +
+                 bytes([c0, c1, pktno & 0xff]))
+
+
+def _re_recv_exact(conn, n):
+    buf = b''
+    while len(buf) < n:
+        chunk = conn.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def _re_recv_block(conn):
+    hdr = _re_recv_exact(conn, 2)
+    if hdr is None:
+        return None
+    total = (hdr[0] << 8) | hdr[1]
+    if total < 5 or total > 4096:
+        return None
+    rest = _re_recv_exact(conn, total - 2)
+    if rest is None:
+        return None
+    payload, (cs0, cs1) = rest[:-3], (rest[-3], rest[-2])
+    c0, c1 = _re_checksums(payload)
+    if c0 != cs0 or c1 != cs1:
+        return 'BADCS'
+    return (payload, rest[-1])
+
+
+def _re_recv_reply(conn, handler):
+    """Read the framed blocks the Next pushes in reply to a command, acking each
+    with "Ok". handler(payload) returns True to stop. Returns True on clean
+    completion, False on drop."""
+    expected = 0
+    while True:
+        blk = _re_recv_block(conn)
+        if blk is None:
+            return False
+        if blk == 'BADCS':
+            _re_sendpacket(conn, b"Resend", expected)
+            continue
+        payload, pktno = blk
+        if pktno == ((expected - 1) & 0xff):
+            _re_sendpacket(conn, b"Ok", pktno)
+            continue
+        if pktno != expected:
+            _re_sendpacket(conn, b"Err seq", pktno)
+            return False
+        stop = handler(payload)
+        _re_sendpacket(conn, b"Ok", pktno)
+        expected = (expected + 1) & 0xff
+        if stop:
+            return True
+
+
+def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
+                             max_payload=1024):
+    """Run the NextSync ``.sync4 -listen`` remote file server in a worker thread.
+
+    Waits for a Next running ``.sync4 -listen`` to connect, then drives it from
+    commands pulled off ``cmd_queue`` (a queue.Queue), emitting results through
+    ``sig`` (a RemoteExplorerSignals). Commands are tuples:
+        ("ls",    remote_path)
+        ("get",   remote_path, local_dest_dir)
+        ("put",   local_file,  remote_path)
+        ("mkdir", remote_path)
+        ("rmdir", remote_path)
+        ("rm",    remote_path)
+        ("quit",)
+    ``stop_event`` (threading.Event) ends the session/thread.
+
+    This is the app-side twin of nextsync4.py's listen_session: same wire
+    protocol, but driven by the UI queue and reporting via Qt signals instead of
+    a console CLI. It never touches the Sync3/Sync4 sync paths.
+    """
+    def log(msg):
+        sig.log.emit(msg)
+
+    srv = None
+    try:
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("", port))
+        srv.listen()
+        srv.settimeout(1.0)
+        log(f"Remote explorer: waiting for '.sync4 -listen' on port {port}…")
+
+        conn = None
+        while not stop_event.is_set():
+            try:
+                conn, addr = srv.accept()
+                break
+            except socket.timeout:
+                continue
+        if conn is None:
+            return
+
+        with conn:
+            conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            # The Next opens the session with the "Listen" handshake keyword.
+            data = conn.recv(1024)
+            if data != b"Listen":
+                sig.error.emit("Connected client did not request -listen mode.")
+                return
+            _re_sendpacket(conn, b"Listening", 0)
+            log(f"Remote explorer: connected to {addr[0]}")
+            sig.connected.emit()
+
+            put_data = b''
+            put_ofs = 0
+            put_pkt = 0
+            last_packet = b''
+            pending = None   # the command awaiting its pushed reply
+
+            while not stop_event.is_set():
+                try:
+                    conn.settimeout(1.0)
+                    data = conn.recv(1024)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+                if not data:
+                    break
+
+                if data == b"Poll":
+                    try:
+                        cmd = cmd_queue.get_nowait()
+                    except queue.Empty:
+                        _re_sendpacket(conn, b"I", 0)   # idle
+                        continue
+                    op = cmd[0]
+                    if op == "quit":
+                        _re_sendpacket(conn, b"Q", 0)
+                        break
+                    elif op == "ls":
+                        path = cmd[1] or "."
+                        entries = []
+
+                        def _h(payload, _e=entries):
+                            o = payload[0:1]
+                            if o == b'E':
+                                return True
+                            if o == b'D':
+                                i = 1
+                                while i + 6 <= len(payload):
+                                    flags = payload[i]
+                                    size = (payload[i+1] | (payload[i+2] << 8) |
+                                            (payload[i+3] << 16) | (payload[i+4] << 24))
+                                    nl = payload[i+5]
+                                    name = payload[i+6:i+6+nl].decode(errors='replace')
+                                    i += 6 + nl
+                                    _e.append((bool(flags & 1), size, name))
+                            return False
+                        _re_sendpacket(conn, b"L" + path.encode(), 0)
+                        if _re_recv_reply(conn, _h):
+                            entries.sort(key=lambda e: (0 if e[0] else 1, e[2].lower()))
+                            sig.listing.emit(path, entries)
+                        else:
+                            sig.error.emit(f"ls {path}: connection dropped")
+                    elif op == "get":
+                        remote, dest_dir = cmd[1], cmd[2]
+                        os.makedirs(dest_dir, exist_ok=True)
+                        st = {'f': None, 'name': None, 'bytes': 0, 'last': None}
+
+                        def _h(payload, _st=st, _dd=dest_dir):
+                            o = payload[0:1]
+                            if o == b'N':
+                                namelen = payload[5] if len(payload) > 5 else 0
+                                name = payload[6:6+namelen].decode(errors='replace')
+                                safe = os.path.basename(name.replace('\\', '/').rstrip('/')) or "received.bin"
+                                path = os.path.join(_dd, safe)
+                                if _st['f']:
+                                    _st['f'].close()
+                                _st['f'] = open(path, 'wb')
+                                _st['name'] = name
+                                _st['last'] = path
+                                _st['bytes'] = 0
+                            elif o == b'D':
+                                if _st['f']:
+                                    _st['f'].write(payload[1:])
+                                    _st['bytes'] += len(payload) - 1
+                            elif o == b'E':
+                                if _st['f']:
+                                    _st['f'].close()
+                                    _st['f'] = None
+                            elif o == b'B':
+                                if _st['f']:
+                                    _st['f'].close()
+                                    _st['f'] = None
+                                return True
+                            return False
+                        _re_sendpacket(conn, b"G" + remote.encode(), 0)
+                        ok = _re_recv_reply(conn, _h)
+                        if st['f']:
+                            st['f'].close()
+                        if ok and st['last']:
+                            sig.got.emit(remote, st['last'])
+                        else:
+                            sig.error.emit(f"get {remote}: failed")
+                    elif op == "put":
+                        local, remote = cmd[1], cmd[2]
+                        try:
+                            with open(local, 'rb') as fh:
+                                put_data = fh.read()
+                        except OSError as ex:
+                            sig.error.emit(f"put {local}: {ex}")
+                            continue
+                        put_ofs = 0
+                        put_pkt = 0
+                        if remote.endswith('/') or remote.endswith('\\'):
+                            remote = remote + os.path.basename(local)
+                        pending = ("put", remote)
+                        _re_sendpacket(conn, b"P" + remote.encode(), 0)
+                        # the Next now pulls the bytes via "Get" (served below)
+                    elif op in ("mkdir", "rmdir", "rm"):
+                        opc = {"mkdir": b"M", "rmdir": b"R", "rm": b"X"}[op]
+                        path = cmd[1]
+                        res = {'ok': None}
+
+                        def _h(payload, _r=res):
+                            _r['ok'] = (payload[0:1] == b'O')
+                            return True
+                        _re_sendpacket(conn, opc + path.encode(), 0)
+                        if _re_recv_reply(conn, _h):
+                            sig.op_done.emit(bool(res['ok']), op, path)
+                        else:
+                            sig.error.emit(f"{op} {path}: connection dropped")
+
+                elif data == b"Get" or data == b"Gee":
+                    n = min(max_payload, len(put_data) - put_ofs)
+                    last_packet = put_data[put_ofs:put_ofs + n]
+                    _re_sendpacket(conn, last_packet, put_pkt)
+                    put_ofs += n
+                    put_pkt += 1
+                    if put_ofs >= len(put_data) and pending and pending[0] == "put":
+                        sig.put_done.emit(True, pending[1])
+                        pending = None
+                elif data == b"Retry":
+                    _re_sendpacket(conn, last_packet, (put_pkt - 1) & 0xff)
+                elif data == b"Restart":
+                    put_ofs = 0
+                    put_pkt = 0
+                    _re_sendpacket(conn, b"Back", 0)
+                elif data == b"Bye":
+                    _re_sendpacket(conn, b"Later", 0)
+                    break
+                else:
+                    _re_sendpacket(conn, b"I", 0)   # keep the Next polling
+    except OSError as ex:
+        sig.error.emit(f"Remote explorer server error: {ex}")
+    finally:
+        if srv is not None:
+            try:
+                srv.close()
+            except OSError:
+                pass
+        sig.disconnected.emit()
 
 
 class HdfTaskSignals(QObject):


### PR DESCRIPTION
## What & why

Adds a **remote file explorer** for the NextSync tab: browse the ZX Spectrum Next's filesystem from the PC and transfer files both ways over the Sync protocol — a dual-pane manager modelled on the SD Card Utility tab, but the "Next" side is driven by a new `.sync4 -listen` mode instead of hdfmonkey.

**Fully backward compatible.** Everything is gated behind a *new* `"Listen"` handshake keyword. `Sync3` (PC→Next), `Sync4` (`-send`, Next→PC), and the block framing/checksums are untouched, and an un-upgraded dot or server never emits or expects `"Listen"`.

## Dot command — `nextsync/sync/z88dk/`
- **`.sync4 -listen`** runs the Next as a small remote file server the PC drives: it polls for commands and executes them with esxDOS — `ls`, `get`, `put`, `mkdir`, `rmdir`, `rm`, `quit`. `get` reuses `send_file`/`send_dir`; `put` reuses the download path; `ls` streams packed `[flags][size][name]` entries.
- New esxDOS wrappers `sync_rmdir` / `sync_unlink` / `sync_readdir_entry` (with size).
- **`-v`** echoes received commands and the file-create steps on the Next screen (used to diagnose a subdirectory-`put` issue).

## Server — `nextsync/sync/server/nextsync4.py`
- `listen_session()` — `"Listen"` handshake + a console CLI driving the same commands.
- `-v` verbose flag (per-packet logging is now **off by default**; it was constant noise in `-listen`).
- `put` into a directory (`put file /dir/`) keeps the local basename → `/dir/file`.
- Guarded module entry (`if __name__ == "__main__"`) so it's importable by tests.
- **Tests:** `test_listen.py` and `test_remote_listen.py` drive a mock Next over a socket and cover `ls/get/put/mkdir/rmdir/rm` for both the CLI server and the app worker.

## App — ZX-Next-Unite
- `zxnu_workers.run_remote_listen_server` + `RemoteExplorerSignals`: a non-modal listen session driven by a command queue, reporting results via Qt signals.
- `zxnu_remote_explorer.RemoteExplorerWidget`: SD-card-style dual-pane (local ⇄ Next) with `->:` / `:<-` transfer buttons, two-way drag & drop, folder navigation, and New Folder / Delete.
- **NextSync tab:** a **Remote Explorer** toggle flips the log window into the dual-pane. In that mode the Prepare/Start buttons and the Sync-mode group are hidden and replaced by a dedicated **Start / Stop NextSync server** button, a 5-second *"run `.sync4 -listen` on your Next"* toast, and a pulsing green running indicator.

## Testing
- `test_listen.py` / `test_remote_listen.py` — **all pass** (ls/get/put/mkdir/rmdir/rm over a mock Next).
- Widget builds + signal slots verified offscreen; the full app launches clean; the Remote-Explorer enter/start/stop/leave flow was driven offscreen and asserts the correct visibility/running/indicator state at each step.
- Live `.sync4 -listen` transfers (`ls`/`get`/`put`/`mkdir`/`rmdir`/`rm`, incl. subdirectory `put`) confirmed on real Next hardware.

No build artifacts are committed (the built `syncdev` is regenerated by `build_dotn.ps1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)