### PR TITLE
App: bump version 8.7.4 -> 8.7.5

### DIFF
--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "8.7.4"
+ZX_NEXT_UNITE_VERSION = "8.7.5"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False


### PR DESCRIPTION
Bumps `ZX_NEXT_UNITE_VERSION` to **8.7.5** — the release that ships the NextSync **remote file explorer** (`.sync4 -listen` dual-pane, merged in #137).

Single-constant change in `zxnu_config.py`; window title, HTTP user-agents, welcome banner and help text all derive from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)