### PR TITLE
NextSync: fix crash when cancelling a traditional sync

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -6652,6 +6652,12 @@ class MainWindow(QMainWindow):
                 nextsync_hide_start_cancel_buttons()
                 t.start()
                 dlg.exec()   # blocks main thread showing the modal dialog
+                # Tear the dialog (and its child spinner QTimer) down on the
+                # event loop now, instead of leaving it in a reference cycle for
+                # Python's GC to collect later — a QTimer firing / a QDialog
+                # being destroyed mid-paint is what triggers the "QBackingStore
+                # ::flush() ... does not have a handle" crash on cancel.
+                dlg.deleteLater()
                 # Ensure pane is in the correct state after dialog closes
                 QTimer.singleShot(0, lambda: (
                     nextsync_hide_start_cancel_buttons(),

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -608,6 +608,12 @@ class HdfProgressDialog(QDialog):
 
     @Slot()
     def _tick_spinner(self):
+        # Never repaint once the dialog is hidden: a tick after accept()/hide()
+        # would schedule an update on a top-level window whose native handle is
+        # already gone, which Qt flushes with the fatal "QBackingStore::flush()
+        # called for QWidgetWindow ... which does not have a handle" and crashes.
+        if not self.isVisible():
+            return
         self._spinner_idx = (self._spinner_idx + 1) % len(self._spinner_frames)
         self._spinner_label.setText(self._spinner_frames[self._spinner_idx])
 
@@ -635,6 +641,15 @@ class HdfProgressDialog(QDialog):
         """Called when the worker confirms it stopped early."""
         self._action_label.setText("Cancelled.")
         self._file_label.setText("")
+
+    def done(self, result):
+        # done() is the single funnel for accept()/reject()/close(), whereas
+        # closeEvent() fires only on close() (not on accept()/reject()). This
+        # dialog is normally dismissed with accept(), so stopping the spinner
+        # timer here — not just in closeEvent — guarantees it can never tick
+        # after the window is hidden and loses its native handle.
+        self._anim_timer.stop()
+        super().done(result)
 
     def closeEvent(self, event):
         self._anim_timer.stop()


### PR DESCRIPTION
## Summary

Hitting **Stop** on the NextSync send progress dialog could crash the app with:

> `QBackingStore::flush() called for QWidgetWindow(..., name="MainWindowClassWindow") which does not have a handle.`

## Root cause

`HdfProgressDialog` runs its spinner on a `QTimer` and only stopped it in `closeEvent()`. The dialog is dismissed via `accept()` (from the finished/cancelled signal), which does **not** fire `closeEvent`, so the timer kept ticking `setText()` → `update()` on the now-hidden top-level dialog, and the dialog lingered in a Python GC cycle. When the GC later destroyed the `QDialog` + its live `QTimer` mid-paint, Qt flushed the unwinding window stack (up to the main window) with a dead native handle → crash.

## Fix

- **`HdfProgressDialog`** (`zxnu_workers.py`): stop `_anim_timer` in `done()` — the single funnel for `accept()`/`reject()`/`close()` — and make `_tick_spinner()` a no-op while the dialog isn't visible.
- **`nextsync_start_server`** (`zx-next-unite.py`): `dlg.deleteLater()` after `exec()` so the dialog and its child timer are torn down deterministically on the event loop, not by a later GC cycle mid-paint.

## Testing

- Both files byte-compile.
- Headless (offscreen) test confirms the real dismissal path: after `accept()` the spinner timer is **stopped** (previously left running), the dialog is hidden, and a forced `_tick_spinner()` while hidden is a **no-op**.

> Note: the live GUI crash couldn't be reproduced in this headless environment; the timer/teardown behavior was verified directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)