### PR TITLE
NextSync Remote Explorer: full-width layout, folder transfers, keys, cut/move, progress+cancel

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -6148,8 +6148,14 @@ class MainWindow(QMainWindow):
             self.treeview.show()
 
         def nextsync_update_root_drive():
-            self.nextsync_treeview.setRootIndex(self.nextsync_model.mapFromSource(self.nextsync_filesystem_model.index(self.nextsync_diskdrive.itemText(0))))
+            drive = self.nextsync_diskdrive.currentText() or self.nextsync_diskdrive.itemText(0)
+            self.nextsync_treeview.setRootIndex(self.nextsync_model.mapFromSource(self.nextsync_filesystem_model.index(drive)))
             self.nextsync_treeview.show()
+            # The drive switcher also drives the Remote Explorer's local pane so
+            # the user can change drive from within it.
+            re_widget = getattr(self, "_re_widget", None)
+            if re_widget is not None:
+                re_widget.set_local_dir(drive)
 
         # ---------------------------------------------------------------
         # Scan helpers: walk an image directory tree and return flat lists
@@ -10787,13 +10793,28 @@ class MainWindow(QMainWindow):
             if self._re_queue is not None:
                 self._re_queue.put(cmd)
 
+        def _re_drain():
+            # Remove every still-queued command (used by the explorer's Cancel to
+            # stop after the in-flight transfer). Returns how many were dropped.
+            n = 0
+            q = self._re_queue
+            if q is not None:
+                while True:
+                    try:
+                        q.get_nowait()
+                        n += 1
+                    except Exception:   # queue.Empty (or anything) -> stop
+                        break
+            return n
+
         def _nextsync_build_remote_explorer():
             if self._re_widget is not None:
                 return self._re_widget
             start_dir = configuration_dictionary.get(SETTING_NEXTSYNC_EXPLORERPATH) or None
             widget = RemoteExplorerWidget(
                 _re_enqueue, local_start_dir=start_dir,
-                log=lambda s: add_nextsync_log_window(str(s)))
+                log=lambda s: add_nextsync_log_window(str(s)),
+                drain=_re_drain)
             self._re_widget = widget
             self.nextsync_log_stack.addWidget(widget)
             return widget
@@ -10852,7 +10873,9 @@ class MainWindow(QMainWindow):
             self._re_sig.got.connect(widget.on_got)
             self._re_sig.put_done.connect(widget.on_put_done)
             self._re_sig.op_done.connect(widget.on_op_done)
+            self._re_sig.marked.connect(widget.on_marked)
             self._re_sig.log.connect(lambda s: add_nextsync_log_window(str(s)))
+            self._re_sig.error.connect(widget.on_error)
             self._re_sig.error.connect(lambda s: add_nextsync_log_window("Remote explorer: " + str(s)))
             self._re_thread = threading.Thread(
                 target=run_remote_listen_server,
@@ -10911,6 +10934,13 @@ class MainWindow(QMainWindow):
                 self.nextsync_slowtransfer_checkbox.setVisible(False)
                 self.nextsync_re_start_button.setVisible(True)
                 self.nextsync_re_play_label.setVisible(self._re_running)
+                # Give the Remote Explorer the full width: hide the local file
+                # explorer column (with its SyncIgnore / SyncPoint buttons) and
+                # the name filter. The drive switcher stays so the Remote
+                # Explorer can still change drive.
+                self.nextsync_fileexplorer_and_buttons_container.setVisible(False)
+                self.nextsync_filterlabel.setVisible(False)
+                self.nextsync_filtertext.setVisible(False)
                 add_nextsync_log_window(
                     "Remote explorer: click 'Start NextSync server', then run '.sync4 -listen' on your Next.")
             else:
@@ -10923,6 +10953,10 @@ class MainWindow(QMainWindow):
                 self.nextsync_prepare_server.setVisible(True)
                 self.nextsync_sync_mode_group.setVisible(True)
                 self.nextsync_slowtransfer_checkbox.setVisible(True)
+                # Restore the local file explorer column and the name filter.
+                self.nextsync_fileexplorer_and_buttons_container.setVisible(True)
+                self.nextsync_filterlabel.setVisible(True)
+                self.nextsync_filtertext.setVisible(True)
                 nextsync_hide_start_cancel_buttons()
 
         self.nextsync_remote_button.toggled.connect(_nextsync_toggle_remote_explorer)

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -12,14 +12,17 @@ through RemoteExplorerSignals and are applied here on the UI thread.
 
 import os
 import posixpath
+import shutil
 
-from PySide6.QtCore import Qt, QDir, QModelIndex, QMimeData, QUrl, QSize
-from PySide6.QtGui import QDrag, QStandardItem, QStandardItemModel
+from PySide6.QtCore import Qt, QDir, QModelIndex, QMimeData, QUrl, QSize, QTimer
+from PySide6.QtGui import QDrag, QKeySequence, QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (
     QAbstractItemView, QFileSystemModel, QGridLayout, QHBoxLayout, QInputDialog,
     QLabel, QMenu, QMessageBox, QPushButton, QStyle, QTreeView, QVBoxLayout,
     QWidget,
 )
+
+from zxnu_workers import HdfProgressDialog
 
 # Roles carrying the remote entry's full posix path and its directory flag.
 RE_PATH_ROLE = Qt.UserRole + 1
@@ -53,12 +56,35 @@ class RemoteExplorerWidget(QWidget):
     on_put_done/on_op_done.  `log` is an optional callable(str) for status lines.
     """
 
-    def __init__(self, enqueue, local_start_dir=None, log=None, parent=None):
+    def __init__(self, enqueue, local_start_dir=None, log=None, parent=None,
+                 drain=None):
         super().__init__(parent)
-        self._enqueue = enqueue
+        self._enqueue_raw = enqueue          # host closure: put one command
+        self._drain_raw = drain              # host closure: empty the queue, -> count
         self._log = log or (lambda s: None)
         self._cwd = "/"                      # current Next directory
         self._connected = False
+        # Internal copy/paste buffer shared between the two panes, as
+        # (kind, items, mode) where kind is "local"/"next", mode is "copy"/"cut"
+        # and items is [local_path, …] or [(remote_path, is_dir), …].
+        self._clip = None
+        # In-flight cut/move jobs, oldest first. Each is a dict:
+        #   {token, src_kind, src_path, is_dir, local_copy, ok}
+        # The source is deleted only once its marker confirms a clean transfer.
+        self._cut_jobs = []
+        self._cut_seq = 0
+
+        # A remote "operation" is a batch of commands the user shouldn't
+        # interrupt (except via Cancel): transfers, mkdir/rename/delete, moves.
+        # While one runs the whole widget is disabled and a modal progress
+        # dialog is shown. Plain directory listings (ls) are NOT operations.
+        self._op_active = False
+        self._op_total = 0            # commands queued so far for this op
+        self._op_completed = 0        # commands finished so far
+        self._op_cancelled = False
+        self._op_determinate = True   # False -> marquee bar (totals may grow)
+        self._op_title = ""
+        self._op_dialog = None
 
         # ---- left: local file explorer ------------------------------------
         self.local_model = QFileSystemModel(self)
@@ -78,6 +104,7 @@ class RemoteExplorerWidget(QWidget):
         self.local_view.dragEnterEvent = self._local_drag_enter
         self.local_view.dragMoveEvent = self._local_drag_enter
         self.local_view.dropEvent = self._local_drop
+        self.local_view.keyPressEvent = self._local_key_press
 
         self.local_path_label = QLabel(self)
         self.local_path_label.setToolTip("Local folder (double-click a folder to enter, Up to go back)")
@@ -142,6 +169,7 @@ class RemoteExplorerWidget(QWidget):
         self.next_view.dragMoveEvent = self._next_drag_enter
         self.next_view.dropEvent = self._next_drop
         self.next_view.startDrag = self._next_start_drag
+        self.next_view.keyPressEvent = self._next_key_press
 
         self.next_path_label = QLabel("Next: (not connected)", self)
         next_up = QPushButton("Up", self)
@@ -192,6 +220,100 @@ class RemoteExplorerWidget(QWidget):
         self._set_connected(False)
 
     # ==================================================================
+    #  command queue  (counts toward the running operation, if any)
+    # ==================================================================
+    def _enqueue(self, cmd):
+        # Every remote command except a plain refresh (ls) is enqueued here.
+        # While an operation runs, refresh() is suppressed, so anything queued
+        # during one is genuine operation work and counts toward its progress.
+        if self._op_active:
+            self._op_total += 1
+        self._enqueue_raw(cmd)
+
+    # ==================================================================
+    #  operation progress / blocking / cancel
+    # ==================================================================
+    def _run_op(self, title, enqueue_fn, determinate=True):
+        """Run a batch of remote commands as a cancellable, blocking operation.
+
+        ``enqueue_fn`` queues the commands (via _enqueue). The widget is
+        disabled and, after a short delay, a modal progress dialog appears; both
+        are lifted once every queued command has reported back.
+        """
+        if self._op_active or not self._connected:
+            # Never nest, and never start without a live server: with no queue
+            # the commands would silently vanish and the op could never end.
+            return
+        self._op_active = True
+        self._op_total = 0
+        self._op_completed = 0
+        self._op_cancelled = False
+        self._op_determinate = determinate
+        self._op_title = title
+        self._op_dialog = None
+        self.setEnabled(False)           # make the whole explorer unclickable
+        # Delay the dialog so instant operations (a quick mkdir/rename) don't
+        # flash a modal box on screen.
+        QTimer.singleShot(250, self._show_op_dialog_if_running)
+        enqueue_fn()
+        if self._op_total == 0:          # nothing actually queued
+            self._end_operation()
+
+    def _show_op_dialog_if_running(self):
+        if not self._op_active or self._op_dialog is not None:
+            return
+        dlg = HdfProgressDialog(self._op_title, self.window(), cancel_label="Cancel")
+        dlg.cancel_requested.connect(self._on_op_cancel)
+        dlg.set_progress(0 if self._op_determinate else -1)
+        dlg.set_status("Transfer/Operation in progress…")
+        self._op_dialog = dlg
+        dlg.show()
+        self._update_op_progress()
+
+    def _op_step_done(self, label=None):
+        """One queued command reported back (success or failure)."""
+        if not self._op_active:
+            return
+        self._op_completed += 1
+        if label and self._op_dialog is not None:
+            self._op_dialog.set_status(f"Transfer/Operation in progress…\n{label}")
+        self._update_op_progress()
+        if self._op_completed >= self._op_total:
+            self._end_operation()
+
+    def _update_op_progress(self):
+        if self._op_dialog is None or not self._op_determinate:
+            return
+        if self._op_total > 0:
+            self._op_dialog.set_progress(
+                int(100 * self._op_completed / self._op_total))
+
+    def _on_op_cancel(self):
+        # Stop after the current file: drop everything still queued (the in-flight
+        # transfer finishes on its own so nothing is left half-written), and don't
+        # delete any further move sources.
+        if not self._op_active or self._op_cancelled:
+            return
+        self._op_cancelled = True
+        drained = self._drain_raw() if self._drain_raw else 0
+        # Drained commands will never report back, so count them as done.
+        self._op_completed += int(drained or 0)
+        self._cut_jobs.clear()
+        self._log("Cancelling remote operation after the current transfer…")
+        # If nothing was in flight, we're already finished.
+        if self._op_completed >= self._op_total:
+            self._end_operation()
+
+    def _end_operation(self):
+        self._op_active = False
+        if self._op_dialog is not None:
+            self._op_dialog.close()
+            self._op_dialog = None
+        self.setEnabled(True)
+        # One listing now that the batch is done (suppressed during the op).
+        self.refresh()
+
+    # ==================================================================
     #  connection state
     # ==================================================================
     def _set_connected(self, on):
@@ -211,6 +333,16 @@ class RemoteExplorerWidget(QWidget):
 
     def on_disconnected(self):
         self._set_connected(False)
+        # Abandon any in-flight moves: their transfers can't complete, so their
+        # sources must stay put.
+        if self._cut_jobs:
+            self._log("Connection ended; unfinished moves kept their sources.")
+            self._cut_jobs.clear()
+        # A running operation can never report back now -- release the UI so the
+        # window doesn't stay blocked.
+        if self._op_active:
+            self._log("Connection ended; stopped the running operation.")
+            self._end_operation()
 
     def on_listing(self, path, entries):
         self._cwd = path if path.startswith("/") else "/" + path
@@ -227,14 +359,61 @@ class RemoteExplorerWidget(QWidget):
     def on_got(self, remote, local_path):
         self._log(f"Downloaded {remote} -> {local_path}")
         self.local_model.setRootPath(self.local_model.rootPath())  # nudge a refresh
+        self._op_step_done(f"Downloaded {posixpath.basename(remote.rstrip('/')) or remote}")
 
     def on_put_done(self, ok, remote):
         self._log(f"Uploaded -> {remote}" if ok else f"Upload failed: {remote}")
-        self.refresh()
+        if not ok:
+            self._cut_fail_head()
+        # Only refresh when the file landed in the folder we're looking at, so a
+        # recursive folder upload doesn't fire one listing per file.
+        if self._in_cwd(remote):
+            self.refresh()
+        self._op_step_done(f"Uploaded {posixpath.basename(remote.rstrip('/')) or remote}")
 
     def on_op_done(self, ok, op, path):
         self._log(f"{op} {path}: {'ok' if ok else 'FAILED'}")
-        self.refresh()
+        # A failed mkdir usually just means the folder already exists, which does
+        # not doom a move; only real transfer failures (put/get) count, and those
+        # arrive via put_done(ok=False) / error.
+        if self._in_cwd(path):
+            self.refresh()
+        self._op_step_done(f"{op} {posixpath.basename(path.rstrip('/')) or path}")
+
+    def on_error(self, _msg=None):
+        # Any error while a move's transfer is draining means we must not delete
+        # its source. It also counts as that command reporting back.
+        self._cut_fail_head()
+        self._op_step_done()
+
+    def on_marked(self, token):
+        """A queued move barrier was reached: the head job's transfer is done.
+
+        Any follow-on deletes are queued *before* this marker is counted, so the
+        operation stays active until they too complete.
+        """
+        job = None
+        if self._cut_jobs:
+            head = self._cut_jobs[0]
+            if str(head.get("token")) == str(token):
+                job = self._cut_jobs.pop(0)
+        if job is None:
+            # Cancelled, out of step, or not a move marker: just count it.
+            self._op_step_done()
+            return
+        if not job.get("ok", False):
+            self._log(f"Move: transfer failed, kept {job['src_path']}")
+        elif job["src_kind"] == "local":
+            self._delete_local_after_move(job["src_path"])
+        else:
+            self._delete_remote_after_move(job)
+        self._op_step_done()
+
+    def _in_cwd(self, path):
+        """True if ``path``'s parent is the directory currently shown."""
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        cwd = (self._cwd if self._cwd.startswith("/") else "/" + self._cwd)
+        return parent == (cwd.rstrip("/") or "/")
 
     # ==================================================================
     #  Next pane
@@ -247,7 +426,9 @@ class RemoteExplorerWidget(QWidget):
         self.next_model.appendRow([name_item, size_item])
 
     def refresh(self):
-        if self._connected:
+        # Suppressed while an operation runs (a single listing happens when it
+        # ends), so mid-batch completions don't flood the queue with listings.
+        if self._connected and not self._op_active:
             self._enqueue(("ls", self._cwd))
 
     def _next_up(self):
@@ -306,7 +487,9 @@ class RemoteExplorerWidget(QWidget):
             return
         name, ok = QInputDialog.getText(self, "New Folder", f"New folder in {self._cwd}:")
         if ok and name.strip():
-            self._enqueue(("mkdir", _posix_join(self._cwd, name.strip())))
+            target = _posix_join(self._cwd, name.strip())
+            self._run_op("Creating folder on the Next…",
+                         lambda: self._enqueue(("mkdir", target)))
 
     def _rename_selected(self):
         if not self._connected:
@@ -326,7 +509,9 @@ class RemoteExplorerWidget(QWidget):
             self._log("Rename: enter a name only, not a path.")
             return
         parent = posixpath.dirname(path.rstrip("/")) or "/"
-        self._enqueue(("rename", path, _posix_join(parent, new_name)))
+        target = _posix_join(parent, new_name)
+        self._run_op("Renaming on the Next…",
+                     lambda: self._enqueue(("rename", path, target)))
 
     def _delete_selected(self):
         entries = self._selected_next_entries()
@@ -335,8 +520,177 @@ class RemoteExplorerWidget(QWidget):
         names = "\n".join(p for p, _ in entries)
         if QMessageBox.question(self, "Delete", f"Delete on the Next?\n\n{names}") != QMessageBox.Yes:
             return
+
+        def go():
+            for path, is_dir in entries:
+                self._enqueue(("rmdir" if is_dir else "rm", path))
+        self._run_op("Deleting on the Next…", go)
+
+    def _next_key_press(self, event):
+        # Ctrl+C / Ctrl+X copy or cut the Next selection; Ctrl+V pastes local
+        # clipboard items here (upload). Delete / F2 mirror the context-menu
+        # Delete / Rename.
+        if event.matches(QKeySequence.StandardKey.Copy):
+            self._copy_next("copy")
+            return
+        if event.matches(QKeySequence.StandardKey.Cut):
+            self._copy_next("cut")
+            return
+        if self._connected:
+            if event.matches(QKeySequence.StandardKey.Paste):
+                self._paste_into_next()
+                return
+            if event.key() == Qt.Key.Key_Delete:
+                self._delete_selected()
+                return
+            if event.key() == Qt.Key.Key_F2:
+                self._rename_selected()
+                return
+        QTreeView.keyPressEvent(self.next_view, event)
+
+    # ==================================================================
+    #  copy / cut / paste (internal buffer shared between the two panes)
+    # ==================================================================
+    def _copy_next(self, mode="copy"):
+        entries = self._selected_next_entries()
+        if entries:
+            self._clip = ("next", entries, mode)
+            verb = "Cut" if mode == "cut" else "Copied"
+            self._log(f"{verb} {len(entries)} Next item(s). Paste in the local "
+                      "pane to " + ("move" if mode == "cut" else "download") + ".")
+
+    def _copy_local(self, mode="copy"):
+        paths = [p for p in self._selected_local_paths() if os.path.exists(p)]
+        if paths:
+            self._clip = ("local", paths, mode)
+            verb = "Cut" if mode == "cut" else "Copied"
+            self._log(f"{verb} {len(paths)} local item(s). Paste in the Next "
+                      "pane to " + ("move" if mode == "cut" else "upload") + ".")
+
+    def _paste_into_next(self):
+        # Paste local clipboard items into the current Next directory: copy =
+        # upload, cut = upload then delete the local source once confirmed.
+        if not self._connected or not self._clip or self._clip[0] != "local":
+            return
+        _kind, paths, mode = self._clip
+        paths = list(paths)
+        if mode == "cut":
+            self._clip = None            # a cut is consumed by its paste
+            self._run_op("Moving to the Next…",
+                         lambda: self._move_local_paths_to_next(paths),
+                         determinate=False)
+        else:
+            self._run_op("Uploading to the Next…",
+                         lambda: self._put_paths(paths))
+
+    def _paste_into_local(self):
+        # Paste Next clipboard items into the current local directory: copy =
+        # download, cut = download then delete the Next source once confirmed.
+        if not self._clip or self._clip[0] != "next":
+            return
+        _kind, entries, mode = self._clip
+        entries = list(entries)
+        if mode == "cut":
+            self._clip = None
+            self._run_op("Moving from the Next…",
+                         lambda: self._move_next_entries_to_local(entries),
+                         determinate=False)
+        else:
+            dest = self._local_dir()
+
+            def go():
+                for path, _is_dir in entries:
+                    self._enqueue(("get", path, dest))
+                self._log(f"Downloading {len(entries)} item(s) to {dest} …")
+            self._run_op("Downloading from the Next…", go)
+
+    # ==================================================================
+    #  cut / move (transfer, then delete the source only once confirmed)
+    # ==================================================================
+    def _new_cut_token(self):
+        self._cut_seq += 1
+        return f"cut{self._cut_seq}"
+
+    def _cut_head(self):
+        return self._cut_jobs[0] if self._cut_jobs else None
+
+    def _cut_fail_head(self):
+        head = self._cut_head()
+        if head is not None:
+            head["ok"] = False
+
+    def _move_local_paths_to_next(self, paths):
+        """Upload each local file/folder, then delete it locally once its
+        marker confirms the whole item transferred cleanly."""
+        base = self._cwd if self._cwd.endswith("/") else self._cwd + "/"
+        n = 0
+        for p in paths:
+            if os.path.isdir(p):
+                self._enqueue_dir_upload(p, base)
+            elif os.path.isfile(p):
+                self._enqueue(("put", p, base))
+            else:
+                continue
+            token = self._new_cut_token()
+            self._cut_jobs.append({"token": token, "src_kind": "local",
+                                   "src_path": p, "is_dir": os.path.isdir(p),
+                                   "local_copy": None, "ok": True})
+            self._enqueue(("mark", token))
+            n += 1
+        if n:
+            self._log(f"Moving {n} item(s) to {self._cwd} …")
+
+    def _move_next_entries_to_local(self, entries):
+        """Download each Next file/folder, then delete it on the Next once its
+        marker confirms the download completed."""
+        dest = self._local_dir()
+        n = 0
         for path, is_dir in entries:
-            self._enqueue(("rmdir" if is_dir else "rm", path))
+            self._enqueue(("get", path, dest))
+            local_copy = (os.path.join(dest, os.path.basename(path.rstrip("/")))
+                          if is_dir else None)
+            token = self._new_cut_token()
+            self._cut_jobs.append({"token": token, "src_kind": "next",
+                                   "src_path": path, "is_dir": bool(is_dir),
+                                   "local_copy": local_copy, "ok": True})
+            self._enqueue(("mark", token))
+            n += 1
+        if n:
+            self._log(f"Moving {n} item(s) to {dest} …")
+
+    def _delete_local_after_move(self, path):
+        try:
+            if os.path.isdir(path) and not os.path.islink(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+            self._log(f"Moved (removed local {path})")
+        except OSError as ex:
+            self._log(f"Move: uploaded but could not remove local {path}: {ex}")
+
+    def _delete_remote_after_move(self, job):
+        path = job["src_path"]
+        if not job.get("is_dir"):
+            self._enqueue(("rm", path))
+            self._log(f"Moved (removing {path} on the Next)")
+            return
+        # esxDOS rmdir only removes empty folders, so delete the tree from the
+        # bottom up. We just downloaded an exact copy, so mirror its layout
+        # instead of re-listing the Next.
+        local_copy = job.get("local_copy")
+        if not local_copy or not os.path.isdir(local_copy):
+            # Nothing to mirror from; try a plain rmdir (works if it was empty).
+            self._enqueue(("rmdir", path))
+            self._log(f"Moved (removing {path} on the Next)")
+            return
+        for root, _dirs, files in os.walk(local_copy, topdown=False):
+            rel = os.path.relpath(root, local_copy)
+            rdir = path if rel in (".", "") else _posix_join(
+                path, rel.replace(os.sep, "/"))
+            for name in sorted(files):
+                self._enqueue(("rm", _posix_join(rdir, name)))
+            self._enqueue(("rmdir", rdir))
+        self._log(f"Moved (removing {path} tree on the Next)")
 
     # ==================================================================
     #  transfers
@@ -346,26 +700,83 @@ class RemoteExplorerWidget(QWidget):
         if not entries:
             return
         dest = self._local_dir()
-        for path, _is_dir in entries:
-            self._enqueue(("get", path, dest))
-        self._log(f"Downloading {len(entries)} item(s) to {dest} …")
+
+        def go():
+            for path, _is_dir in entries:
+                self._enqueue(("get", path, dest))
+            self._log(f"Downloading {len(entries)} item(s) to {dest} …")
+        self._run_op("Downloading from the Next…", go)
 
     def _put_selected(self):
-        files = [p for p in self._selected_local_paths() if os.path.isfile(p)]
-        if not files:
-            self._log("Select local file(s) to upload (folders: drag or one at a time).")
+        paths = [p for p in self._selected_local_paths() if os.path.exists(p)]
+        if not paths:
+            self._log("Select local file(s) or folder(s) to upload.")
             return
-        self._put_files(files)
+        self._run_op("Uploading to the Next…", lambda: self._put_paths(paths))
 
-    def _put_files(self, files):
+    def _put_paths(self, paths):
+        """Upload files and/or whole folders to the current Next directory.
+
+        Folders are recreated on the Next: each sub-directory is made with
+        ``mkdir`` and every file is ``put`` into it, in top-down order so a
+        directory always exists before files land in it (the listen worker
+        processes the queue strictly in order).
+        """
         base = self._cwd if self._cwd.endswith("/") else self._cwd + "/"
-        for f in files:
-            self._enqueue(("put", f, base))
-        self._log(f"Uploading {len(files)} file(s) to {self._cwd} …")
+        n_files = 0
+        n_dirs = 0
+        for p in paths:
+            if os.path.isdir(p):
+                n_files += self._enqueue_dir_upload(p, base)
+                n_dirs += 1
+            elif os.path.isfile(p):
+                self._enqueue(("put", p, base))
+                n_files += 1
+        if n_files or n_dirs:
+            what = f"{n_files} file(s)"
+            if n_dirs:
+                what += f" in {n_dirs} folder(s)"
+            self._log(f"Uploading {what} to {self._cwd} …")
+
+    def _enqueue_dir_upload(self, local_dir, remote_base):
+        """Queue mkdir/put commands to copy ``local_dir`` under ``remote_base``.
+
+        Returns the number of files queued.
+        """
+        local_dir = os.path.normpath(local_dir)
+        top = os.path.basename(local_dir.rstrip("/\\")) or "dir"
+        remote_top = _posix_join(remote_base, top)
+        self._enqueue(("mkdir", remote_top))
+        n = 0
+        for root, dirs, files in os.walk(local_dir):
+            dirs.sort()
+            rel = os.path.relpath(root, local_dir)
+            if rel in (".", ""):
+                remote_dir = remote_top
+            else:
+                remote_dir = _posix_join(remote_top, rel.replace(os.sep, "/"))
+                self._enqueue(("mkdir", remote_dir))
+            for name in sorted(files):
+                self._enqueue(("put", os.path.join(root, name), remote_dir + "/"))
+                n += 1
+        return n
+
+    # Back-compat alias: earlier code/tests referenced _put_files.
+    def _put_files(self, files):
+        self._put_paths(files)
 
     # ==================================================================
     #  local pane
     # ==================================================================
+    def set_local_dir(self, path):
+        """Public: point the local pane at `path` (e.g. a drive root).
+
+        Used by the host's drive switcher so the Remote Explorer can change
+        drive too. Ignored if `path` isn't an existing directory.
+        """
+        if path and os.path.isdir(path):
+            self._set_local_dir(path)
+
     def _set_local_dir(self, path):
         self.local_view.setRootIndex(self.local_model.index(path))
         self.local_path_label.setText(path)
@@ -392,6 +803,71 @@ class RemoteExplorerWidget(QWidget):
                 out.append(p)
         return out
 
+    def _local_key_press(self, event):
+        # Ctrl+C / Ctrl+X copy or cut the local selection; Ctrl+V pastes Next
+        # clipboard items here (download). Delete / F2 act on the local pane,
+        # mirroring the Next pane. (QFileSystemModel refreshes on change.)
+        if event.matches(QKeySequence.StandardKey.Copy):
+            self._copy_local("copy")
+            return
+        if event.matches(QKeySequence.StandardKey.Cut):
+            self._copy_local("cut")
+            return
+        if event.matches(QKeySequence.StandardKey.Paste):
+            self._paste_into_local()
+            return
+        if event.key() == Qt.Key.Key_Delete:
+            self._local_delete_selected()
+            return
+        if event.key() == Qt.Key.Key_F2:
+            self._local_rename_selected()
+            return
+        QTreeView.keyPressEvent(self.local_view, event)
+
+    def _local_delete_selected(self):
+        paths = [p for p in self._selected_local_paths()
+                 if p and os.path.exists(p)]
+        if not paths:
+            return
+        names = "\n".join(paths)
+        if QMessageBox.question(self, "Delete",
+                                f"Delete from the local disk?\n\n{names}") != QMessageBox.Yes:
+            return
+        for p in paths:
+            try:
+                if os.path.isdir(p) and not os.path.islink(p):
+                    shutil.rmtree(p)
+                else:
+                    os.remove(p)
+                self._log(f"Deleted {p}")
+            except OSError as ex:
+                self._log(f"Delete failed: {p}: {ex}")
+
+    def _local_rename_selected(self):
+        paths = self._selected_local_paths()
+        if len(paths) != 1:
+            self._log("Select exactly one local item to rename.")
+            return
+        old = paths[0]
+        old_name = os.path.basename(old.rstrip("/\\")) or old
+        new_name, ok = QInputDialog.getText(
+            self, "Rename", f"Rename '{old_name}' to:", text=old_name)
+        new_name = new_name.strip()
+        if not ok or not new_name or new_name == old_name:
+            return
+        if "/" in new_name or "\\" in new_name:
+            self._log("Rename: enter a name only, not a path.")
+            return
+        new_path = os.path.join(os.path.dirname(old), new_name)
+        if os.path.exists(new_path):
+            self._log(f"Rename: '{new_name}' already exists.")
+            return
+        try:
+            os.rename(old, new_path)
+            self._log(f"Renamed {old_name} -> {new_name}")
+        except OSError as ex:
+            self._log(f"Rename failed: {ex}")
+
     # ==================================================================
     #  drag & drop
     # ==================================================================
@@ -402,13 +878,15 @@ class RemoteExplorerWidget(QWidget):
             event.ignore()
 
     def _next_drop(self, event):
+        # Accept both files and folders dragged from the local pane or the OS
+        # file manager; folders are uploaded recursively (see _put_paths).
         paths = [u.toLocalFile() for u in event.mimeData().urls()
-                 if u.isLocalFile() and os.path.isfile(u.toLocalFile())]
+                 if u.isLocalFile() and os.path.exists(u.toLocalFile())]
         if not paths:
             event.ignore()
             return
         event.acceptProposedAction()
-        self._put_files(paths)
+        self._run_op("Uploading to the Next…", lambda: self._put_paths(paths))
 
     def _next_start_drag(self, supported):
         # Drag Next entries to the local pane / OS to download them.
@@ -436,7 +914,14 @@ class RemoteExplorerWidget(QWidget):
             return
         event.acceptProposedAction()
         dest = self._local_dir()
-        for line in bytes(data).decode(errors="replace").splitlines():
-            if "\t" in line:
-                _flag, path = line.split("\t", 1)
+        paths = [line.split("\t", 1)[1]
+                 for line in bytes(data).decode(errors="replace").splitlines()
+                 if "\t" in line]
+        if not paths:
+            return
+
+        def go():
+            for path in paths:
                 self._enqueue(("get", path, dest))
+            self._log(f"Downloading {len(paths)} item(s) to {dest} …")
+        self._run_op("Downloading from the Next…", go)

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -176,6 +176,7 @@ class RemoteExplorerSignals(QObject):
     got          = Signal(str, str)       # (remote, local_path) a "get" finished
     put_done     = Signal(bool, str)      # (ok, remote) a "put" finished
     op_done      = Signal(bool, str, str) # (ok, op, path) mkdir/rmdir/rm result
+    marked       = Signal(str)            # a queued ("mark", token) was reached
     log          = Signal(str)            # a human-readable log line
     error        = Signal(str)            # a human-readable error
 
@@ -247,6 +248,29 @@ def _re_recv_reply(conn, handler):
             return True
 
 
+def _re_sanitize_incoming_path(root, name):
+    """Map a filename reported by the Next to a safe path under ``root``.
+
+    A "get" of a directory streams every file back with its path relative to
+    the fetched folder (e.g. ``GAMES/level1/boot.tap``); this preserves that
+    sub-structure locally instead of flattening it to the basename. Strips any
+    drive letter and leading slashes, drops '.'/'..' segments, and guarantees
+    the result stays inside ``root``. Mirrors nextsync4.sanitize_incoming_path.
+    """
+    name = name.replace('\\', '/')
+    if len(name) >= 2 and name[1] == ':':
+        name = name[2:]
+    name = name.lstrip('/')
+    parts = [p for p in name.split('/') if p not in ('', '.', '..')]
+    rel = os.path.join(*parts) if parts else 'received.bin'
+    dest = os.path.normpath(os.path.join(root, rel))
+    root_abs = os.path.abspath(root)
+    if not (os.path.abspath(dest) == root_abs or
+            os.path.abspath(dest).startswith(root_abs + os.sep)):
+        dest = os.path.join(root, os.path.basename(rel) or 'received.bin')
+    return dest
+
+
 def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                              max_payload=1024):
     """Run the NextSync ``.sync4 -listen`` remote file server in a worker thread.
@@ -261,8 +285,15 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
         ("rmdir", remote_path)
         ("rm",    remote_path)
         ("rename", old_path, new_path)
+        ("mark",  token)          -> echoes back via sig.marked once reached
         ("quit",)
     ``stop_event`` (threading.Event) ends the session/thread.
+
+    ``mark`` is a client-side barrier: it touches nothing on the Next, it just
+    emits ``marked(token)`` the moment the queue drains down to it. Because the
+    queue is a single-consumer FIFO, everything enqueued before the marker has
+    finished by then -- the UI uses this to know a cut/move's transfer completed
+    before deleting the source.
 
     This is the app-side twin of nextsync4.py's listen_session: same wire
     protocol, but driven by the UI queue and reporting via Qt signals instead of
@@ -328,6 +359,12 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                     if op == "quit":
                         _re_sendpacket(conn, b"Q", 0)
                         break
+                    elif op == "mark":
+                        # Client-side barrier: nothing goes to the Next, we just
+                        # report that the queue reached this point, then idle so
+                        # the Next keeps polling.
+                        sig.marked.emit(str(cmd[1]))
+                        _re_sendpacket(conn, b"I", 0)
                     elif op == "ls":
                         path = cmd[1] or "."
                         entries = []
@@ -354,23 +391,31 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                         else:
                             sig.error.emit(f"ls {path}: connection dropped")
                     elif op == "get":
+                        # Works for a single file or a whole directory: the Next
+                        # streams every file back (N/D/E per file, B at the end)
+                        # with a path relative to the fetched item, which we keep
+                        # so sub-folders are recreated locally intact.
                         remote, dest_dir = cmd[1], cmd[2]
                         os.makedirs(dest_dir, exist_ok=True)
-                        st = {'f': None, 'name': None, 'bytes': 0, 'last': None}
+                        st = {'f': None, 'name': None, 'bytes': 0, 'last': None,
+                              'count': 0}
 
                         def _h(payload, _st=st, _dd=dest_dir):
                             o = payload[0:1]
                             if o == b'N':
                                 namelen = payload[5] if len(payload) > 5 else 0
                                 name = payload[6:6+namelen].decode(errors='replace')
-                                safe = os.path.basename(name.replace('\\', '/').rstrip('/')) or "received.bin"
-                                path = os.path.join(_dd, safe)
+                                path = _re_sanitize_incoming_path(_dd, name)
                                 if _st['f']:
                                     _st['f'].close()
+                                parent = os.path.dirname(path)
+                                if parent:
+                                    os.makedirs(parent, exist_ok=True)
                                 _st['f'] = open(path, 'wb')
                                 _st['name'] = name
                                 _st['last'] = path
                                 _st['bytes'] = 0
+                                _st['count'] += 1
                             elif o == b'D':
                                 if _st['f']:
                                     _st['f'].write(payload[1:])
@@ -389,8 +434,8 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                         ok = _re_recv_reply(conn, _h)
                         if st['f']:
                             st['f'].close()
-                        if ok and st['last']:
-                            sig.got.emit(remote, st['last'])
+                        if ok:
+                            sig.got.emit(remote, st['last'] or dest_dir)
                         else:
                             sig.error.emit(f"get {remote}: failed")
                     elif op == "put":


### PR DESCRIPTION
Brings the NextSync **Remote Explorer** to parity with the SD Card explorers, and adds a progress / blocking / cancel layer for its remote operations.

## Layout
- Entering Remote Explorer mode hides the local file column and the **"Search:" / "Filter by name…"** widgets (keeping the **drive switcher**) so the explorer spans the full width; leaving restores them.
- Fixes a latent bug where the drive switcher used `itemText(0)` (always the first drive) instead of the selected one, and wires it to also retarget the Remote Explorer's local pane.

## Folder transfers (both ways)
- **Upload**: folders are recreated on the Next (`mkdir` + `put`, top-down so a directory always exists before files land in it).
- **Download**: the listen worker's `get` handler now preserves each streamed file's relative sub-path (mirrors `nextsync4.sanitize_incoming_path`), so a whole folder comes down intact instead of being flattened into one directory.

## Keyboard & clipboard (both panes)
- **Delete** and **F2** (rename).
- **Ctrl+C / Ctrl+X / Ctrl+V** — copy, cut and paste between the two panes.

## Cut / move with completion tracking
- Transfers, then deletes the source **only once** a per-item `("mark", token)` barrier confirms a clean transfer (a failed transfer keeps the source).
- Local sources are removed directly; a moved **remote** folder is deleted bottom-up, mirrored from the just-downloaded local copy (esxDOS `rmdir` only removes empty dirs).

## Progress / blocking / cancel
- Every remote operation disables the explorer and shows the modal `HdfProgressDialog` (spinner, bar, live "Transfer/Operation in progress… / \<current file\>") — the same dialog the traditional sync uses — after a **250 ms delay** so instant ops don't flash.
- **Cancel** drains the queued commands so nothing new starts while the in-flight file finishes (no half-written files) — built for the "uploading a folder of thousands of files and need to stop" case.
- Completion is tracked by a per-command counter; a dropped connection force-ends the operation so the window can't get stuck disabled.

## Testing
Verified with unit tests plus an end-to-end integration test (real listen worker + mock Next + Qt event loop + live modal dialog): folder up/download intact, copy/cut/paste routing, cut/move completion + failure-keeps-source, marker ordering, and the operation lifecycle — the dialog appears during a slow upload, **Cancel stops early after the current file (2 of 6)**, and the explorer is released every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
