### PR TITLE
RemoteExplorer: colored Name/Type/Size tree matching SD Card image tree

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -10822,6 +10822,29 @@ class MainWindow(QMainWindow):
                         break
             return n
 
+        def _re_apply_item_colors():
+            # Push the SD Card Utility's live item colours into the Remote
+            # Explorer so its two panes are tinted the same way as the image tree
+            # (dir/file name, type, size, up-dir). Safe to call before the widget
+            # exists (lazy build) — it's a no-op then, and the build applies the
+            # current colours itself.
+            widget = getattr(self, "_re_widget", None)
+            if widget is None:
+                return
+            try:
+                widget.set_item_colors({
+                    "up_directory": self.img_color_up_directory,
+                    "dir_name":     self.img_color_dir_name,
+                    "dir_type":     self.img_color_dir_type,
+                    "file_name":    self.img_color_file_name,
+                    "file_ext":     self.img_color_file_ext,
+                    "file_size":    self.img_color_file_size,
+                    "general_text": self.img_color_general_text,
+                })
+            except Exception:
+                pass
+        self._re_apply_item_colors = _re_apply_item_colors
+
         def _nextsync_build_remote_explorer():
             if self._re_widget is not None:
                 return self._re_widget
@@ -10832,6 +10855,7 @@ class MainWindow(QMainWindow):
                 drain=_re_drain)
             self._re_widget = widget
             self.nextsync_log_stack.addWidget(widget)
+            _re_apply_item_colors()          # tint to the user's configured colours
             return widget
 
         # Soft green "breathing" pulse on the running indicator (same idea as the
@@ -22105,6 +22129,12 @@ class MainWindow(QMainWindow):
                     self._image_recolor_all()
                 except Exception:
                     pass
+            # Mirror the theme's item colours into the Remote Explorer panes.
+            if hasattr(self, "_re_apply_item_colors"):
+                try:
+                    self._re_apply_item_colors()
+                except Exception:
+                    pass
             # Re-apply the general UI text colour to the (always-dark) tab panes.
             if hasattr(self, "_refresh_tab_stylesheet"):
                 try:
@@ -22312,6 +22342,9 @@ class MainWindow(QMainWindow):
                 # change is visible immediately (no async re-listing needed).
                 if hasattr(self, "_image_recolor_all"):
                     self._image_recolor_all()
+                # Mirror the change into the NextSync Remote Explorer's panes.
+                if hasattr(self, "_re_apply_item_colors"):
+                    self._re_apply_item_colors()
                 # If the general UI text colour changed, re-apply it to the panes.
                 if hasattr(self, "_refresh_tab_stylesheet"):
                     self._refresh_tab_stylesheet()

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -15,13 +15,20 @@ import posixpath
 import shutil
 
 from PySide6.QtCore import Qt, QDir, QModelIndex, QMimeData, QUrl, QSize, QTimer
-from PySide6.QtGui import QDrag, QKeySequence, QStandardItem, QStandardItemModel
+from PySide6.QtGui import (
+    QColor, QDrag, QKeySequence, QStandardItem, QStandardItemModel,
+)
 from PySide6.QtWidgets import (
     QAbstractItemView, QFileSystemModel, QGridLayout, QHBoxLayout, QInputDialog,
     QLabel, QMenu, QMessageBox, QPushButton, QStyle, QTreeView, QVBoxLayout,
     QWidget,
 )
 
+from zxnu_config import (
+    DEFAULT_COLOR_UP_DIRECTORY, DEFAULT_COLOR_DIR_NAME, DEFAULT_COLOR_DIR_TYPE,
+    DEFAULT_COLOR_FILE_NAME, DEFAULT_COLOR_FILE_EXT, DEFAULT_COLOR_FILE_SIZE,
+    DEFAULT_COLOR_GENERAL_TEXT, hex_to_qcolor,
+)
 from zxnu_workers import HdfProgressDialog
 
 # Roles carrying the remote entry's full posix path and its directory flag.
@@ -29,6 +36,57 @@ RE_PATH_ROLE = Qt.UserRole + 1
 RE_ISDIR_ROLE = Qt.UserRole + 2
 
 ARROW_BTN_W = 40
+
+
+def _default_item_colors():
+    """The SD Card Utility's image-tree item colours as a fresh dict of QColor.
+
+    Keys mirror the SETTING_COLOR_* families used by the SD-card explorer so the
+    host can push its live ``img_color_*`` values straight in (see
+    RemoteExplorerWidget.set_item_colors). Used until the host supplies the
+    user's configured colours.
+    """
+    return {
+        "up_directory": hex_to_qcolor(DEFAULT_COLOR_UP_DIRECTORY),
+        "dir_name":     hex_to_qcolor(DEFAULT_COLOR_DIR_NAME),
+        "dir_type":     hex_to_qcolor(DEFAULT_COLOR_DIR_TYPE),
+        "file_name":    hex_to_qcolor(DEFAULT_COLOR_FILE_NAME),
+        "file_ext":     hex_to_qcolor(DEFAULT_COLOR_FILE_EXT),
+        "file_size":    hex_to_qcolor(DEFAULT_COLOR_FILE_SIZE),
+        "general_text": hex_to_qcolor(DEFAULT_COLOR_GENERAL_TEXT),
+    }
+
+
+class ColoredFileSystemModel(QFileSystemModel):
+    """QFileSystemModel that tints each column with the SD-card explorer's
+    configurable item colours, so the local pane matches the look of the SD Card
+    Utility's image tree.
+
+    ``colours`` is a live dict (see _default_item_colors) shared with the owning
+    widget: it is mutated in place when the user changes the colours in Settings,
+    and a repaint re-queries these values — no re-listing of the folder needed.
+    QFileSystemModel's native column order is 0=Name, 1=Size, 2=Type, so the
+    colour mapping is keyed off that (the view re-orders them visually to
+    Name/Type/Size to mirror the image tree).
+    """
+
+    def __init__(self, colours, parent=None):
+        super().__init__(parent)
+        self._colours = colours
+
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
+        if role == Qt.ItemDataRole.ForegroundRole and index.isValid():
+            is_dir = self.isDir(index)
+            col = index.column()
+            c = self._colours
+            if col == 0:                       # Name
+                return c["dir_name"] if is_dir else c["file_name"]
+            if col == 2:                       # Type
+                return c["dir_type"] if is_dir else c["file_ext"]
+            if col == 1 and not is_dir:        # Size (blank for folders)
+                return c["file_size"]
+            return None                        # let the view use its default
+        return super().data(index, role)
 
 
 def _human_size(n):
@@ -89,8 +147,14 @@ class RemoteExplorerWidget(QWidget):
         self._op_title = ""
         self._op_dialog = None
 
+        # Per-item font colours, mirroring the SD Card Utility's image tree. The
+        # host pushes the user's configured colours in via set_item_colors(); the
+        # dict is mutated in place so ColoredFileSystemModel (which holds the same
+        # reference) always sees the current values.
+        self._colors = _default_item_colors()
+
         # ---- left: local file explorer ------------------------------------
-        self.local_model = QFileSystemModel(self)
+        self.local_model = ColoredFileSystemModel(self._colors, self)
         self.local_model.setRootPath("")
         self.local_view = QTreeView(self)
         self.local_view.setModel(self.local_model)
@@ -98,8 +162,12 @@ class RemoteExplorerWidget(QWidget):
         self.local_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.local_view.setUniformRowHeights(True)
         self.local_view.setSortingEnabled(True)
-        for col in (1, 2, 3):
-            self.local_view.hideColumn(col)      # keep just the name column
+        # Show Name / Type / Size (hide Date Modified) and, like the SD-card image
+        # tree, order them Name, Type, Size — QFileSystemModel's native order is
+        # Name(0), Size(1), Type(2), so swap the last two visually.
+        self.local_view.hideColumn(3)
+        self.local_view.header().swapSections(1, 2)
+        self.local_view.setColumnWidth(0, 250)
         self.local_view.setDragEnabled(True)
         self.local_view.setAcceptDrops(True)
         self.local_view.setDropIndicatorShown(True)
@@ -162,13 +230,14 @@ class RemoteExplorerWidget(QWidget):
         self._file_icon = self.style().standardIcon(QStyle.StandardPixmap.SP_FileIcon)
 
         self.next_model = QStandardItemModel(self)
-        self.next_model.setHorizontalHeaderLabels(["Name", "Size"])
+        self.next_model.setHorizontalHeaderLabels(["Name", "Type", "Size"])
         self.next_view = QTreeView(self)
         self.next_view.setModel(self.next_model)
         self.next_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.next_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.next_view.setUniformRowHeights(True)
         self.next_view.setRootIsDecorated(False)
+        self.next_view.setColumnWidth(0, 250)
         self.next_view.setContextMenuPolicy(Qt.CustomContextMenu)
         self.next_view.customContextMenuRequested.connect(self._next_context_menu)
         self.next_view.doubleClicked.connect(self._next_double_clicked)
@@ -432,8 +501,64 @@ class RemoteExplorerWidget(QWidget):
         name_item = QStandardItem(self._dir_icon if is_dir else self._file_icon, name)
         name_item.setData(".." if is_updir else _posix_join(self._cwd, name), RE_PATH_ROLE)
         name_item.setData(bool(is_dir), RE_ISDIR_ROLE)
-        size_item = QStandardItem("" if is_dir else _human_size(size))
-        self.next_model.appendRow([name_item, size_item])
+        name_item.setEditable(False)
+        if is_updir:
+            type_item = QStandardItem("")
+            size_item = QStandardItem("")
+        elif is_dir:
+            type_item = QStandardItem("DIR")
+            size_item = QStandardItem("")
+        else:
+            # Mirror the SD-card image tree: the "type" is the first extension
+            # segment (guarded by the '.' test, so [1] is always present).
+            type_item = QStandardItem(name.split(".")[1] if "." in name else "")
+            size_item = QStandardItem(_human_size(size))
+        type_item.setEditable(False)
+        size_item.setEditable(False)
+        self.next_model.appendRow([name_item, type_item, size_item])
+        self._color_next_row(name_item, type_item, size_item)
+
+    def _color_next_row(self, name_item, type_item, size_item):
+        """Tint one Next row's items with the configured SD-card item colours."""
+        c = self._colors
+        if name_item.data(RE_PATH_ROLE) == "..":
+            name_item.setForeground(c["up_directory"])
+            return
+        if bool(name_item.data(RE_ISDIR_ROLE)):
+            name_item.setForeground(c["dir_name"])
+            type_item.setForeground(c["dir_type"])
+        else:
+            name_item.setForeground(c["file_name"])
+            type_item.setForeground(c["file_ext"])
+            size_item.setForeground(c["file_size"])
+
+    def _recolor_next(self):
+        """Re-tint every row already shown in the Next pane, in place (used when
+        the user changes the item colours in Settings — no re-listing needed)."""
+        model = self.next_model
+        for r in range(model.rowCount()):
+            name_item = model.item(r, 0)
+            if name_item is None:
+                continue
+            self._color_next_row(name_item, model.item(r, 1), model.item(r, 2))
+
+    def set_item_colors(self, colors):
+        """Push the SD Card Utility's live item colours into both panes.
+
+        ``colors`` maps the keys up_directory/dir_name/dir_type/file_name/
+        file_ext/file_size/general_text to QColor (the host's ``img_color_*``
+        values). Missing keys keep their current value. The shared ``_colors``
+        dict is mutated in place so the local model repaints in the new colours
+        and the Next rows are re-tinted immediately.
+        """
+        if not colors:
+            return
+        for key, value in colors.items():
+            if key in self._colors and value is not None:
+                self._colors[key] = QColor(value)
+        self._recolor_next()
+        # The local model reads _colors live in data(); a repaint re-queries it.
+        self.local_view.viewport().update()
 
     def refresh(self):
         # Suppressed while an operation runs (a single listing happens when it


### PR DESCRIPTION
## Summary
Updates the NextSync **Remote Explorer**'s two panes (local file explorer + Next) so they render like the SD Card Utility's image tree instead of plain flat tables — with **Name / Type / Size** columns and the same configurable **font-color settings** applied per item.

## Changes
**`zxnu_remote_explorer.py`**
- New `ColoredFileSystemModel` (subclass of `QFileSystemModel`) tints the **local** pane per item via `Qt.ForegroundRole`, reading the shared color dict live — a repaint picks up changes, no folder re-listing needed.
- Both panes now show **Name / Type / Size** columns. The local pane hides "Date Modified" and orders columns `Name, Type, Size` to match the image tree.
- The **Next** pane builds all three columns and tints them; added `set_item_colors()` plus `_color_next_row` / `_recolor_next` to re-tint existing rows in place.
- Item coloring mirrors the SD Card settings exactly: directory name/type, file name/ext/size, and the `..` up-directory each use their `SETTING_COLOR_*` value.

**`zx-next-unite.py`**
- Added `_re_apply_item_colors()` that pushes the live `img_color_*` values into the widget on build, and wired it into the two places colors change (Settings color picker `_apply_color` and Desktop Theme apply `_apply_desktop_theme_colors`), alongside the existing `_image_recolor_all()` calls — so the SD Card tree and Remote Explorer stay in sync.

Drag and drop is **unchanged** (handlers and `filePath`/`index` calls untouched; selection/DnD still key off column 0).

## Testing
- Both files byte-compile.
- Headless smoke tests confirmed: Next pane 3 columns with `..`/dir/file coloring and live re-tint via `set_item_colors`; local `ColoredFileSystemModel` returns correct foreground colors for real dir/file entries with columns ordered Name/Type/Size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)