### PR TITLE
RemoteExplorer: sync-root gating, name filter, and colored trees

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -10803,6 +10803,11 @@ class MainWindow(QMainWindow):
         self._re_running = False
         self._re_pulse_timer = None            # green "running" pulse (play label)
         self._re_start_btn_pulse_timer = None  # yellow "start me" pulse (start button)
+        # The Remote Explorer's chosen local "sync root". "" until the user picks
+        # a folder in its left file explorer; the 'Start NextSync server' button
+        # stays disabled (with a prompt) until then. Mirrored from the widget via
+        # _re_on_sync_root_changed.
+        self._re_sync_root = ""
 
         def _re_enqueue(cmd):
             if self._re_queue is not None:
@@ -10845,6 +10850,44 @@ class MainWindow(QMainWindow):
                 pass
         self._re_apply_item_colors = _re_apply_item_colors
 
+        # 'Start NextSync server' button text shown once a sync root is chosen.
+        _RE_START_TEXT = "▶ Start NextSync server"
+        _RE_NO_ROOT_TEXT = "Please select a sync root folder on the left local file explorer"
+
+        def _re_update_start_button():
+            # Reflect the current state on the Remote Explorer's server button
+            # (pulses only run while the Remote Explorer view is in front):
+            #   running        -> "Stop", clickable, no pulse
+            #   sync root set  -> "Start", clickable, yellow "start me" pulse
+            #   no sync root   -> prompt text, disabled, green "pick one" pulse
+            btn = self.nextsync_re_start_button
+            if self._re_running:
+                _re_stop_startbtn_pulse()
+                btn.setEnabled(True)
+                btn.setText("⏹ Stop NextSync server")
+                return
+            in_view = self.nextsync_remote_button.isChecked()
+            if getattr(self, "_re_sync_root", ""):
+                btn.setEnabled(True)
+                btn.setText(_RE_START_TEXT)
+                _re_start_startbtn_pulse("yellow") if in_view else _re_stop_startbtn_pulse()
+            else:
+                btn.setEnabled(False)
+                btn.setText(_RE_NO_ROOT_TEXT)
+                _re_start_startbtn_pulse("green") if in_view else _re_stop_startbtn_pulse()
+        self._re_update_start_button = _re_update_start_button
+
+        def _re_on_sync_root_changed(root):
+            # The widget reports the user picked (or changed) the local sync root.
+            self._re_sync_root = (root or "").strip()
+            if self._re_sync_root:
+                try:
+                    configuration_dictionary[SETTING_NEXTSYNC_EXPLORERPATH] = self._re_sync_root
+                    save_configuration_file()
+                except Exception:
+                    pass
+            _re_update_start_button()
+
         def _nextsync_build_remote_explorer():
             if self._re_widget is not None:
                 return self._re_widget
@@ -10852,10 +10895,14 @@ class MainWindow(QMainWindow):
             widget = RemoteExplorerWidget(
                 _re_enqueue, local_start_dir=start_dir,
                 log=lambda s: add_nextsync_log_window(str(s)),
-                drain=_re_drain)
+                drain=_re_drain, on_sync_root_changed=_re_on_sync_root_changed)
             self._re_widget = widget
             self.nextsync_log_stack.addWidget(widget)
             _re_apply_item_colors()          # tint to the user's configured colours
+            # Sync the cached sync root with whatever the widget restored (a saved
+            # path enables Start; first run leaves it disabled).
+            self._re_sync_root = widget.sync_root() or ""
+            _re_update_start_button()
             return widget
 
         # Soft green "breathing" pulse on the running indicator (same idea as the
@@ -10897,10 +10944,15 @@ class MainWindow(QMainWindow):
         # Explorer is open but the server has not been started yet — the amber
         # counterpart to the green "running" pulse above, so it's obvious the
         # next step is to start the server.
-        def _re_start_startbtn_pulse():
+        def _re_start_startbtn_pulse(color="yellow"):
             _re_stop_startbtn_pulse()
             steps = 22
             phase = {"n": 0}
+            # Pulse colour encodes what the button is asking for:
+            #   green  -> no sync root yet, prompting the user to pick a folder
+            #   yellow -> sync root chosen, server not started ("start me")
+            (r, g, b), fg = ((46, 204, 113), "#eafff0") if color == "green" \
+                else ((241, 196, 15), "#3a2e00")
 
             def _tick():
                 phase["n"] = (phase["n"] + 1) % (2 * steps)
@@ -10909,10 +10961,11 @@ class MainWindow(QMainWindow):
                 a = int(70 + 150 * tri)
                 try:
                     self.nextsync_re_start_button.setStyleSheet(
-                        "QPushButton { color: #3a2e00; font-weight: bold;"
+                        "QPushButton { color: %s; font-weight: bold;"
                         " padding: 4px 10px; border-radius: 6px;"
-                        f" background-color: rgba(241,196,15,{a});"
-                        f" border: 1px solid rgba(241,196,15,{min(a + 60, 255)}); }}")
+                        " background-color: rgba(%d,%d,%d,%d);"
+                        " border: 1px solid rgba(%d,%d,%d,%d); }" % (
+                            fg, r, g, b, a, r, g, b, min(a + 60, 255)))
                 except RuntimeError:
                     pass
             timer = QTimer(self)
@@ -10949,20 +11002,24 @@ class MainWindow(QMainWindow):
             self._re_running = False
             _re_stop_play_pulse()          # green "running" pulse off
             try:
-                self.nextsync_re_start_button.setText("▶ Start NextSync server")
                 self.nextsync_re_play_label.setVisible(False)
             except RuntimeError:
                 pass
             add_nextsync_log_window(
                 "Remote explorer: the Next disconnected (BREAK / Bye). "
                 "Press 'Start NextSync server' to accept a new connection.")
-            # Still viewing the Remote Explorer? Pulse Start yellow again to
-            # prompt starting a fresh server.
-            if self.nextsync_remote_button.isChecked():
-                _re_start_startbtn_pulse()
+            # Restore the button to "Start" (and pulse it, if still in view and a
+            # sync root is set) so the user can accept a fresh connection.
+            _re_update_start_button()
 
         def _nextsync_start_listen_server():
             if self._re_running:
+                return
+            # A sync root must be chosen first (the button is normally disabled
+            # without one; this guards direct/programmatic calls).
+            if not getattr(self, "_re_sync_root", ""):
+                add_nextsync_log_window(
+                    "Select a sync root folder in the left local file explorer first.")
                 return
             # Can't run the listen server while a normal sync is in progress.
             t = getattr(self, "_nextsync_thread", None)
@@ -11030,10 +11087,12 @@ class MainWindow(QMainWindow):
             self._re_running = False
             _re_stop_play_pulse()
             try:
-                self.nextsync_re_start_button.setText("▶ Start NextSync server")
                 self.nextsync_re_play_label.setVisible(False)
             except RuntimeError:
                 pass
+            # Back to "not started": restore the button (Start + pulse if a sync
+            # root is set and we're still in view, else the disabled prompt).
+            _re_update_start_button()
         # Exposed so app-exit paths (window close / Ctrl-C) can say goodbye to a
         # connected Next before the process dies. Safe/idempotent to call twice.
         self._nextsync_stop_listen_server_fn = _nextsync_stop_listen_server
@@ -11041,9 +11100,6 @@ class MainWindow(QMainWindow):
         def _nextsync_re_toggle_server():
             if self._re_running:
                 _nextsync_stop_listen_server()
-                # Back to "not started" while still in the Remote Explorer view:
-                # pulse the Start button again to prompt starting it.
-                _re_start_startbtn_pulse()
             else:
                 _nextsync_start_listen_server()
         self._nextsync_re_toggle_server = _nextsync_re_toggle_server
@@ -11061,9 +11117,9 @@ class MainWindow(QMainWindow):
                 self.nextsync_slowtransfer_checkbox.setVisible(False)
                 self.nextsync_re_start_button.setVisible(True)
                 self.nextsync_re_play_label.setVisible(self._re_running)
-                # Not started yet -> pulse the Start button yellow to prompt it.
-                if not self._re_running:
-                    _re_start_startbtn_pulse()
+                # Set the button state: disabled with a "pick a sync root" prompt
+                # until the user selects one, then "Start" (pulsing yellow).
+                _re_update_start_button()
                 # Give the Remote Explorer the full width: hide the local file
                 # explorer column (with its SyncIgnore / SyncPoint buttons) and
                 # the name filter. The drive switcher stays so the Remote
@@ -11072,7 +11128,8 @@ class MainWindow(QMainWindow):
                 self.nextsync_filterlabel.setVisible(False)
                 self.nextsync_filtertext.setVisible(False)
                 add_nextsync_log_window(
-                    "Remote explorer: click 'Start NextSync server', then run '.sync4 -listen' on your Next.")
+                    "Remote explorer: pick a sync root folder in the left file explorer, "
+                    "click 'Start NextSync server', then run '.sync4 -listen' on your Next.")
             else:
                 _nextsync_stop_listen_server()
                 _re_stop_startbtn_pulse()   # leaving the RE view: drop the pulse

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -20,8 +20,8 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import (
     QAbstractItemView, QFileSystemModel, QGridLayout, QHBoxLayout, QInputDialog,
-    QLabel, QMenu, QMessageBox, QPushButton, QStyle, QTreeView, QVBoxLayout,
-    QWidget,
+    QLabel, QLineEdit, QMenu, QMessageBox, QPushButton, QStyle, QTreeView,
+    QVBoxLayout, QWidget,
 )
 
 from zxnu_config import (
@@ -29,7 +29,7 @@ from zxnu_config import (
     DEFAULT_COLOR_FILE_NAME, DEFAULT_COLOR_FILE_EXT, DEFAULT_COLOR_FILE_SIZE,
     DEFAULT_COLOR_GENERAL_TEXT, hex_to_qcolor,
 )
-from zxnu_workers import HdfProgressDialog
+from zxnu_workers import DotDotFirstProxyModel, HdfProgressDialog
 
 # Roles carrying the remote entry's full posix path and its directory flag.
 RE_PATH_ROLE = Qt.UserRole + 1
@@ -115,16 +115,24 @@ class RemoteExplorerWidget(QWidget):
     enqueue(cmd_tuple) is the single channel to the listen worker; the host wires
     the worker's signals to on_connected/on_disconnected/on_listing/on_got/
     on_put_done/on_op_done.  `log` is an optional callable(str) for status lines.
+    `on_sync_root_changed` is an optional callable(str) fired whenever the user
+    picks (or clears) the local "sync root" folder, so the host can enable/disable
+    the 'Start NextSync server' button.
     """
 
     def __init__(self, enqueue, local_start_dir=None, log=None, parent=None,
-                 drain=None):
+                 drain=None, on_sync_root_changed=None):
         super().__init__(parent)
         self._enqueue_raw = enqueue          # host closure: put one command
         self._drain_raw = drain              # host closure: empty the queue, -> count
         self._log = log or (lambda s: None)
+        self._on_sync_root_changed = on_sync_root_changed or (lambda p: None)
         self._cwd = "/"                      # current Next directory
         self._connected = False
+        # The local folder the Remote Explorer works in. "" until the user picks
+        # one (first run); a folder must be chosen before the server can start.
+        self._sync_root = ""
+        self._browse_root = ""               # folder the local tree is rooted at
         # Internal copy/paste buffer shared between the two panes, as
         # (kind, items, mode) where kind is "local"/"next", mode is "copy"/"cut"
         # and items is [local_path, …] or [(remote_path, is_dir), …].
@@ -156,8 +164,18 @@ class RemoteExplorerWidget(QWidget):
         # ---- left: local file explorer ------------------------------------
         self.local_model = ColoredFileSystemModel(self._colors, self)
         self.local_model.setRootPath("")
+        # Name-filter proxy, mirroring the classic sync local explorer: it filters
+        # by file name and keeps any ".." entry on top. The per-item foreground
+        # colours pass straight through to the source model.
+        self.local_proxy = DotDotFirstProxyModel(
+            recursiveFilteringEnabled=True,
+            filterRole=QFileSystemModel.FileNameRole)
+        self.local_proxy.setSourceModel(self.local_model)
+        self.local_proxy.setSortCaseSensitivity(Qt.CaseInsensitive)
+        self.local_proxy.setDynamicSortFilter(True)
+
         self.local_view = QTreeView(self)
-        self.local_view.setModel(self.local_model)
+        self.local_view.setModel(self.local_proxy)
         self.local_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.local_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.local_view.setUniformRowHeights(True)
@@ -171,6 +189,7 @@ class RemoteExplorerWidget(QWidget):
         self.local_view.setDragEnabled(True)
         self.local_view.setAcceptDrops(True)
         self.local_view.setDropIndicatorShown(True)
+        self.local_view.clicked.connect(self._local_clicked)
         self.local_view.doubleClicked.connect(self._local_double_clicked)
         self.local_view.dragEnterEvent = self._local_drag_enter
         self.local_view.dragMoveEvent = self._local_drag_enter
@@ -179,13 +198,8 @@ class RemoteExplorerWidget(QWidget):
         self.local_view.setContextMenuPolicy(Qt.CustomContextMenu)
         self.local_view.customContextMenuRequested.connect(self._local_context_menu)
 
-        self.local_path_label = QLabel(self)
-        self.local_path_label.setToolTip("Local folder (double-click a folder to enter, Up to go back)")
-
-        start = local_start_dir if (local_start_dir and os.path.isdir(local_start_dir)) \
-            else QDir.homePath()
-        self._set_local_dir(start)
-
+        # Top bar: Up / Refresh + the name filter ("Search: … Filter by name…"),
+        # mirroring the classic sync local explorer.
         local_up = QPushButton("Up", self)
         local_up.setMaximumWidth(48)
         local_up.clicked.connect(self._local_up)
@@ -193,19 +207,45 @@ class RemoteExplorerWidget(QWidget):
         local_refresh.setMaximumWidth(72)
         local_refresh.setToolTip("Re-read the current local folder from disk")
         local_refresh.clicked.connect(self._local_refresh)
+        self.local_filter_label = QLabel("Search: ", self)
+        self.local_filter_edit = QLineEdit(self)
+        self.local_filter_edit.setPlaceholderText("Filter by name...")
+        self.local_filter_edit.setClearButtonEnabled(True)
+        self.local_filter_edit.textChanged.connect(self._local_filter_changed)
         local_bar = QHBoxLayout()
         local_bar.setContentsMargins(0, 0, 0, 0)
         local_bar.addWidget(local_up)
         local_bar.addWidget(local_refresh)
-        local_bar.addWidget(self.local_path_label, 1)
+        local_bar.addWidget(self.local_filter_label)
+        local_bar.addWidget(self.local_filter_edit, 1)
+
+        # Under the tree: the sync-root path box (same idea as classic sync's
+        # "Path…" field). Shows the chosen sync root; typing a folder path and
+        # pressing Enter jumps there and selects it.
+        self.local_path_edit = QLineEdit(self)
+        self.local_path_edit.setPlaceholderText("Select a sync root folder above...")
+        self.local_path_edit.setToolTip(
+            "Sync root: the local folder the Remote Explorer works in. Click a "
+            "folder above to choose it, or type a path here and press Enter.")
+        self.local_path_edit.editingFinished.connect(self._on_path_edit)
 
         local_box = QVBoxLayout()
         local_box.setContentsMargins(0, 0, 0, 0)
         local_box.setSpacing(2)
         local_box.addLayout(local_bar)
         local_box.addWidget(self.local_view)
+        local_box.addWidget(self.local_path_edit)
         local_container = QWidget(self)
         local_container.setLayout(local_box)
+
+        # First run has no sync root: browse from home but leave the sync root
+        # unset, so the host keeps the Start button disabled until the user picks
+        # a folder. A saved path (SETTING_NEXTSYNC_EXPLORERPATH) is restored as
+        # the sync root and enables Start straight away.
+        if local_start_dir and os.path.isdir(local_start_dir):
+            self._set_local_dir(local_start_dir, commit=True)
+        else:
+            self._set_local_dir(QDir.homePath(), commit=False)
 
         # ---- centre: transfer buttons -------------------------------------
         self.btn_to_next = QPushButton("->:", self)
@@ -922,27 +962,70 @@ class RemoteExplorerWidget(QWidget):
     # ==================================================================
     #  local pane
     # ==================================================================
-    def set_local_dir(self, path):
-        """Public: point the local pane at `path` (e.g. a drive root).
+    def sync_root(self):
+        """The chosen sync-root folder ("" until the user picks one). The host
+        gates the 'Start NextSync server' button on this."""
+        return self._sync_root
 
-        Used by the host's drive switcher so the Remote Explorer can change
-        drive too. Ignored if `path` isn't an existing directory.
+    def set_local_dir(self, path):
+        """Public: point the local pane's browse root at `path` (e.g. a drive
+        root from the host's drive switcher). Leaves the sync root unchanged.
+        Ignored if `path` isn't an existing directory.
         """
         if path and os.path.isdir(path):
-            self._set_local_dir(path)
+            self._set_local_dir(path, commit=False)
 
-    def _set_local_dir(self, path):
-        self.local_view.setRootIndex(self.local_model.index(path))
-        self.local_path_label.setText(path)
+    # -- index mapping between the filter proxy (the view) and the file model --
+    def _view_ix(self, path):
+        return self.local_proxy.mapFromSource(self.local_model.index(path))
+
+    def _path_of(self, view_ix):
+        return self.local_model.filePath(self.local_proxy.mapToSource(view_ix))
+
+    def _browse_dir(self):
+        """The folder the tree is rooted at (used by Up / Refresh / New Folder)."""
+        return self._browse_root or QDir.homePath()
 
     def _local_dir(self):
-        return self.local_model.filePath(self.local_view.rootIndex()) or QDir.homePath()
+        """Where downloads land: the sync root once chosen, else the browse root."""
+        return self._sync_root or self._browse_dir()
+
+    def _set_local_dir(self, path, commit=True):
+        """Point the browse root at `path`. When `commit`, also make it the sync
+        root (navigating into a folder means you want to work there)."""
+        path = path.replace("\\", "/") if path else path
+        self.local_view.setRootIndex(self._view_ix(path))
+        self._browse_root = path
+        if commit:
+            self._commit_sync_root(path)
+
+    def _commit_sync_root(self, path):
+        """Record `path` as the sync root, show it in the path box, and notify the
+        host (which enables the Start button)."""
+        norm = (path or "").replace("\\", "/").rstrip("/")
+        if not norm or not os.path.isdir(norm):
+            return
+        self._sync_root = norm
+        if self.local_path_edit.text() != norm:
+            self.local_path_edit.setText(norm)
+        self._on_sync_root_changed(norm)
+
+    def _local_filter_changed(self, text):
+        self.local_proxy.setFilterFixedString((text or "").strip())
+
+    def _on_path_edit(self):
+        new = self.local_path_edit.text().strip()
+        if new and os.path.isdir(new):
+            self._set_local_dir(new, commit=True)
+        else:
+            # Restore the last valid sync root (empty falls back to placeholder).
+            self.local_path_edit.setText(self._sync_root)
 
     def _local_up(self):
-        cur = self._local_dir()
+        cur = self._browse_dir()
         parent = os.path.dirname(cur.rstrip("/\\"))
         if parent and os.path.isdir(parent):
-            self._set_local_dir(parent)
+            self._set_local_dir(parent, commit=True)
 
     def _local_refresh(self):
         """Force the local pane to re-read the current folder from disk.
@@ -951,22 +1034,32 @@ class RemoteExplorerWidget(QWidget):
         via its file-system watcher, but bouncing the root path guarantees an
         immediate rescan (e.g. right after files land from a download).
         """
-        cur = self._local_dir()
+        cur = self._browse_dir()
         self.local_model.setRootPath("")          # bounce so an unchanged path rescans
         self.local_model.setRootPath(cur or "")
         if cur and os.path.isdir(cur):
-            self.local_view.setRootIndex(self.local_model.index(cur))
-            self.local_path_label.setText(cur)
+            self.local_view.setRootIndex(self._view_ix(cur))
+
+    def _local_clicked(self, index):
+        """Single-click picks a sync root, like the classic sync explorer: a
+        folder selects itself, a file selects its parent folder. Changing the
+        tree root (browsing) still happens on double-click / Up."""
+        path = self._path_of(index)
+        if not path:
+            return
+        folder = path if os.path.isdir(path) else os.path.dirname(path)
+        if folder and os.path.isdir(folder):
+            self._commit_sync_root(folder)
 
     def _local_double_clicked(self, index):
-        path = self.local_model.filePath(index)
+        path = self._path_of(index)
         if os.path.isdir(path):
-            self._set_local_dir(path)
+            self._set_local_dir(path, commit=True)
 
     def _selected_local_paths(self):
         out = []
         for ix in self.local_view.selectionModel().selectedRows(0):
-            p = self.local_model.filePath(ix)
+            p = self._path_of(ix)
             if p:
                 out.append(p)
         return out
@@ -1033,7 +1126,7 @@ class RemoteExplorerWidget(QWidget):
             self._local_refresh()
 
     def _local_new_folder(self):
-        base = self._local_dir()
+        base = self._browse_dir()
         if not base or not os.path.isdir(base):
             return
         name, ok = QInputDialog.getText(self, "New Folder", f"New folder in {base}:")


### PR DESCRIPTION
## Summary
Brings the NextSync **Remote Explorer**'s two panes (local + Next) in line with the SD Card Utility's image tree and classic sync mode.

### Colored Name/Type/Size trees
- Both panes now show **Name / Type / Size** columns tinted with the configurable font-color settings (dir/file name, type, ext, size, up-directory), via a new `ColoredFileSystemModel` and `set_item_colors()`, wired from the host on build and whenever colors change (Settings picker + Desktop Theme).

### Sync-root gating on the Start button
- The Start button is **disabled** and reads *"Please select a sync root folder on the left local file explorer"* — pulsing **green** — until the user picks a folder. Once selected it flips to **"▶ Start NextSync server"** (pulsing yellow) and becomes clickable. A saved path is restored on later runs; first run starts unset.

### Sync-root path box + name filter
- Added an editable **sync-root path box** under the local tree (like classic mode's Path field) and a **"Search: / Filter by name…"** box using the same `DotDotFirstProxyModel` name filter as classic sync.

Drag and drop is **unchanged** — all local index access maps through the filter proxy, and the colored foreground data passes straight through.

## Testing
- Both files compile.
- Headless widget tests: first run has no sync root; selecting a folder fills the path box, fires the host callback, and sets the download destination; name filter works and clears; single-click selects a sync root without navigating; selection/paths map correctly through the proxy; Next + local panes tint correctly and re-tint on color change.
- Headless full-app runs (including Remote Explorer opened at startup with no sync root) run clean, exercising the widget build, the disabled/green-pulse button state, and color wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)