### PR TITLE
v9.0.3: Remote Explorer recursive delete + local copy/paste & drag-drop

### DIFF
--- a/nextsync/sync/server/test_remote_listen.py
+++ b/nextsync/sync/server/test_remote_listen.py
@@ -35,12 +35,36 @@ def rx_payload(s):
 def settle():
     time.sleep(0.003)
 
-def mock_next(sock, entries, filebytes, cap):
+def fs_node(fs, path):
+    """Walk the mock filesystem dict to ``path``; None if missing. Dirs are
+    dicts, files are bytes."""
+    node = fs
+    for part in [p for p in path.split("/") if p]:
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+def fs_parent(fs, path):
+    """(parent dict, leaf name) for ``path``, or (None, None) if unreachable."""
+    parts = [p for p in path.split("/") if p]
+    if not parts:
+        return None, None
+    node = fs
+    for part in parts[:-1]:
+        if not isinstance(node, dict) or part not in node:
+            return None, None
+        node = node[part]
+    return (node, parts[-1]) if isinstance(node, dict) else (None, None)
+
+def mock_next(sock, entries, filebytes, cap, fs):
     sock.sendall(b"Listen")
     assert rx_payload(sock) == b"Listening"
     def push(payload, pkt):
         settle(); sock.sendall(frame(payload, pkt))
         assert rx_payload(sock)[0:1] == b'O'
+    def push_status(ok):
+        push(b'O' if ok else b'F', 0)
     while True:
         settle(); sock.sendall(b"Poll")
         cmd = rx_payload(sock)
@@ -50,6 +74,21 @@ def mock_next(sock, entries, filebytes, cap):
         if op == b'L':
             if arg.rstrip("/") == "/gone":
                 push(b'F', 0)            # opendir failed on the Next: folder is gone
+                continue
+            if arg.rstrip("/").startswith("/del"):
+                # rmtree playground: list from the mock fs, dirs first, with the
+                # "." / ".." entries a real readdir yields (the walker must skip
+                # them or it would recurse forever).
+                node = fs_node(fs, arg)
+                if not isinstance(node, dict):
+                    push(b'F', 0)
+                    continue
+                pl = b'D'
+                for name, child in [(".", {}), ("..", {})] + sorted(node.items()):
+                    is_dir = isinstance(child, dict)
+                    size = 0 if is_dir else len(child)
+                    pl += bytes([1 if is_dir else 0]) + int(size).to_bytes(4, "little") + bytes([len(name)]) + name.encode()
+                push(pl, 0); push(b'E', 1)
                 continue
             pl = b'D'
             for is_dir, size, name in entries:
@@ -88,7 +127,33 @@ def mock_next(sock, entries, filebytes, cap):
         elif op == b'V':                     # ren: arg is "old\x00new"
             cap['ren'] = arg
             push(b'O', 0)
-        elif op in (b'M', b'R', b'X'):
+        elif op == b'X':
+            if arg.startswith("/del"):
+                # rm against the mock fs; "locked.txt" simulates an esxDOS
+                # delete failure (read-only/open file).
+                parent, name = fs_parent(fs, arg)
+                if (parent is not None and name != "locked.txt"
+                        and not isinstance(parent.get(name), dict)
+                        and name in parent):
+                    del parent[name]
+                    push_status(1)
+                else:
+                    push_status(0)
+            else:
+                push(b'O', 0)
+        elif op == b'R':
+            if arg.startswith("/del"):
+                # esxDOS semantics: rmdir only removes an EMPTY directory.
+                parent, name = fs_parent(fs, arg)
+                node = parent.get(name) if parent is not None else None
+                if isinstance(node, dict) and len(node) == 0:
+                    del parent[name]
+                    push_status(1)
+                else:
+                    push_status(0)
+            else:
+                push(b'O', 0)
+        elif op == b'M':
             push(b'O', 0)
 
 def main():
@@ -101,6 +166,10 @@ def main():
 
     entries = [(True, 0, "GAMES"), (False, 1234, "boot.bas")]
     filebytes = b"Hello Next!\r\n" * 5
+    # Mock Next-side filesystem for the rmtree tests: /del is a healthy nested
+    # tree (with an empty folder); /del2 holds a file the Next refuses to rm.
+    fs = {"del": {"a.txt": b"AA", "sub": {"b.txt": b"BB", "empty": {}}},
+          "del2": {"locked.txt": b"LL"}}
     cap = {}
     got = {'listing': None, 'gets': [], 'put': None, 'puts': [], 'ops': [],
            'ls_failed': []}
@@ -122,6 +191,8 @@ def main():
               ("put", putfile, "/ho/"),
               ("put", putfile, "/locked/up.bin"),   # put that fails with 'F'
               ("rm", "/x.tap"), ("rmdir", "/y"),
+              ("rmtree", "/del"),                   # recursive delete, must empty the tree
+              ("rmtree", "/del2"),                  # contains an undeletable file -> ok=False
               ("rename", "/ho/a.txt", "/ho/b.txt"), ("quit",)]:
         cmd_q.put(c)
 
@@ -130,7 +201,7 @@ def main():
     time.sleep(0.3)  # let it bind/accept
     s = socket.create_connection(("127.0.0.1", PORT), timeout=5)
     try:
-        mock_next(s, entries, filebytes, cap)
+        mock_next(s, entries, filebytes, cap, fs)
     finally:
         stop.set(); t.join(timeout=5); s.close()
 
@@ -178,6 +249,21 @@ def main():
         print("PASS ren  :", cap['ren'].replace("\x00", " -> "))
     else:
         print("FAIL ren  :", cap.get('ren'), got['ops']); ok = False
+    # rmtree must have deleted the whole /del tree (files first, folders
+    # bottom-up: esxDOS rmdir only removes empty folders, and the mock enforces
+    # that) and reported ONE op_done(True, "delete", "/del").
+    if "del" not in fs and (True, "delete", "/del") in got['ops']:
+        print("PASS rmtree: /del fully removed, one delete op reported")
+    else:
+        print("FAIL rmtree: fs=", fs, "ops:", got['ops']); ok = False
+    # /del2 holds an undeletable file: the tree must survive and the job must
+    # report ok=False (exactly once) without desyncing later commands (ren above).
+    if (fs.get("del2") == {"locked.txt": b"LL"}
+            and (False, "delete", "/del2") in got['ops']
+            and sum(1 for o in got['ops'] if o[1] == "delete") == 2):
+        print("PASS rmtree-fail: /del2 kept, delete reported failed")
+    else:
+        print("FAIL rmtree-fail: fs=", fs.get("del2"), "ops:", got['ops']); ok = False
     # A missing folder must raise ls_failed (never a phantom empty listing) and
     # leave the stream in sync so the later commands above still passed.
     if got['ls_failed'] == ["/gone"]:

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.0.2"
+ZX_NEXT_UNITE_VERSION = "9.0.3"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -299,6 +299,10 @@ class RemoteExplorerWidget(QWidget):
         self.local_view.setDragEnabled(True)
         self.local_view.setAcceptDrops(True)
         self.local_view.setDropIndicatorShown(True)
+        # A drag within the local pane proposes a COPY (we perform the copy
+        # ourselves in _local_drop); without this Qt would propose an internal
+        # move for same-view drags.
+        self.local_view.setDefaultDropAction(Qt.CopyAction)
         self.local_view.clicked.connect(self._local_clicked)
         self.local_view.doubleClicked.connect(self._local_double_clicked)
         self.local_view.dragEnterEvent = self._local_drag_enter
@@ -965,12 +969,18 @@ class RemoteExplorerWidget(QWidget):
         if not entries:
             return
         names = "\n".join(p for p, _ in entries)
-        if QMessageBox.question(self, "Delete", f"Delete on the Next?\n\n{names}") != QMessageBox.Yes:
+        if QMessageBox.question(
+                self, "Delete",
+                "Delete on the Next? Folders are deleted with everything "
+                f"inside them.\n\n{names}") != QMessageBox.Yes:
             return
 
+        # Folders go through the worker's recursive rmtree walk: esxDOS rmdir
+        # only removes *empty* folders, so a bare rmdir on a folder with content
+        # fails and deletes nothing.
         def go():
             for path, is_dir in entries:
-                self._enqueue(("rmdir" if is_dir else "rm", path))
+                self._enqueue(("rmtree" if is_dir else "rm", path))
         self._run_op("Deleting on the Next…", go)
 
     def _next_key_press(self, event):
@@ -1012,7 +1022,9 @@ class RemoteExplorerWidget(QWidget):
             self._clip = ("local", paths, mode)
             verb = "Cut" if mode == "cut" else "Copied"
             self._log(f"{verb} {len(paths)} local item(s). Paste in the Next "
-                      "pane to " + ("move" if mode == "cut" else "upload") + ".")
+                      "pane to " + ("move" if mode == "cut" else "upload")
+                      + ", or in a local folder to "
+                      + ("move" if mode == "cut" else "copy") + " it there.")
 
     def _paste_into_next(self):
         # Paste local clipboard items into the current Next directory: copy =
@@ -1031,9 +1043,18 @@ class RemoteExplorerWidget(QWidget):
                          lambda: self._put_paths(paths))
 
     def _paste_into_local(self):
-        # Paste Next clipboard items into the current local directory: copy =
-        # download, cut = download then delete the Next source once confirmed.
-        if not self._clip or self._clip[0] != "next":
+        # Paste the clipboard into the current local directory. Next items:
+        # copy = download, cut = download then delete the Next source once
+        # confirmed. Local items: copy = duplicate here, cut = move here.
+        if not self._clip:
+            return
+        if self._clip[0] == "local":
+            _kind, paths, mode = self._clip
+            paths = [p for p in paths if os.path.exists(p)]
+            if mode == "cut":
+                self._clip = None            # a cut is consumed by its paste
+            self._copy_paths_into_local(paths, self._local_dir(),
+                                        move=(mode == "cut"), dup_in_place=True)
             return
         _kind, entries, mode = self._clip
         entries = list(entries)
@@ -1376,9 +1397,9 @@ class RemoteExplorerWidget(QWidget):
         return out
 
     def _local_key_press(self, event):
-        # Ctrl+C / Ctrl+X copy or cut the local selection; Ctrl+V pastes Next
-        # clipboard items here (download). Delete / F2 act on the local pane,
-        # mirroring the Next pane. (QFileSystemModel refreshes on change.)
+        # Ctrl+C / Ctrl+X copy or cut the local selection; Ctrl+V pastes the
+        # clipboard here (Next items download, local items copy/move). Delete /
+        # F2 act on the local pane, mirroring the Next pane.
         if event.matches(QKeySequence.StandardKey.Copy):
             self._copy_local("copy")
             return
@@ -1418,8 +1439,9 @@ class RemoteExplorerWidget(QWidget):
         act_cut.setEnabled(has_sel)
         act_ren.setEnabled(len(sel) == 1)
         act_del.setEnabled(has_sel)
-        # Paste here downloads the copied/cut Next items into this local folder.
-        act_paste.setEnabled(bool(self._clip) and self._clip[0] == "next")
+        # Paste here downloads copied/cut Next items into this local folder, or
+        # copies/moves copied/cut LOCAL items into it.
+        act_paste.setEnabled(bool(self._clip))
         chosen = menu.exec(self.local_view.viewport().mapToGlobal(pos))
         if chosen == act_new:
             self._local_new_folder()
@@ -1476,6 +1498,71 @@ class RemoteExplorerWidget(QWidget):
                 self._log(f"Deleted {p}")
             except OSError as ex:
                 self._log(f"Delete failed: {p}: {ex}")
+
+    @staticmethod
+    def _unique_copy_target(dest, name):
+        """A free path for ``name`` inside ``dest``: the name itself if unused,
+        else "name - Copy", "name - Copy (2)", … (Explorer-style), so a paste
+        into the source's own folder duplicates instead of overwriting."""
+        target = os.path.join(dest, name)
+        if not os.path.exists(target):
+            return target
+        stem, ext = os.path.splitext(name)
+        n = 1
+        while True:
+            suffix = " - Copy" if n == 1 else f" - Copy ({n})"
+            target = os.path.join(dest, stem + suffix + ext)
+            if not os.path.exists(target):
+                return target
+            n += 1
+
+    def _copy_paths_into_local(self, paths, dest, move=False, dup_in_place=False):
+        """Copy (or move) local files/folders into the local folder ``dest``.
+
+        Backs both a drag-drop onto a folder and a local Copy/Cut -> Paste.
+        Copies colliding with an existing name get an Explorer-style
+        " - Copy" name; a same-folder copy only does that when
+        ``dup_in_place`` (deliberate paste), a drag there is a no-op. Moves
+        never overwrite and a same-folder move is always a no-op. Failures are
+        logged and summarised in one toast.
+        """
+        fails = []
+        done = 0
+        dest_abs = os.path.normcase(os.path.abspath(dest))
+        for src in paths:
+            name = os.path.basename(src.rstrip("/\\")) or src
+            src_abs = os.path.normcase(os.path.abspath(src))
+            src_is_dir = os.path.isdir(src) and not os.path.islink(src)
+            if src_is_dir and (dest_abs == src_abs
+                               or dest_abs.startswith(src_abs + os.sep)):
+                self._log(f"Skipped {name}: cannot copy a folder into itself.")
+                fails.append(f"{name}: cannot copy a folder into itself")
+                continue
+            same_folder = os.path.normcase(
+                os.path.dirname(src_abs.rstrip("\\/"))) == dest_abs
+            if same_folder and (move or not dup_in_place):
+                continue                     # already here: nothing to do
+            target = self._unique_copy_target(dest, name)
+            if move and os.path.basename(target) != name:
+                self._log(f"Skipped {name}: already exists in {dest}.")
+                fails.append(f"{name}: already exists")
+                continue
+            try:
+                if move:
+                    shutil.move(src, target)
+                elif src_is_dir:
+                    shutil.copytree(src, target, symlinks=True)
+                else:
+                    shutil.copy2(src, target)
+                done += 1
+                self._log(f"{'Moved' if move else 'Copied'} {src} -> {target}")
+            except (OSError, shutil.Error) as ex:
+                self._log(f"{'Move' if move else 'Copy'} failed: {src}: {ex}")
+                fails.append(f"{name}: {ex}")
+        if done:
+            self._local_refresh()
+        if fails:
+            self._toast_failures(fails)
 
     def _local_rename_selected(self):
         paths = self._selected_local_paths()
@@ -1536,15 +1623,37 @@ class RemoteExplorerWidget(QWidget):
         drag.exec(Qt.CopyAction)
 
     def _local_drag_enter(self, event):
-        if event.mimeData().hasFormat("application/x-zxnu-next-entries"):
+        # Next-pane entries (download here) or file URLs -- from the local pane
+        # itself or the OS file manager (copy into the folder dropped on).
+        if (event.mimeData().hasFormat("application/x-zxnu-next-entries")
+                or event.mimeData().hasUrls()):
             event.acceptProposedAction()
         else:
             event.ignore()
 
+    def _local_drop_dir(self, event):
+        """The local folder a drop lands in: the folder row under the cursor,
+        else the pane's current folder (the ".." row counts as current too)."""
+        ix = self.local_view.indexAt(event.position().toPoint())
+        if ix.isValid() and not self._is_local_updir(ix):
+            p = self._path_of(ix)
+            if p and os.path.isdir(p):
+                return p
+        return self._local_dir()
+
     def _local_drop(self, event):
         data = event.mimeData().data("application/x-zxnu-next-entries")
         if not data:
-            event.ignore()
+            # Local/OS file drag: copy the dropped items into the folder they
+            # were dropped on (a drop back into their own folder is a no-op).
+            paths = [u.toLocalFile() for u in event.mimeData().urls()
+                     if u.isLocalFile() and os.path.exists(u.toLocalFile())]
+            if not paths:
+                event.ignore()
+                return
+            event.setDropAction(Qt.CopyAction)
+            event.accept()
+            self._copy_paths_into_local(paths, self._local_drop_dir(event))
             return
         event.acceptProposedAction()
         dest = self._local_dir()

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -8,6 +8,7 @@ import queue
 import socket
 import threading
 import time
+from collections import deque
 from PySide6.QtCore import (
     QObject, QPoint, QRect, QRunnable, QSize, QSortFilterProxyModel, QTimer,
     Qt, Signal, Slot,
@@ -372,6 +373,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
         ("mkdir", remote_path)
         ("rmdir", remote_path)
         ("rm",    remote_path)
+        ("rmtree", remote_path)   -> recursive folder delete (see below)
         ("rename", old_path, new_path)
         ("mark",  token)          -> echoes back via sig.marked once reached
         ("quit",)
@@ -382,6 +384,16 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
     queue is a single-consumer FIFO, everything enqueued before the marker has
     finished by then -- the UI uses this to know a cut/move's transfer completed
     before deleting the source.
+
+    ``rmtree`` deletes a whole folder on the Next: esxDOS rmdir only removes
+    *empty* directories, so the worker walks the tree itself over the ordinary
+    protocol -- ls each directory, rm its files, recurse into its sub-folders,
+    then rmdir it once empty (bottom-up). The walk runs as internally queued
+    sub-commands served one per "Poll", exactly like user commands, and reports
+    a single op_done(ok, "delete", root) when the root folder is gone (ok only
+    if every file and folder inside deleted cleanly). A user cancel drains the
+    host queue only, so an rmtree already underway finishes on its own -- same
+    "stop after the current item" semantics as a cancelled transfer.
 
     This is the app-side twin of nextsync5.py's listen_session: same wire
     protocol, but driven by the UI queue and reporting via Qt signals instead of
@@ -434,6 +446,12 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
             put_pkt = 0
             last_packet = b''
             pending = None   # the command awaiting its pushed reply
+            # rmtree walk state: sub-commands the worker generates for itself
+            # (rmtree_ls/rmtree_rm/rmtree_rmdir) are served before the host
+            # queue, so a recursive delete runs as one contiguous batch.
+            local_cmds = deque()
+            rmtree_jobs = {}   # job id -> {'root': path, 'fails': 0}
+            rmtree_seq = 0
 
             while not stop_event.is_set():
                 try:
@@ -475,12 +493,22 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                     put_pkt = 0
 
                 if data == b"Poll":
-                    try:
-                        cmd = cmd_queue.get_nowait()
-                    except queue.Empty:
-                        _re_sendpacket(conn, b"I", 0)   # idle
-                        continue
+                    if local_cmds:
+                        cmd = local_cmds.popleft()
+                    else:
+                        try:
+                            cmd = cmd_queue.get_nowait()
+                        except queue.Empty:
+                            _re_sendpacket(conn, b"I", 0)   # idle
+                            continue
                     op = cmd[0]
+                    if op == "rmtree":
+                        # Recursive folder delete: open a walk job and start with
+                        # the root's listing (handled below, on this same poll).
+                        rmtree_seq += 1
+                        rmtree_jobs[rmtree_seq] = {'root': cmd[1], 'fails': 0}
+                        cmd = ("rmtree_ls", rmtree_seq, cmd[1])
+                        op = cmd[0]
                     if op == "quit":
                         _re_sendpacket(conn, b"Q", 0)
                         break
@@ -605,6 +633,75 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             sig.op_done.emit(bool(res['ok']), op, path)
                         else:
                             sig.error.emit(f"{op} {path}: connection dropped")
+                    elif op == "rmtree_ls":
+                        # rmtree step 1: list one folder of the walk, then queue
+                        # deleting its files, walking its sub-folders and finally
+                        # removing the (now empty) folder itself, ahead of
+                        # anything else -- so the tree comes down bottom-up.
+                        jid, path = cmd[1], cmd[2]
+                        entries = []
+                        st = {'failed': False}
+
+                        def _h(payload, _e=entries, _st=st):
+                            o = payload[0:1]
+                            if o == b'E':
+                                return True
+                            if o == b'F':
+                                _st['failed'] = True
+                                return True
+                            if o == b'D':
+                                i = 1
+                                while i + 6 <= len(payload):
+                                    flags = payload[i]
+                                    nl = payload[i+5]
+                                    name = payload[i+6:i+6+nl].decode(errors='replace')
+                                    i += 6 + nl
+                                    _e.append((bool(flags & 1), name))
+                            return False
+                        _re_sendpacket(conn, b"L" + path.encode(), 0)
+                        if _re_recv_reply(conn, _h):
+                            subs = []
+                            if not st['failed']:
+                                base = path.rstrip("/")
+                                for is_dir, name in entries:
+                                    if name in (".", ".."):
+                                        continue
+                                    child = base + "/" + name
+                                    subs.append(("rmtree_ls", jid, child) if is_dir
+                                                else ("rmtree_rm", jid, child))
+                            # On a failed listing (gone, or not a folder) still try
+                            # the rmdir: it reports the failure if the folder is
+                            # really stuck, instead of stalling the job.
+                            subs.append(("rmtree_rmdir", jid, path))
+                            local_cmds.extendleft(reversed(subs))
+                        else:
+                            rmtree_jobs.pop(jid, None)
+                            sig.error.emit(f"delete {path}: connection dropped")
+                    elif op in ("rmtree_rm", "rmtree_rmdir"):
+                        # rmtree steps 2/3: delete one file / one emptied folder.
+                        # Only the root folder's rmdir reports back to the UI --
+                        # one op_done for the whole job, matching the single
+                        # command the UI enqueued.
+                        jid, path = cmd[1], cmd[2]
+                        opc = b"X" if op == "rmtree_rm" else b"R"
+                        res = {'ok': None}
+
+                        def _h(payload, _r=res):
+                            _r['ok'] = (payload[0:1] == b'O')
+                            return True
+                        _re_sendpacket(conn, opc + path.encode(), 0)
+                        if _re_recv_reply(conn, _h):
+                            job = rmtree_jobs.get(jid)
+                            if job is not None:
+                                if not res['ok']:
+                                    job['fails'] += 1
+                                    log(f"delete: could not remove {path}")
+                                if op == "rmtree_rmdir" and path == job['root']:
+                                    rmtree_jobs.pop(jid, None)
+                                    sig.op_done.emit(job['fails'] == 0, "delete", path)
+                        else:
+                            rmtree_jobs.pop(jid, None)
+                            sig.error.emit(f"delete {path}: connection dropped")
                     elif op == "rename":
                         old, new = cmd[1], cmd[2]
                         res = {'ok': None}


### PR DESCRIPTION
## Summary
- **Next pane delete now actually deletes folders**: esxDOS `rmdir` only removes *empty* directories, so the old single-`rmdir` delete silently failed on any folder with content (no `rm` was ever sent for the files inside). A new worker-side `rmtree` command walks the tree over the existing `-listen` protocol (ls each folder, rm its files, rmdir bottom-up) and reports one `op_done` per job, so UI progress accounting is unchanged and already-deployed `.sync5` dots work as-is.
- **Local pane drag & drop**: dragging local (or OS file-manager) files onto a folder in the left pane now copies them there; dropping items back into their own folder is a no-op.
- **Local pane Copy/Cut -> Paste**: Paste is no longer grayed out for local clipboard items — Copy pastes a copy (Explorer-style `name - Copy` names when pasting in place), Cut moves. Moves never overwrite, and copying a folder into itself is guarded. Cross-pane paste (upload/download) unchanged.
- Version bump 9.0.2 -> 9.0.3.

## Testing
- `nextsync/sync/server/test_remote_listen.py` extended with a mock Next filesystem enforcing esxDOS rmdir semantics (and `.`/`..` readdir entries): rmtree fully empties a nested tree and reports `ok=False` without desync when a file is undeletable — ALL PASS.
- End-to-end offscreen test: real `RemoteExplorerWidget` + real listen worker + fake dot on localhost; multi-select delete of files + non-empty folders empties the fake Next FS cleanly.
- Headless local-pane test: 17 checks over copy/paste, cut/move, collision handling and drag-drop guards — ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)