### PR TITLE
9.0.4: friendly port-busy exit in nextsync5.py, proper root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,25 @@
-# Created by venv; see https://docs.python.org/3/library/venv.html
-#*
+# Python virtual environments created in-place (python -m venv .)
+Lib/
+Scripts/
+Include/
+env/
+pyvenv.cfg
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# IDE / tooling state
+.vs/
+*.pyproj.user
+
+# PyInstaller build outputs (see CLAUDE.md "Packaging (optional)")
+build/
+dist/
+zx-next-unite.spec
+
+# Files the app / NextSync server create at runtime next to themselves
+hdfg.cfg
+syncpoint.dat
+downloads/
+zx-next-unite-crash.log

--- a/nextsync5.py
+++ b/nextsync5.py
@@ -1215,8 +1215,32 @@ def main():
         }
         starttime = 0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", PORT))
-            s.listen()
+            try:
+                s.bind(("", PORT))
+                s.listen()
+            except OSError as ex:
+                # WinError 10048 / errno 98 (Linux) / 48 (macOS): the NextSync
+                # port is already taken - almost always another NextSync
+                # server: a second nextsync5.py, or ZX-Next-Unite with its
+                # classic sync or Remote Explorer listen server running.
+                # Exit cleanly with an explanation instead of a traceback.
+                if getattr(ex, "winerror", None) in (10048, 10013) or \
+                        getattr(ex, "errno", None) in (98, 48):
+                    print()
+                    print(f"{timestamp()} | *** Another process is already "
+                          f"listening on the NextSync port {PORT}. ***")
+                    print(f"{timestamp()} | It is most likely another NextSync "
+                          "server: a second nextsync5.py, or ZX-Next-Unite "
+                          "with its classic sync or Remote Explorer server "
+                          "started.")
+                    print(f"{timestamp()} | Please close/stop that other "
+                          "server first, then start nextsync5.py again.")
+                else:
+                    print()
+                    print(f"{timestamp()} | *** Could not open the NextSync "
+                          f"port {PORT}: {ex} ***")
+                print(f"{timestamp()} | Sync server stopped. Bye!")
+                return
             # Poll accept() with a short timeout so a Ctrl-C pressed while we're
             # idle (no client connected) is noticed promptly - no transfer is in
             # progress, so it's safe to stop right away.

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.0.3"
+ZX_NEXT_UNITE_VERSION = "9.0.4"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False


### PR DESCRIPTION
## What

- **nextsync5.py: clean exit when the NextSync port is taken.** Starting the CLI server while another NextSync server already listens on port 2048 (ZX-Next-Unite''s classic sync or Remote Explorer server, or a second nextsync5.py) used to die with a raw `OSError: [WinError 10048]` traceback. It now prints that another process is already listening, names the likely culprits, asks to close that server first, and exits cleanly (code 0, no traceback). Covers Linux/macOS `EADDRINUSE` and the Windows 10013 variant too; other bind failures get a one-line explanation. Verified by holding port 2048 and launching the script.
- **App version bumped to 9.0.4** (`ZX_NEXT_UNITE_VERSION` in zxnu_config.py) — covers the HTTP bridge, the rcpy precheck/progress/background work and the dot 5.3 pairing.
- **Proper root .gitignore.** Audited that every dot-command source is tracked (z88dk dotN .c/.h/.asm/.inc/.lst/.ps1 and the legacy SDCC .c/.h/.s files — all are). The root .gitignore was just the venv stub, so `git status` drowned in Lib/ env/ build/ dist/ downloads/ noise; it now ignores in-place venvs, bytecode, IDE state, PyInstaller outputs and the app/server runtime files. Verified no tracked file becomes ignored by the new rules.

## Testing

- Port-busy repro: friendly message, empty stderr, exit code 0.
- Listen protocol suite still ALL PASS.
- `git ls-files -i -c` clean apart from the two pre-existing deliberate exceptions (`syncdev.dot`, `ihx2bin.exe` from nextsync/.gitignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)