### PR TITLE
NextSync forceexit, zip/unzip on all explorers, colour-coded free space, 9.0.5

### DIFF
--- a/nextsync/sync/server/HTTP_BRIDGE.md
+++ b/nextsync/sync/server/HTTP_BRIDGE.md
@@ -217,6 +217,34 @@ bytes: 1234567 (1.2 MB)
 ```
 The natural "will it fit" companion of `/rcpy` (check `/free` too).
 
+### `GET /forceexit` — tell the Next to leave `-listen` and exit
+
+```
+curl "http://192.168.1.10/forceexit"
+.http -h 192.168.1.10 -u /forceexit -f ok.txt
+```
+```
+OK forceexit - the Next is disconnecting
+```
+The dot answers its next poll with the protocol's `Q` (quit) opcode: it
+closes the connection and exits **gracefully** to BASIC (the same clean
+path as `quit` in the `listen>` console or pressing BREAK on the Next —
+UART speed, CPU speed and turbo/50-60 settings are all restored). The
+`-listen` server keeps running, so a fresh `.sync5 -listen` reconnects at
+any time. With no Next connected the route answers `503`.
+
+Also callable straight from the command line, without writing a curl line —
+`nextsync5.py -forceexit` calls the route on `127.0.0.1:80` (stdlib only, no
+Flask needed on the calling side), `-forceexit=host[:port]` on any other
+running bridge:
+
+```
+python nextsync5.py -forceexit=192.168.1.10:8080
+```
+
+(In PowerShell, quote the dotted form — `"-forceexit=192.168.1.10:8080"` —
+or PowerShell itself splits the argument at the dots.)
+
 ### `GET /` or `GET /help` — the route list
 
 ```

--- a/nextsync/sync/server/test_http_bridge.py
+++ b/nextsync/sync/server/test_http_bridge.py
@@ -104,6 +104,8 @@ def phase_a():
             return ("free", a1, reply)
         if op == "drives":
             return ("drives", reply)
+        if op == "forceexit":
+            return ("quit", reply)
         return None
 
     def enqueue(cmd):
@@ -193,13 +195,17 @@ def phase_a():
     check("A /drives", st == 200 and b"partitions: 2" in body, body)
 
     st, body = http(HTTP_A, "/help")
-    check("A /help lists routes", st == 200 and b"/rcpy" in body and b"/status" in body)
+    check("A /help lists routes", st == 200 and b"/rcpy" in body
+          and b"/status" in body and b"/forceexit" in body)
 
     st, body = http(HTTP_A, "/ls")   # defaults to "/"
     check("A /ls default path", st == 200, body)
 
-    # End the session: the mock leaves on 'Q', the worker then disconnects.
-    cmd_q.put(("quit",))
+    # End the session over HTTP: /forceexit sends 'Q', the mock leaves, the
+    # worker fills the bridge reply and disconnects.
+    st, body = http(HTTP_A, "/forceexit?json=1")
+    j = json.loads(body)
+    check("A /forceexit", st == 200 and j["ok"], j)
     check("A disconnected", wait_until(lambda: not state["connected"]))
     st, body = http(HTTP_A, "/status?json=1")
     j = json.loads(body)
@@ -233,6 +239,8 @@ def phase_b():
     check("B /status before session", st == 200 and not j["connected"], j)
     st, body = http(HTTP_B, "/mkdir?path=/x")
     check("B command without session -> 503", st == 503, body)
+    st, body = http(HTTP_B, "/forceexit")
+    check("B /forceexit without session -> 503", st == 503, body)
 
     entries = [(True, 0, "GAMES"), (False, 1234, "boot.bas")]
     filebytes = b"Hi from nextsync5\r\n" * 3
@@ -281,9 +289,14 @@ def phase_b():
     st, body = http(HTTP_B, "/rmtree?path=/del")
     check("B /rmtree unsupported -> 501", st == 501, body)
 
-    nextsync5._listen_queue().put(("quit", "", ""))
+    # End the session through the CLI client (-forceexit): same /forceexit
+    # route, driven by nextsync5's own stdlib HTTP caller.
+    rc = nextsync5._cli_forceexit(f"127.0.0.1:{HTTP_B}")
+    check("B -forceexit CLI", rc == 0, rc)
     check("B session ended",
           wait_until(lambda: not nextsync5._listen_state['active']))
+    rc = nextsync5._cli_forceexit("127.0.0.1:1")   # nothing listens there
+    check("B -forceexit unreachable -> 1", rc == 1, rc)
     st, body = http(HTTP_B, "/status?json=1")
     j = json.loads(body)
     check("B /status after quit", st == 200 and not j["connected"], j)

--- a/nextsync5.py
+++ b/nextsync5.py
@@ -49,6 +49,7 @@ opt_always_sync = False
 opt_sync_once = False
 opt_verbose = False   # -v: per-packet / per-command logging (off by default)
 opt_http_port = 0     # -http[=port]: NextSync HTTP bridge (0 = off)
+opt_forceexit = ''    # -forceexit[=host[:port]]: call a bridge's /forceexit and exit
 # How to treat an incoming (-send) file/dir that already exists locally:
 #   "prompt"    - ask at the console (default)
 #   "overwrite" - always overwrite
@@ -475,7 +476,7 @@ LISTEN_HELP = """\
     psize [drive]              free space on a partition, in bytes (dot v5.2+)
     pfull [drive]              free space on a partition, human-readable (dot v5.2+)
     help                       show this help
-    quit                       tell the Next to leave -listen and disconnect
+    quit | forceexit           tell the Next to leave -listen and disconnect
 """
 
 def _listen_recv_reply(conn, handler):
@@ -690,9 +691,10 @@ def _listen_console_reader(cmd_q):
             cmd_q.put((verb, a1, ""))
         elif verb == "help":
             print(LISTEN_HELP)
-        elif verb in ("quit", "exit", "bye"):
+        elif verb in ("quit", "exit", "bye", "forceexit"):
             # Ends the CURRENT Next session (sends 'Q'); the server keeps
             # listening for a reconnection. Ctrl-C stops the server itself.
+            # "forceexit" is the same thing under the HTTP bridge's name.
             cmd_q.put(("quit", "", ""))
         else:
             print(f"  unknown command: {verb} (try 'help')")
@@ -1074,6 +1076,38 @@ def _listen_session_inner(conn, stats, _test_commands=None):
     # accepting, so a restarted '.sync5 -listen' reconnects.
     print(f'{timestamp()} | listen: the Next disconnected - waiting for a new connection.')
 
+def _cli_forceexit(target):
+    """-forceexit[=host[:port]]: act as a plain HTTP client against an
+    already-RUNNING NextSync HTTP bridge (this server started with -w/-http,
+    or the ZX-Next-Unite app's) and call its /forceexit route — telling the
+    Next connected there in '.sync5 -listen' to close the connection and
+    exit gracefully to BASIC. Stdlib only (no Flask needed on this side).
+    Returns the process exit code: 0 = the Next was told to exit."""
+    import urllib.request
+    import urllib.error
+    if '://' not in target:
+        target = 'http://' + target
+    url = target.rstrip('/') + '/forceexit'
+    try:
+        # The route waits for the Next's next poll (bridge timeout 45 s);
+        # give the client a little more than that.
+        with urllib.request.urlopen(url, timeout=60) as r:
+            print(r.read().decode(errors='replace').strip())
+            return 0
+    except urllib.error.HTTPError as e:
+        # Real bridge answer with an error status (503 = no Next connected,
+        # 504 = the Next never polled): show its own message.
+        body = e.read().decode(errors='replace').strip()
+        print(body or f"HTTP {e.code}")
+        return 1
+    except OSError as ex:
+        print(f"Could not reach {url}: {ex}")
+        print("Is the HTTP bridge running there? Start it with "
+              "'nextsync5.py -w' / '-http=<port>' or the app's Settings "
+              "toggle, or point at it with -forceexit=<host[:port]>.")
+        return 1
+
+
 def _start_http_bridge(port):
     """-w / -http: start the NextSync HTTP bridge (zxnu_http_bridge, Flask)
     so any HTTP client — a Next running the .http dot command, curl, a
@@ -1098,7 +1132,8 @@ def _start_http_bridge(port):
         # Canonical bridge op -> this server's (verb, a1, a2, reply) tuples.
         verbs = {"ls": "ls", "get": "get", "mkdir": "mkdir", "rmdir": "rmdir",
                  "rm": "rm", "ren": "ren", "rcpy": "rcpy", "rfsize": "rfsize",
-                 "free": "psize", "drives": "drives"}
+                 "free": "psize", "drives": "drives",
+                 "forceexit": "quit"}   # /forceexit -> the session's quit ('Q')
         if op == "put":
             return ("put", a2, a1, reply)   # session order: (local, remote)
         if op in verbs:
@@ -1123,7 +1158,8 @@ def _start_http_bridge(port):
     ok, err = bridge.start()
     if ok:
         print(f"{timestamp()} | HTTP bridge on port {port}: /status /ls /get "
-              "/put /mkdir /rmdir /rm /ren /rcpy /rfsize /free /drives")
+              "/put /mkdir /rmdir /rm /ren /rcpy /rfsize /free /drives "
+              "/forceexit")
         if opt_verbose:
             print(f"{timestamp()} | HTTP bridge: -v request/response logging "
                   "is ON")
@@ -1433,6 +1469,16 @@ for x in sys.argv[1:]:
         except ValueError:
             print(f"Bad -http port in '{x}' (want -w, -http or -http=8080)")
             quit()
+    elif x == '-forceexit' or x.startswith('-forceexit='):
+        # One-shot client mode: call /forceexit on a running HTTP bridge
+        # (default 127.0.0.1:80) so the Next connected there in
+        # '.sync5 -listen' closes the connection and exits to BASIC,
+        # then quit — the sync server itself is NOT started.
+        opt_forceexit = x.split('=', 1)[1] if '=' in x else '127.0.0.1:80'
+        if not opt_forceexit:
+            print(f"Bad -forceexit target in '{x}' "
+                  "(want -forceexit or -forceexit=host[:port])")
+            quit()
     elif x == '-s':
         MAX_PAYLOAD = 256
     elif x == '-u':
@@ -1471,6 +1517,15 @@ for x in sys.argv[1:]:
             - Same as -w, with an optional custom port.
               Combine with -v to log every HTTP request, its payload and
               the response on the console for troubleshooting.
+        -forceexit / -forceexit=<host[:port]>
+            - One-shot: tell the Next connected in '.sync5 -listen' to close
+              the connection and exit gracefully to BASIC, by calling the
+              /forceexit route of an already-running HTTP bridge (default
+              127.0.0.1:80 - this server's -w/-http, or the ZX-Next-Unite
+              app's). Prints the bridge's reply and exits; the sync server
+              itself is not started. In PowerShell quote the dotted form:
+              "-forceexit=192.168.1.10:8080" (PowerShell splits it at the
+              dots otherwise).
         -s  - Use safe payload size (256 bytes). Slower, but more robust.
               Use this if you get a lot of retries.
         -u  - To live on the edge, you can try to use really unsafe payload
@@ -1490,4 +1545,6 @@ for x in sys.argv[1:]:
 # Guarded so the module can be imported (e.g. by tests) without launching the
 # server. Standalone `python nextsync5.py` behaviour is unchanged.
 if __name__ == "__main__":
+    if opt_forceexit:
+        sys.exit(_cli_forceexit(opt_forceexit))
     main()

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -5244,7 +5244,9 @@ class MainWindow(QMainWindow):
                 info = zxnu_itchio.latest_cspect_upload(api_key)
                 if not info:
                     return {"skip": "itch.io lists no CSpect download for this "
-                                    "account (not owned, or no download key)"}
+                                    "account (not owned, no download key, or "
+                                    "only BETA builds — betas are never "
+                                    "offered as updates)"}
                 info = dict(info)
                 info["installed_name"] = installed_name
                 info["installed_exe"] = installed_exe
@@ -6993,14 +6995,37 @@ class MainWindow(QMainWindow):
                     new_dir_target, local_explorer_refresh, add_main_log_window)))
             action_rename.triggered.connect(
                 lambda: QTimer.singleShot(0, lambda: local_explorer_rename_item(file_path, name, is_dir)))
+            # Delete acts on the selection (or the clicked item); the Del key
+            # runs the same handler. Deferred like the other dialog-openers.
+            action_delete = QAction("Delete", self.treeview)
+            action_delete.triggered.connect(
+                lambda: QTimer.singleShot(0, local_explorer_delete_selection))
+            # Zip actions (mirroring the Remote Explorer's local pane): "Unzip
+            # file" only on a .zip file, "Zip" archives the selection (or the
+            # clicked item) into <first item>.zip next to it. Deferred like the
+            # other dialog-openers so the menu's grab is released first.
+            action_unzip = QAction("Unzip file", self.treeview)
+            action_unzip.triggered.connect(
+                lambda: QTimer.singleShot(0, lambda: _local_unzip_file(
+                    file_path, local_explorer_refresh, add_main_log_window)))
+            action_zip = QAction("Zip", self.treeview)
+            action_zip.triggered.connect(
+                lambda: QTimer.singleShot(0, lambda: _local_zip_selection(
+                    _local_explorer_selected_paths_or(file_path),
+                    local_explorer_refresh, add_main_log_window)))
             menu.addAction(action_copy_text)
             menu.addAction(action_copy_path)
+            menu.addSeparator()
+            if not is_dir and name.lower().endswith(".zip"):
+                menu.addAction(action_unzip)
+            menu.addAction(action_zip)
             menu.addSeparator()
             menu.addAction(action_copy)
             menu.addAction(action_cut)
             menu.addAction(action_paste)
             menu.addAction(action_newdir)
             menu.addAction(action_rename)
+            menu.addAction(action_delete)
             menu.exec(self.treeview.viewport().mapToGlobal(pos))
 
         def local_explorer_refresh():
@@ -7083,6 +7108,127 @@ class MainWindow(QMainWindow):
                 QMessageBox.critical(self, "Rename failed", f"Could not rename:\n{file_path}\n\n{e}")
             finally:
                 local_explorer_refresh()
+
+        def local_explorer_delete_selection():
+            """Delete the SD-card local explorer's selected files/folders
+            (Del key / context menu). Honours the "Do not prompt for
+            confirmation on deletion" setting like the NextSync explorer's
+            delete; otherwise asks first — folders warn that all their
+            contents go too, multi-selections are confirmed as one batch."""
+            fallback = ""
+            cur = self.treeview.currentIndex()
+            if cur.isValid():
+                src = self.proxy_model.mapToSource(cur)
+                if self.model.fileName(src) != "..":
+                    fallback = self.model.filePath(src)
+            paths = [p for p in _local_explorer_selected_paths_or(fallback)
+                     if p and os.path.exists(p)]
+            if not paths:
+                return
+            items = [(p, os.path.isdir(p)) for p in paths]
+            if not self.settings_no_prompt_on_deletion_checkbox.isChecked():
+                if len(items) == 1:
+                    p, is_dir = items[0]
+                    name = os.path.basename(p.rstrip("/\\")) or p
+                    msg = (f'Delete the folder "{name}" and all of its '
+                           f'contents?\n\n{p}' if is_dir
+                           else f'Delete the file "{name}"?\n\n{p}')
+                else:
+                    listing = "\n".join(p for p, _d in items[:15])
+                    if len(items) > 15:
+                        listing += f"\n… and {len(items) - 15} more"
+                    msg = (f"Delete these {len(items)} items? Folders are "
+                           f"deleted with all of their contents.\n\n{listing}")
+                msg += "\n\nThis cannot be undone."
+                if QMessageBox.question(
+                        self, "Confirm deletion", msg,
+                        QMessageBox.Yes | QMessageBox.No,
+                        QMessageBox.No) != QMessageBox.Yes:
+                    return
+
+            def _force_remove(func, path, exc_info):
+                # shutil.rmtree onerror: clear a Windows read-only attribute
+                # and retry, so the delete proceeds instead of erroring out.
+                try:
+                    os.chmod(path, stat.S_IWRITE)
+                    func(path)
+                except OSError:
+                    pass
+
+            for p, is_dir in items:
+                try:
+                    if is_dir and not os.path.islink(p):
+                        shutil.rmtree(p, onerror=_force_remove)
+                    else:
+                        os.remove(p)
+                    add_main_log_window(f"Deleted: {p}")
+                except OSError as e:
+                    logging.error(f"Failed to delete {p}: {e}", exc_info=True)
+                    add_main_log_window(f"Failed to delete {p}: {e}")
+                    QMessageBox.critical(self, "Delete failed",
+                                         f"Could not delete:\n{p}\n\n{e}")
+            # Both local explorers browse the same filesystem: refresh both.
+            local_explorer_refresh()
+            nextsync_refresh_explorer()
+
+        def _local_unzip_file(zip_path, refresh_fn, log_fn):
+            """'Unzip file' on a local explorer's .zip: extract it into its
+            own folder (cancellable per-file progress dialog; zip-slip entries
+            skipped). Shared by the SD-card local explorer; a cancel keeps
+            what was already extracted."""
+            name = os.path.basename(zip_path)
+            dest = os.path.dirname(zip_path) or "."
+            res = zip_extract_with_dialog(self, zip_path, dest, log=log_fn)
+            if res["cancelled"]:
+                log_fn(f"Unzip of {name} cancelled — already-extracted files remain.")
+            elif res["error"]:
+                log_fn(f"ERROR: could not extract {name}: {res['error']}")
+                QMessageBox.critical(self, "Unzip failed",
+                                     f"Could not extract {name}:\n{res['error']}")
+            else:
+                skipped = res["skipped"]
+                extra = (f" ({skipped} unsafe "
+                         f"{'entry' if skipped == 1 else 'entries'} skipped)"
+                         if skipped else "")
+                log_fn(f"Extracted {res['files']} file(s) from {name} into {dest}.{extra}")
+            refresh_fn()
+
+        def _local_zip_selection(paths, refresh_fn, log_fn):
+            """'Zip' on a local explorer selection: build <first item>.zip next
+            to it (name uniquified against the folder), cancellable with
+            per-file progress."""
+            paths = [p for p in paths if p and os.path.exists(p)]
+            if not paths:
+                return
+            first = os.path.basename(paths[0].rstrip("/\\")) or "archive"
+            dest = os.path.dirname(os.path.abspath(paths[0].rstrip("/\\"))) or "."
+            try:
+                taken = {n.lower() for n in os.listdir(dest)}
+            except OSError:
+                taken = set()
+            zip_name = zip_unique_name(first, taken)
+            zip_local = os.path.join(dest, zip_name)
+            res = zip_create_with_dialog(self, paths, zip_local, log=log_fn)
+            if res["cancelled"]:
+                log_fn(f"Zip cancelled — {zip_name} was not created.")
+            elif res["error"]:
+                log_fn(f"ERROR: could not create {zip_name}: {res['error']}")
+                QMessageBox.critical(self, "Zip failed",
+                                     f"Could not create {zip_name}:\n{res['error']}")
+            else:
+                log_fn(f"Created {zip_name} in {dest} ({res['files']} file(s)).")
+            refresh_fn()
+
+        def _local_explorer_selected_paths_or(fallback_path):
+            """The SD-card local tree's multi-selection paths (minus '..'), or
+            the given fallback when nothing is selected."""
+            paths = []
+            for ix in self.treeview.selectionModel().selectedRows(0):
+                src = self.proxy_model.mapToSource(ix)
+                if self.model.fileName(src) == "..":
+                    continue
+                paths.append(self.model.filePath(src))
+            return paths or [fallback_path]
 
         def local_explorer_import_external_paths(paths, dest_dir, refresh_fn=None,
                                                  on_complete=None):
@@ -8832,6 +8978,141 @@ class MainWindow(QMainWindow):
             # argument is no longer needed (the tree re-lists itself).
             image_reload_dir(image_dest_dir())
 
+        # ── Remote Zip / Unzip on the SD-card image (hdfmonkey-staged) ──────
+        # hdfmonkey cannot zip, so both actions stage through the PC exactly
+        # like the Remote Explorer's Next-side versions: download (progress +
+        # Cancel) -> zip/unzip locally (per-file progress + Cancel) -> upload
+        # back into the image. Chained stages are deferred with a 0-timer so
+        # each modal transfer dialog fully unwinds before the next opens.
+        def _image_remote_unzip(zip_path):
+            """'Remote Unzip file' on a .zip inside the image: get it to a
+            temp dir, extract on the PC, upload the tree back into the zip's
+            image folder. The image is only touched by the final upload."""
+            if not right_disk_image_explorer_content:
+                return
+            img_err = _check_image_writable(self.right_disk_image_path)
+            if img_err:
+                add_main_log_window(f"ERROR: {img_err}")
+                QMessageBox.critical(self, "Image not writable", img_err)
+                return
+            name = zip_path.rstrip("/").rsplit("/", 1)[-1]
+            dest_dir = zip_path.rstrip("/").rsplit("/", 1)[0] or "/"
+            tmp = tempfile.mkdtemp(prefix="zxnu_imgunzip_")
+
+            def _go(success):
+                local_zip = os.path.join(tmp, name)
+                if not success or not os.path.isfile(local_zip):
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    add_main_log_window("Remote unzip: download from the image "
+                                        "failed or was cancelled — the image "
+                                        "is unchanged.")
+                    return
+                extract_dir = os.path.join(tmp, "_extracted")
+                os.makedirs(extract_dir, exist_ok=True)
+                res = zip_extract_with_dialog(self, local_zip, extract_dir,
+                                              log=add_main_log_window)
+                if not res["ok"] or res["files"] == 0:
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    if res["cancelled"]:
+                        add_main_log_window("Remote unzip cancelled — the "
+                                            "image is unchanged.")
+                    elif res["error"]:
+                        add_main_log_window(f"ERROR: could not extract {name}: "
+                                            f"{res['error']}")
+                        QMessageBox.critical(
+                            self, "Remote unzip failed",
+                            f"Could not extract {name}:\n{res['error']}")
+                    else:
+                        add_main_log_window(f"{name} contains no extractable "
+                                            "files.")
+                    return
+                tops = [os.path.join(extract_dir, e)
+                        for e in sorted(os.listdir(extract_dir))]
+
+                def _done(up_ok):
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    if up_ok:
+                        skipped = res["skipped"]
+                        extra = (f" ({skipped} unsafe "
+                                 f"{'entry' if skipped == 1 else 'entries'} "
+                                 "skipped)" if skipped else "")
+                        add_main_log_window(
+                            f"Extracted {res['files']} file(s) from {name} "
+                            f"into {dest_dir} on the image.{extra}")
+                    else:
+                        add_main_log_window("Remote unzip: upload into the "
+                                            "image failed or was cancelled.")
+                image_upload_external_paths(tops, dest_dir, on_complete=_done)
+
+            add_main_log_window(f"Remote unzip: fetching {zip_path} from "
+                                "the image …")
+            image_get_paths_to_local(
+                [(zip_path, False)], tmp, refresh_fn=lambda: None,
+                on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
+
+        def _image_remote_zip(items):
+            """'Remote Zip' on the image selection: get the items to a temp
+            dir, zip them on the PC, upload <first item>.zip back into the
+            first item's image folder (name uniquified via hdfmonkey ls)."""
+            if not right_disk_image_explorer_content or not items:
+                return
+            img_err = _check_image_writable(self.right_disk_image_path)
+            if img_err:
+                add_main_log_window(f"ERROR: {img_err}")
+                QMessageBox.critical(self, "Image not writable", img_err)
+                return
+            first = items[0][0].rstrip("/").rsplit("/", 1)[-1] or "archive"
+            dest_dir = items[0][0].rstrip("/").rsplit("/", 1)[0] or "/"
+            taken = set()
+            res_ls = execute_hdf_monkey("ls", self.right_disk_image_path,
+                                        extra_argv=[dest_dir], silent=True)
+            if res_ls.returncode == 0:
+                taken = {n.lower() for n, _d, _s in image_parse_ls(res_ls.stdout)}
+            zip_name = zip_unique_name(first, taken)
+            tmp = tempfile.mkdtemp(prefix="zxnu_imgzip_")
+            dl = os.path.join(tmp, "dl")
+            os.makedirs(dl, exist_ok=True)
+
+            def _go(success):
+                if not success:
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    add_main_log_window("Remote zip: download from the image "
+                                        "failed or was cancelled — no zip was "
+                                        "created.")
+                    return
+                src_paths = [os.path.join(dl, e) for e in sorted(os.listdir(dl))]
+                zip_local = os.path.join(tmp, zip_name)
+                res = zip_create_with_dialog(self, src_paths, zip_local,
+                                             log=add_main_log_window)
+                if not res["ok"]:
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    if res["cancelled"]:
+                        add_main_log_window("Remote zip cancelled — no zip "
+                                            "was created.")
+                    else:
+                        add_main_log_window(f"ERROR: could not build "
+                                            f"{zip_name}: {res['error']}")
+                    return
+                size = os.path.getsize(zip_local)
+
+                def _done(up_ok):
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    if up_ok:
+                        add_main_log_window(
+                            f"Created {zip_name} in {dest_dir} on the image "
+                            f"({res['files']} file(s), {size:,} bytes).")
+                    else:
+                        add_main_log_window("Remote zip: upload into the "
+                                            "image failed or was cancelled.")
+                image_upload_external_paths([zip_local], dest_dir,
+                                            on_complete=_done)
+
+            add_main_log_window(f"Remote zip: fetching {len(items)} item(s) "
+                                "from the image …")
+            image_get_paths_to_local(
+                items, dl, refresh_fn=lambda: None,
+                on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
+
         def image_tree_context_menu(pos):
             # Right-click menu on the image explorer tree, mirroring the
             # "New Folder" and "Delete Files or Folder" buttons below it.
@@ -8870,6 +9151,26 @@ class MainWindow(QMainWindow):
                                    lambda: QTimer.singleShot(0, image_rename_dialog))
                 delete_label = f"Delete {selected_count} items" if selected_count > 1 else "Delete"
                 menu.addAction(delete_label, delete_files_button_show_confirmation_buttons)
+                # Remote Zip/Unzip (PC-staged via hdfmonkey): "Remote Unzip
+                # file" only on a lone .zip file, "Remote Zip" on any selection.
+                item_path = (name_item.data(IMG_PATH_ROLE) or "") \
+                    if name_item is not None else ""
+                menu.addSeparator()
+                if (selected_count <= 1 and not is_dir
+                        and item_path.lower().endswith(".zip")):
+                    menu.addAction(
+                        "Remote Unzip file",
+                        lambda p=item_path: QTimer.singleShot(
+                            0, lambda: _image_remote_unzip(p)))
+                sel_items = (list(self.image_selected_paths)
+                             or ([(item_path, is_dir)] if item_path else []))
+                if sel_items:
+                    zip_label = (f"Remote Zip {selected_count} items"
+                                 if selected_count > 1 else "Remote Zip")
+                    menu.addAction(
+                        zip_label,
+                        lambda it=sel_items: QTimer.singleShot(
+                            0, lambda: _image_remote_zip(it)))
             else:
                 # Empty area: clear the selection so a new folder lands at the root.
                 self.image_treeview.clearSelection()
@@ -9788,6 +10089,11 @@ class MainWindow(QMainWindow):
             if event.matches(QKeySequence.StandardKey.Paste):
                 _explorer_paste_into_local(_local_explorer_paste_target_dir(),
                                            local_explorer_refresh, add_main_log_window)
+                return
+            # Delete mirrors the context-menu "Delete": prompt (honouring the
+            # "no prompt on deletion" setting), then remove the selection.
+            if event.key() == Qt.Key.Key_Delete:
+                local_explorer_delete_selection()
                 return
             # F2 mirrors the context-menu "Rename" action on the selected entry.
             if event.key() == Qt.Key.Key_F2:
@@ -11086,6 +11392,8 @@ class MainWindow(QMainWindow):
                 return ("free", a1, reply)
             if op == "drives":
                 return ("drives", reply)
+            if op == "forceexit":
+                return ("quit", reply)     # the dot leaves -listen and exits
             return None
 
         def _re_bridge_enqueue(cmd):
@@ -23423,7 +23731,7 @@ class MainWindow(QMainWindow):
                 "Starts a small self-hosted web server (Flask, port 80 by default —\n"
                 "set nextsync_http_port in hdfg.cfg to change it) that republishes\n"
                 "the Remote Explorer's '.sync5 -listen' session as HTTP routes:\n"
-                "/status /ls /get /put /mkdir /rmdir /rmtree /rm /ren /rcpy /rfsize\n"
+                "/status /ls /get /put /mkdir /rmdir /rmtree /rm /ren /rcpy /rfsize /forceexit\n"
                 "/free /drives. A Spectrum Next running the built-in .http dot\n"
                 "command (HTTP only, no TLS) — or curl, or a browser — can then\n"
                 "drive the file system of the Next connected in -listen mode.\n"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.0.4"
+ZX_NEXT_UNITE_VERSION = "9.0.5"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False

--- a/zxnu_http_bridge.py
+++ b/zxnu_http_bridge.py
@@ -23,8 +23,8 @@ Wire-up contract (all a host must provide — see :class:`QueueBridgeHost`):
 * ``enqueue(cmd) -> bool``   put one command tuple on the live -listen
   session's queue (False when no session is running);
 * ``make_cmd(op, a1, a2, reply) -> tuple | None``   translate a canonical
-  bridge op (ls/get/put/mkdir/rmdir/rmtree/rm/ren/rcpy/rfsize/free/drives)
-  into the host's own command-tuple dialect, with ``reply`` (a
+  bridge op (ls/get/put/mkdir/rmdir/rmtree/rm/ren/rcpy/rfsize/free/drives/
+  forceexit) into the host's own command-tuple dialect, with ``reply`` (a
   :class:`BridgeReply`) riding along as the LAST element (None = the host
   doesn't support that op → HTTP 501);
 * ``state() -> dict``   {'listening': bool, 'connected': bool,
@@ -44,6 +44,7 @@ Executor reply shapes (both hosts emit these):
     free    {'ok': True, 'free': bytes} | error
     rcpy    {'ok': bool, 'files': n, 'error'?}
     rfsize  {'ok': True, 'files': n, 'dirs': n, 'bytes': n} | error
+    forceexit   {'ok': True}   (the Next then closes the link and exits)
 """
 
 import importlib.util
@@ -196,7 +197,8 @@ class NextSyncHttpBridge:
         "  GET  /rm?path=/old.tap           delete a file\n"
         "  GET  /ren?from=/a&to=/b          rename / move\n"
         "  GET  /rcpy?src=/a&dst=m:/b       copy ON the Next (across drives)\n"
-        "  GET  /rfsize?path=/games         total size of a file / tree\n")
+        "  GET  /rfsize?path=/games         total size of a file / tree\n"
+        "  GET  /forceexit                  make the Next leave -listen and exit\n")
 
     def __init__(self, host_adapter, listen_host="0.0.0.0", port=DEFAULT_PORT,
                  log=None, verbose=False):
@@ -593,3 +595,16 @@ class NextSyncHttpBridge:
                  "bytes": nbytes, "human": fmt_size(nbytes)},
                 ["OK", f"files: {files}", f"folders: {dirs}",
                  f"bytes: {nbytes} ({fmt_size(nbytes)})"])
+
+        # ---- session control -----------------------------------------
+        @app.route("/forceexit")
+        def _forceexit():
+            # Tell the connected Next to leave -listen mode: the dot's next
+            # poll is answered with the protocol's 'Q', on which it closes
+            # the connection and exits cleanly to BASIC. The -listen server
+            # keeps running, so a fresh '.sync5 -listen' can reconnect.
+            res = run("forceexit")
+            if not res.get("ok"):
+                return fail(res, "forceexit")
+            return answer({"ok": True},
+                          ["OK forceexit - the Next is disconnecting"])

--- a/zxnu_itchio.py
+++ b/zxnu_itchio.py
@@ -723,20 +723,33 @@ def latest_cspect_upload(api_key, game=None):
     Builds a minimal game dict from :data:`CSPECT_ITCH_URL` (unless *game* is
     supplied) and reuses :func:`list_owned_uploads` — CSpect exposes several
     builds at once, so this walks the full version list and reports the newest
-    (index 0). Returns a dict describing the newest upload plus the whole list::
+    (index 0). **BETA builds are invisible to the updater**: any upload with
+    "beta" (case-insensitive) in its file or version name is dropped before
+    the newest is picked, so a pre-release is never offered as an update —
+    while a stable build listed alongside it still is. Returns a dict
+    describing the newest non-beta upload plus the (beta-free) list::
 
         {"game", "game_id", "key_id", "uploads",
          "filename", "version_name", "version_key"}
 
     or ``None`` when the account doesn't own CSpect / has no download key / the
-    API lists no uploads (the caller then skips the update check quietly). Raises
-    on a network/API error so the caller can log the reason. Runs synchronously —
-    call from a worker thread."""
+    API lists no (non-beta) uploads (the caller then skips the update check
+    quietly). Raises on a network/API error so the caller can log the reason.
+    Runs synchronously — call from a worker thread."""
     game = game or {"url": CSPECT_ITCH_URL, "title": "CSpect"}
     listed = list_owned_uploads(game, api_key)
     if listed is None:
         return None  # not owned / no download key / no uploads
     game_id, key_id, uploads = listed
+    # The install path downloads uploads[0] (exactly what the prompt named),
+    # so the betas must be filtered OUT OF THE LIST, not merely skipped over
+    # when choosing "newest" — otherwise the prompt and the download could
+    # disagree about which build is meant.
+    uploads = [u for u in uploads
+               if "beta" not in (u.get("filename") or "").lower()
+               and "beta" not in (u.get("version_name") or "").lower()]
+    if not uploads:
+        return None  # only BETA builds listed — nothing the updater may offer
     newest = uploads[0]
     return {
         "game": game,

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -10,9 +10,11 @@ Commands are pushed onto a queue.Queue the listen worker drains; results arrive
 through RemoteExplorerSignals and are applied here on the UI thread.
 """
 
+import html
 import os
 import posixpath
 import shutil
+import tempfile
 
 from PySide6.QtCore import (
     Qt, QDir, QEvent, QModelIndex, QMimeData, QUrl, QSize, QTimer,
@@ -31,7 +33,10 @@ from zxnu_config import (
     DEFAULT_COLOR_FILE_NAME, DEFAULT_COLOR_FILE_EXT, DEFAULT_COLOR_FILE_SIZE,
     DEFAULT_COLOR_GENERAL_TEXT, hex_to_qcolor,
 )
-from zxnu_workers import DotDotFirstProxyModel, HdfProgressDialog
+from zxnu_workers import (
+    DotDotFirstProxyModel, HdfProgressDialog, zip_create_with_dialog,
+    zip_extract_with_dialog, zip_unique_name,
+)
 
 # Roles carrying the remote entry's full posix path and its directory flag.
 RE_PATH_ROLE = Qt.UserRole + 1
@@ -967,19 +972,41 @@ class RemoteExplorerWidget(QWidget):
             if pc["sizes_done"]:
                 self._precheck_evaluate()
 
+    @staticmethod
+    def _free_color(nbytes):
+        """Traffic-light colour for the free-space figure: green above
+        200 MB, yellow between 100 and 200 MB, red below 100 MB. Shades
+        picked to stay readable on both light and dark backgrounds."""
+        mb = nbytes / (1024.0 * 1024.0)
+        if mb > 200:
+            return "#2fb344"       # green: comfortable
+        if mb >= 100:
+            return "#dd9c07"       # yellow/amber: getting tight
+        return "#e03131"           # red: nearly full
+
     def _update_next_path_label(self):
-        """Path label = cwd + the cached free space of its drive (if known)."""
-        text = f"Next: {self._cwd}"
+        """Path label = cwd + the cached free space of its drive (if known).
+        The free-space figure is bold and traffic-light coloured (see
+        _free_color) so a filling-up card is visible at a glance."""
         free = self._free_space.get(self._cwd_drive())
         if free is not None:
-            text += f"  —  {self._fmt_free(free)} free"
+            # Rich text so only the free-space part is coloured; the label
+            # auto-detects HTML. &nbsp; keeps the double-space look that the
+            # plain-text form used (rich text collapses runs of spaces).
+            self.next_path_label.setText(
+                f"Next: {html.escape(self._cwd)}&nbsp;&nbsp;—&nbsp;&nbsp;"
+                f"<b><span style=\"color: {self._free_color(free)};\">"
+                f"{html.escape(self._fmt_free(free))} free</span></b>")
             self.next_path_label.setToolTip(
                 f"Free space on drive {self._cwd_drive()}: {free} bytes "
                 "(reported by the Next via F_GETFREE; NextZXOS exposes no "
-                "safe way for a dot command to read the total partition size)")
+                "safe way for a dot command to read the total partition "
+                "size).\nGreen: more than 200 MB free · yellow: 100–200 MB "
+                "· red: below 100 MB.\nRe-read after every transfer, "
+                "delete, rename or copy, so the figure tracks the card.")
         else:
+            self.next_path_label.setText(f"Next: {self._cwd}")
             self.next_path_label.setToolTip("")
-        self.next_path_label.setText(text)
 
     def _known_drives(self):
         """Every drive the combo offers: the dot-reported set plus the
@@ -1385,6 +1412,8 @@ class RemoteExplorerWidget(QWidget):
         act_new = menu.addAction("New Folder…")
         act_get = menu.addAction("Download (:<-)")
         act_size = menu.addAction("Get size")
+        act_unzip = menu.addAction("Remote Unzip file")
+        act_rzip = menu.addAction("Remote Zip")
         act_copy = menu.addAction("Copy")
         act_cut = menu.addAction("Cut")
         act_paste = menu.addAction("Paste")
@@ -1395,6 +1424,13 @@ class RemoteExplorerWidget(QWidget):
         # Rename and Get size act on exactly one item.
         act_ren.setEnabled(len(sel) == 1)
         act_size.setEnabled(len(sel) == 1)
+        # "Remote Unzip file" only appears for a single selected .zip FILE;
+        # "Remote Zip" whenever something is selected. Both work PC-side
+        # (download -> unzip/zip -> upload): the dot cannot run .unzip
+        # itself while .sync occupies the dot page.
+        act_unzip.setVisible(len(sel) == 1 and not sel[0][1]
+                             and sel[0][0].lower().endswith(".zip"))
+        act_rzip.setVisible(bool(sel))
         act_copy.setEnabled(bool(sel))
         act_cut.setEnabled(bool(sel))
         # Paste: a local clipboard uploads here; a copied Next clipboard is
@@ -1407,6 +1443,10 @@ class RemoteExplorerWidget(QWidget):
             self._get_selected()
         elif chosen == act_size:
             self._get_size_selected()
+        elif chosen == act_unzip:
+            self._remote_unzip(sel[0][0])
+        elif chosen == act_rzip:
+            self._remote_zip(sel)
         elif chosen == act_copy:
             self._copy_next("copy")
         elif chosen == act_cut:
@@ -1952,6 +1992,200 @@ class RemoteExplorerWidget(QWidget):
         return self._cwd or "/"
 
     # ==================================================================
+    #  remote zip / unzip  (PC-side: the Next only moves the bytes)
+    # ==================================================================
+    # A dot command cannot run another dot (.unzip would be loaded over the
+    # running .sync's own $2000 page, and the launch call itself is the
+    # M_P3DOS crash trap), so both actions do the zip work ON THE PC with
+    # the existing protocol verbs: download -> zipfile -> upload. The wire
+    # carries the data twice; the dotN needs zero new bytes.
+
+    def _next_listing_names(self):
+        """Lower-cased entry names currently listed in the Next pane (to pick
+        a zip name that doesn't collide with an existing one)."""
+        names = set()
+        for row in range(self.next_model.rowCount()):
+            item = self.next_model.item(row, 0)
+            p = item.data(RE_PATH_ROLE) if item is not None else None
+            if p and p != "..":
+                names.add((posixpath.basename(p.rstrip("/")) or "").lower())
+        return names
+
+    def _cwd_base(self):
+        return self._cwd if self._cwd.endswith("/") else self._cwd + "/"
+
+    # ---- Remote Unzip file -------------------------------------------
+    def _remote_unzip(self, zip_path):
+        """Context menu 'Remote Unzip file' (a single selected remote .zip):
+        stage 1 downloads the zip to a temp dir (normal cancellable op),
+        stage 2 extracts it locally (own progress dialog + Cancel), stage 3
+        uploads the extracted tree back into the zip's folder. Every abort
+        path removes the temp dir and leaves the Next untouched."""
+        if not self._connected or self._op_active:
+            return
+        tmp = tempfile.mkdtemp(prefix="zxnu_runzip_")
+        name = posixpath.basename(zip_path.rstrip("/"))
+        self._log(f"Remote unzip: fetching {zip_path} …")
+
+        def stage2(ok, _fails):
+            # Deferred so _end_operation fully unwinds before the next stage.
+            QTimer.singleShot(0, lambda: self._remote_unzip_extract(
+                ok, tmp, os.path.join(tmp, name), name))
+
+        self._run_op("Remote Unzip: downloading the zip…",
+                     lambda: self._enqueue(("get", zip_path, tmp)),
+                     on_done=stage2)
+
+    def _remote_unzip_extract(self, ok, tmp, local_zip, name):
+        if not ok or not os.path.isfile(local_zip):
+            shutil.rmtree(tmp, ignore_errors=True)
+            self._log("Remote unzip: download failed or was cancelled — "
+                      "nothing changed on the Next.")
+            return
+        extract_dir = os.path.join(tmp, "_extracted")
+        os.makedirs(extract_dir, exist_ok=True)
+        res = zip_extract_with_dialog(self.window(), local_zip, extract_dir,
+                                      log=self._log)
+        files, skipped = res["files"], res["skipped"]
+        total_bytes = res["bytes"]
+        if not res["ok"] or files == 0:
+            shutil.rmtree(tmp, ignore_errors=True)
+            if res["cancelled"]:
+                self._log("Remote unzip: cancelled — nothing changed on "
+                          "the Next.")
+            elif res["error"]:
+                self._on_toast("Remote unzip failed",
+                               f"Could not extract {name}: {res['error']}",
+                               "red")
+            else:
+                self._on_toast("Remote unzip", f"{name} contains no "
+                               "extractable files.", "yellow")
+            return
+        # Will-it-fit guard against the freshest cached free-space figure
+        # (re-read at the end of the download op just before this).
+        free = self._free_space.get(self._cwd_drive())
+        if free is not None and total_bytes > free:
+            shutil.rmtree(tmp, ignore_errors=True)
+            self._on_toast(
+                "Remote unzip refused",
+                f"Unzipping needs {self._fmt_free(total_bytes)}, but drive "
+                f"{self._cwd_drive()}: only has {self._fmt_free(free)} free.",
+                "red")
+            return
+        base = self._cwd_base()
+
+        def go():
+            for entry in sorted(os.listdir(extract_dir)):
+                full = os.path.join(extract_dir, entry)
+                if os.path.isdir(full):
+                    self._enqueue_dir_upload(full, base)
+                else:
+                    self._enqueue(("put", full, base))
+
+        def done(ok2, _fails2):
+            shutil.rmtree(tmp, ignore_errors=True)
+            if ok2:
+                extra = (f" ({skipped} unsafe "
+                         f"{'entry' if skipped == 1 else 'entries'} skipped)"
+                         if skipped else "")
+                self._on_toast("✅  Remote unzip complete",
+                               f"Extracted {files} file(s) from {name} "
+                               f"into {self._cwd}.{extra}", "green")
+
+        self._log(f"Remote unzip: uploading {files} file(s) to {self._cwd} …")
+        if not self._connected or self._op_active:
+            shutil.rmtree(tmp, ignore_errors=True)
+            self._log("Remote unzip: connection lost before the upload — "
+                      "nothing changed on the Next.")
+            return
+        self._run_op("Remote Unzip: uploading to the Next…", go, on_done=done)
+
+    # ---- Remote Zip ---------------------------------------------------
+    def _remote_zip(self, entries):
+        """Context menu 'Remote Zip': download the selected remote files /
+        folders, zip them on the PC, and upload the zip back into the current
+        Next folder. The zip is named after the FIRST selected item + '.zip'
+        (single or multiple selection alike), uniquified against the current
+        listing so nothing is overwritten."""
+        if not self._connected or self._op_active or not entries:
+            return
+        first = posixpath.basename(entries[0][0].rstrip("/")) or "archive"
+        zip_name = zip_unique_name(first, self._next_listing_names())
+        tmp = tempfile.mkdtemp(prefix="zxnu_rzip_")
+        dl = os.path.join(tmp, "dl")
+        os.makedirs(dl, exist_ok=True)
+
+        def go():
+            for path, is_dir in entries:
+                self._prepare_local_download_dir(dl, path, is_dir)
+                self._enqueue(("get", path, dl))
+
+        def stage2(ok, _fails):
+            QTimer.singleShot(0, lambda: self._remote_zip_pack(
+                ok, tmp, dl, zip_name))
+
+        self._log(f"Remote zip: fetching {len(entries)} item(s) for "
+                  f"{zip_name} …")
+        self._run_op("Remote Zip: downloading from the Next…", go,
+                     on_done=stage2)
+
+    def _remote_zip_pack(self, ok, tmp, dl, zip_name):
+        if not ok:
+            shutil.rmtree(tmp, ignore_errors=True)
+            self._log("Remote zip: download failed or was cancelled — "
+                      "no zip was created.")
+            return
+        # Everything under dl/ mirrors the selection; zip its top-level
+        # entries so the archive holds the items by name (folders recursed).
+        src_paths = [os.path.join(dl, e) for e in sorted(os.listdir(dl))]
+        zip_local = os.path.join(tmp, zip_name)
+        res = zip_create_with_dialog(self.window(), src_paths, zip_local,
+                                     log=self._log)
+        if not res["ok"]:
+            shutil.rmtree(tmp, ignore_errors=True)
+            if res["cancelled"]:
+                self._log("Remote zip: cancelled — no zip was uploaded.")
+            elif res["error"] == "nothing to zip":
+                self._on_toast("Remote zip", "Nothing was downloaded — no "
+                               "zip was created.", "yellow")
+            else:
+                self._on_toast("Remote zip failed",
+                               f"Could not build {zip_name}: {res['error']}",
+                               "red")
+            return
+        files = res["files"]
+        size = os.path.getsize(zip_local)
+        free = self._free_space.get(self._cwd_drive())
+        if free is not None and size > free:
+            shutil.rmtree(tmp, ignore_errors=True)
+            self._on_toast(
+                "Remote zip refused",
+                f"{zip_name} is {self._fmt_free(size)}, but drive "
+                f"{self._cwd_drive()}: only has {self._fmt_free(free)} free.",
+                "red")
+            return
+        base = self._cwd_base()
+
+        def done(ok2, _fails2):
+            shutil.rmtree(tmp, ignore_errors=True)
+            if ok2:
+                self._on_toast("✅  Remote zip complete",
+                               f"Created {zip_name} in {self._cwd} "
+                               f"({files} file(s), {self._fmt_free(size)}).",
+                               "green")
+
+        self._log(f"Remote zip: uploading {zip_name} "
+                  f"({self._fmt_free(size)}) to {self._cwd} …")
+        if not self._connected or self._op_active:
+            shutil.rmtree(tmp, ignore_errors=True)
+            self._log("Remote zip: connection lost before the upload — "
+                      "no zip was created on the Next.")
+            return
+        self._run_op("Remote Zip: uploading the zip…",
+                     lambda: self._enqueue(("put", zip_local, base)),
+                     on_done=done)
+
+    # ==================================================================
     #  local pane
     # ==================================================================
     def sync_root(self):
@@ -2098,6 +2332,8 @@ class RemoteExplorerWidget(QWidget):
         has_sel = len(sel) > 0
         menu = QMenu(self)
         act_new = menu.addAction("New Folder…")
+        act_unzip = menu.addAction("Unzip file")
+        act_zip = menu.addAction("Zip")
         menu.addSeparator()
         act_copy = menu.addAction("Copy")
         act_cut = menu.addAction("Cut")
@@ -2111,12 +2347,21 @@ class RemoteExplorerWidget(QWidget):
         act_cut.setEnabled(has_sel)
         act_ren.setEnabled(len(sel) == 1)
         act_del.setEnabled(has_sel)
+        # Local zip actions mirror the Next pane's Remote Zip/Unzip: "Unzip
+        # file" only for a single selected local .zip, "Zip" for any selection.
+        act_unzip.setVisible(len(sel) == 1 and os.path.isfile(sel[0])
+                             and sel[0].lower().endswith(".zip"))
+        act_zip.setVisible(has_sel)
         # Paste here downloads copied/cut Next items into this local folder, or
         # copies/moves copied/cut LOCAL items into it.
         act_paste.setEnabled(bool(self._clip))
         chosen = menu.exec(self.local_view.viewport().mapToGlobal(pos))
         if chosen == act_new:
             self._local_new_folder()
+        elif chosen == act_unzip:
+            self._local_unzip(sel[0])
+        elif chosen == act_zip:
+            self._local_zip(sel)
         elif chosen == act_copy:
             self._copy_local("copy")
         elif chosen == act_cut:
@@ -2129,6 +2374,59 @@ class RemoteExplorerWidget(QWidget):
             self._local_delete_selected()
         elif chosen == act_ref:
             self._local_refresh()
+
+    def _local_unzip(self, zip_path):
+        """Local pane 'Unzip file': extract a local .zip into its own folder
+        (cancellable, per-file progress; unsafe entries skipped). A cancel
+        keeps what was already extracted."""
+        name = os.path.basename(zip_path)
+        dest = os.path.dirname(zip_path) or "."
+        res = zip_extract_with_dialog(self.window(), zip_path, dest,
+                                      log=self._log)
+        if res["cancelled"]:
+            self._log(f"Unzip of {name} cancelled — already-extracted "
+                      "files remain.")
+        elif res["error"]:
+            self._on_toast("Unzip failed",
+                           f"Could not extract {name}: {res['error']}", "red")
+        else:
+            skipped = res["skipped"]
+            extra = (f" ({skipped} unsafe "
+                     f"{'entry' if skipped == 1 else 'entries'} skipped)"
+                     if skipped else "")
+            self._on_toast("✅  Unzip complete",
+                           f"Extracted {res['files']} file(s) from {name} "
+                           f"into {dest}.{extra}", "green")
+        self._local_refresh()
+
+    def _local_zip(self, paths):
+        """Local pane 'Zip': zip the selection into <first item's name>.zip
+        next to it (uniquified against the folder), cancellable with per-file
+        progress."""
+        paths = [p for p in paths if p and os.path.exists(p)]
+        if not paths:
+            return
+        first = os.path.basename(paths[0].rstrip("/\\")) or "archive"
+        dest = os.path.dirname(os.path.abspath(paths[0].rstrip("/\\"))) or "."
+        try:
+            taken = {n.lower() for n in os.listdir(dest)}
+        except OSError:
+            taken = set()
+        zip_name = zip_unique_name(first, taken)
+        zip_local = os.path.join(dest, zip_name)
+        res = zip_create_with_dialog(self.window(), paths, zip_local,
+                                     log=self._log)
+        if res["cancelled"]:
+            self._log(f"Zip cancelled — {zip_name} was not created.")
+        elif res["error"]:
+            self._on_toast("Zip failed",
+                           f"Could not create {zip_name}: {res['error']}",
+                           "red")
+        else:
+            self._on_toast("✅  Zip complete",
+                           f"Created {zip_name} in {dest} "
+                           f"({res['files']} file(s)).", "green")
+        self._local_refresh()
 
     def _local_new_folder(self):
         base = self._browse_dir()

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -594,6 +594,10 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                         reply = None
                     if op == "quit":
                         _re_sendpacket(conn, b"Q", 0)
+                        # A bridge-driven quit (/forceexit) must fill its reply
+                        # BEFORE we break: the HTTP thread is blocked on it.
+                        if reply is not None:
+                            reply.put({'ok': True})
                         break
                     elif op == "mark":
                         # Client-side barrier: nothing goes to the Next, we just
@@ -1233,6 +1237,147 @@ class HdfProgressDialog(QDialog):
     def closeEvent(self, event):
         self._anim_timer.stop()
         super().closeEvent(event)
+
+
+# ----------------------------------------------------------------------
+#  Local zip helpers — shared by the Remote Explorer (local pane AND the
+#  Next-side Remote Zip/Unzip staging) and the SD Card tab (local explorer
+#  and the image explorer's Remote Zip/Unzip). Both run ON THE UI THREAD
+#  over local files only: they show a cancellable HdfProgressDialog naming
+#  every file, pumping the event loop per entry (local zip work is fast;
+#  the surrounding transfers have their own progress machinery).
+# ----------------------------------------------------------------------
+
+def _zip_dialog(parent, title):
+    from PySide6.QtWidgets import QApplication
+    dlg = HdfProgressDialog(title, parent)
+    state = {"cancel": False}
+    dlg.cancel_requested.connect(lambda: state.__setitem__("cancel", True))
+    dlg.set_progress(0)
+    dlg.show()
+    QApplication.processEvents()
+    return dlg, state
+
+
+def zip_extract_with_dialog(parent, zip_path, dest_dir, log=None):
+    """Extract *zip_path* into *dest_dir* with a cancellable progress dialog
+    that names every file as it comes out. Zip-slip entries ('..' segments,
+    absolute or drive-prefixed paths) are skipped and logged, not extracted.
+    Returns {'ok', 'files', 'skipped', 'bytes', 'cancelled', 'error'};
+    'ok' is True only when the archive extracted without cancel or error
+    (skipped entries alone don't clear it), 'bytes' totals the uncompressed
+    sizes. RuntimeError from zipfile = encrypted members."""
+    import shutil
+    import zipfile
+    from PySide6.QtWidgets import QApplication
+    log = log or (lambda s: None)
+    res = {"ok": False, "files": 0, "skipped": 0, "bytes": 0,
+           "cancelled": False, "error": None}
+    dlg, state = _zip_dialog(parent, "Unzip: extracting…")
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            members = zf.infolist()
+            for i, m in enumerate(members):
+                if state["cancel"]:
+                    res["cancelled"] = True
+                    return res
+                mname = m.filename.replace("\\", "/")
+                parts = [p for p in mname.split("/") if p not in ("", ".")]
+                if (not parts or any(p == ".." for p in parts)
+                        or ":" in parts[0]):
+                    res["skipped"] += 1
+                    log(f"Unzip: skipped unsafe entry {m.filename!r}")
+                    continue
+                dlg.set_status(f"Extracting…\n{mname}")
+                dlg.set_progress(int(100 * (i + 1) / max(len(members), 1)))
+                QApplication.processEvents()
+                target = os.path.join(dest_dir, *parts)
+                if m.is_dir():
+                    os.makedirs(target, exist_ok=True)
+                    continue
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                with zf.open(m) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                res["files"] += 1
+                res["bytes"] += m.file_size
+        res["ok"] = True
+    except (zipfile.BadZipFile, RuntimeError, OSError) as ex:
+        res["error"] = str(ex)
+    finally:
+        dlg.close()
+    return res
+
+
+def zip_create_with_dialog(parent, src_paths, zip_local, log=None):
+    """Build *zip_local* (deflated) from the local files/folders *src_paths*,
+    each archived under its base name (folders recursively, empty folders
+    preserved), with a cancellable per-file progress dialog. Returns
+    {'ok', 'files', 'cancelled', 'error'}; on cancel or error the
+    half-written zip is removed."""
+    import zipfile
+    from PySide6.QtWidgets import QApplication
+    log = log or (lambda s: None)
+    res = {"ok": False, "files": 0, "cancelled": False, "error": None}
+    # Flatten the work list first so the progress bar can be determinate.
+    todo = []          # (full_local_path, arcname, is_dir_entry)
+    for src in src_paths:
+        base = os.path.basename(src.rstrip("/\\"))
+        if not base:
+            continue
+        if os.path.isdir(src):
+            for root, dirs, fnames in os.walk(src):
+                dirs.sort()
+                rel = os.path.relpath(root, src)
+                arc_root = base if rel in (".", "") else \
+                    base + "/" + rel.replace(os.sep, "/")
+                if not dirs and not fnames:
+                    todo.append((root, arc_root + "/", True))
+                for fn in sorted(fnames):
+                    todo.append((os.path.join(root, fn),
+                                 arc_root + "/" + fn, False))
+        elif os.path.isfile(src):
+            todo.append((src, base, False))
+    if not todo:
+        res["error"] = "nothing to zip"
+        return res
+    dlg, state = _zip_dialog(parent, "Zip: compressing…")
+    try:
+        with zipfile.ZipFile(zip_local, "w", zipfile.ZIP_DEFLATED) as zf:
+            for i, (full, arc, is_dir) in enumerate(todo):
+                if state["cancel"]:
+                    res["cancelled"] = True
+                    break
+                dlg.set_status(f"Compressing…\n{arc}")
+                dlg.set_progress(int(100 * (i + 1) / len(todo)))
+                QApplication.processEvents()
+                if is_dir:
+                    zf.writestr(zipfile.ZipInfo(arc), b"")   # empty folder
+                else:
+                    zf.write(full, arc)
+                    res["files"] += 1
+        res["ok"] = not res["cancelled"]
+    except OSError as ex:
+        res["error"] = str(ex)
+    finally:
+        dlg.close()
+    if not res["ok"]:
+        try:
+            os.remove(zip_local)
+        except OSError:
+            pass
+    return res
+
+
+def zip_unique_name(first_name, taken_lower):
+    """The zip name for a selection: the FIRST item's name + '.zip',
+    uniquified Explorer-style against *taken_lower* (a lower-cased set of
+    existing names): 'name.zip', 'name (2).zip', …"""
+    name = first_name + ".zip"
+    n = 1
+    while name.lower() in taken_lower:
+        n += 1
+        name = f"{first_name} ({n}).zip"
+    return name
 
 
 # Export every public/private module-level name (including the


### PR DESCRIPTION
## Summary

Version bump to **9.0.5** with this batch of features:

### NextSync forceexit (zero dotN bytes)
- HTTP bridge: new `GET /forceexit` route — maps to the `-listen` protocol's existing `Q` opcode, so the connected Next closes the connection and exits `.sync` gracefully (UART/CPU state restored, clean return to BASIC). Callable from the app, `nextsync5.py`, curl, or another Next via `.http`.
- `nextsync5.py`: one-shot `-forceexit[=host[:port]]` client mode (stdlib-only) plus a `forceexit` console alias; PowerShell quoting note documented.
- App-side worker now fills the bridge reply on quit so an HTTP-driven exit gets a real answer instead of a 504.

### Remote Explorer
- Free-space figure in the Next pane is now bold and traffic-light coloured: green above 200 MB, yellow 100–200 MB, red below 100 MB; re-read (`psize`) after every transfer/delete/copy batch so it always tracks the card.
- **Remote Unzip file** (single remote `.zip`) and **Remote Zip** (any selection) context-menu actions: staged PC-side (download → extract/pack with cancellable per-file progress → upload), zip-slip guarded, free-space prechecked, temp dirs cleaned on every abort path.

### Zip/unzip on every explorer surface
One shared implementation (`zxnu_workers` zip helpers) drives:
- Remote Explorer local pane (**Unzip file** / **Zip**),
- SD Card utility local explorer (**Unzip file** / **Zip**),
- SD Card image explorer (**Remote Unzip file** / **Remote Zip**, staged through hdfmonkey get/put with name uniquify via `hdfmonkey ls`).

### CSpect itch.io updater
- Builds with "BETA" (case-insensitive) in the name are never offered as updates; a stable build listed alongside a beta still is. Filtered at the source so the prompt and the download can never disagree.

### SD Card local explorer
- **Del** key (and a matching context-menu **Delete**) with confirmation prompt — honours the "Do not prompt for confirmation on deletion" setting, batch-confirms multi-selections, clears Windows read-only attributes on recursive deletes, refreshes both local explorers.

## Test plan
- `test_http_bridge.py` / `test_listen.py` / `test_remote_listen.py`: ALL PASS (forceexit covered end-to-end over both hosts + CLI client).
- Offscreen widget tests: Remote Zip/Unzip flows (22 checks), shared zip helpers + local pane actions (19 checks), free-space label colours/boundaries — ALL PASS.
- CSpect BETA filter unit test (mocked itch.io listing) — ALL PASS.
- Offscreen full-app boot smoke test constructs the entire MainWindow cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
