### PR TITLE
Flask attribution, HTTP bridge feature bullet, MAME patched-build version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Co-developed with the assistance of **Claude** (Anthropic's AI).
   (new folder, delete) directly — no SD-card swapping. Run `.sync5 -listen` on
   the Next to connect. See the
   [Wiki](https://github.com/jclauzel/ZX-Next-Unite/wiki#remote-file-explorer).
+- ⭐ **HTTP bridge** — remote access to a Next's file system over plain **HTTP**:
+  a built-in web server (Flask) republishes the Remote Explorer's `-listen`
+  session as HTTP routes, so you can browse, download, upload and manage the
+  Next's SD card from a browser, `curl` — or from **another Next** using the
+  built-in `.http` dot command. See the
+  [HTTP bridge documentation](nextsync/sync/server/HTTP_BRIDGE.md).
 - **Online libraries** — search and download from GetIt, ZXDB/ZXInfo, zxArt and
   (optionally) itch.io.
 
@@ -54,7 +60,9 @@ the **[Wiki](https://github.com/jclauzel/ZX-Next-Unite/wiki)**:
 
 Released under the **MIT** license (see [LICENSE](LICENSE)). Built on **PySide6**
 and **pygame-ce** (Qt 6, GPLv2/LGPL) and optionally
-[itch-dl](https://github.com/DragoonAethis/itch-dl) by Dragoon Aethis (MIT).
+[itch-dl](https://github.com/DragoonAethis/itch-dl) by Dragoon Aethis (MIT) and
+[Flask](https://flask.palletsprojects.com/) by the Pallets team (BSD-3-Clause),
+the web server that powers the NextSync HTTP bridge.
 
 ## Legal disclaimer — third-party content
 

--- a/nextsync/sync/server/HTTP_BRIDGE.md
+++ b/nextsync/sync/server/HTTP_BRIDGE.md
@@ -1,7 +1,9 @@
 # NextSync HTTP bridge — drive a remote Next's file system over HTTP
 
-The HTTP bridge is a small self-hosted web server (Flask) that republishes a
-NextSync **`.sync5 -listen`** session as plain HTTP routes:
+The HTTP bridge is a small self-hosted web server — built on
+[Flask](https://flask.palletsprojects.com/) by the Pallets team
+(BSD-3-Clause) — that republishes a NextSync **`.sync5 -listen`** session as
+plain HTTP routes:
 
 ```
 caller (.http on a Next / curl / browser)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -623,6 +623,10 @@ INIT_HELP = ((f"Welcome to zx-next-unite {ZX_NEXT_UNITE_VERSION} help"),
              (""),
              ("itch-dl is distributed under the MIT license (Copyright (c) 2022 Dragoon Aethis) and, like Pyside6 and pygame-ce, is not bundled when performing a manual python install and needs to be installed separately (see installation instructions). The itch.io tab is only shown when itch-dl is installed."),
              (""),
+             ("zx-next-unite optionally uses Flask by the Pallets team to power the NextSync HTTP bridge - the web server behind the Next's .http dot command that lets one Next drive another Next's SD card. Many thanks to its authors - see https://flask.palletsprojects.com and https://github.com/pallets/flask."),
+             (""),
+             ("Flask is distributed under the BSD-3-Clause license and, like the other optional packages, is not bundled when performing a manual python install and needs to be installed separately (see installation instructions). The HTTP bridge toggle in Settings is greyed out until Flask is installed."),
+             (""),
              ("Setup & How to:"),
              ("---------------"),
              ("Checkout main setup & demo video avaible at: https://youtu.be/-gUxV4fM1yo  (and the full python install is covered in the old py-hdfm-gooey since ZX-Next-Unite is an evolution of it : https://youtu.be/FJG-Z0DCIjQ )"),
@@ -951,13 +955,18 @@ def parse_mame_version_number(text):
     the binary (``"0.272"`` / ``"MAME v0.272 (mame0272)"`` → 272), so the same
     helper works for both the latest-release tag and the installed build's
     self-reported version.
+
+    The dotted form must win over the tag form: a custom-patched build reports
+    e.g. ``"0.288 (mame0238-18438-g4d332b6484f)"``, where the parenthesised part
+    is a ``git describe`` of some older base tag — only the leading ``0.288`` is
+    the build's real version.
     """
     if not text:
         return None
     s = str(text).lower()
-    m = re.search(r"mame0*(\d+)", s)      # release-tag form, e.g. mame0272
+    m = re.search(r"0\.(\d+)", s)         # version-string form, e.g. 0.272
     if not m:
-        m = re.search(r"0\.(\d+)", s)     # version-string form, e.g. 0.272
+        m = re.search(r"mame0*(\d+)", s)  # release-tag form, e.g. mame0272
     if not m:
         return None
     try:


### PR DESCRIPTION
## Summary
- Credit **Flask** (Pallets team, BSD-3-Clause) as the web server powering the NextSync HTTP bridge — in the README license section, the in-app Help tab third-party licenses (`INIT_HELP` in `zxnu_config.py`), and the intro of `HTTP_BRIDGE.md`. The GitHub wiki (Home licensing section, Installation dependency table/credits) was updated separately.
- README **Features**: new starred **HTTP bridge** bullet describing remote access to a Next's file system over plain HTTP (browser / `curl` / another Next via the `.http` dot command), linking to the [HTTP bridge documentation](https://github.com/jclauzel/ZX-Next-Unite/blob/zx82/nextsync/sync/server/HTTP_BRIDGE.md).
- **MAME update detection fix**: `parse_mame_version_number` now prefers the dotted `0.NNN` version over the parenthesised tag. A custom-patched build reports e.g. `0.288 (mame0238-18438-g4d332b6484f)` — the parens are a `git describe` of an older base tag, so the old order mis-detected the install as 0.238 and offered bogus updates. GitHub release tags (`mame0272`, no dotted form) still parse via the tag fallback.

## Testing
- `parse_mame_version_number` verified against all input shapes: regular `-version` output, patched-build output (238 → now 288), GitHub release tags, old usage-banner form, asset filenames, and empty/garbage inputs.
- `zxnu_config.py` imports cleanly; both new Flask lines present in `INIT_HELP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)