### PR TITLE
HTTP bridge port/connection settings, RE listener autostart, chunked uploads, MAME check messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ and switch the mode on without touching Settings — e.g.
 (the last spawns Clive's saucer plus the attacking green alien squadron).
 Requires pygame.
 
+`python zx-next-unite.py -start-remote-explorer-listener` opens the NextSync
+tab's Remote Explorer view and starts its `.sync5 -listen` server right at
+startup using the saved sync root (this run only — the saved Settings are not
+modified; without a saved sync root the usual "pick a sync root first"
+advisory is logged instead).
+
 ## Packaging (optional)
 
 Create a standalone executable with PyInstaller:
@@ -79,7 +85,7 @@ pyside6-rcc rc_backgrounds.qrc -o rc_backgrounds.py
 | `zxnu_config.py` | Constants, `SETTING_*` keys, API base URLs, UI string tables, color defaults, and pure helpers (`resource_path`, `qcolor_to_hex`, etc.) |
 | `zxnu_workers.py` | Background threading primitives: `WorkerSignals`, `NextSyncSignals`, `HdfTaskSignals`, `HdfTaskWorker`, `HdfProgressDialog`, `DotDotFirstProxyModel`; also the NextSync `-listen` worker (`run_remote_listen_server` + `RemoteExplorerSignals`) behind the Remote Explorer |
 | `zxnu_remote_explorer.py` | `RemoteExplorerWidget`: the dual-pane local ⇄ Next file manager of the NextSync tab (drives the `-listen` worker via a command queue; covered headlessly by `nextsync/sync/server/test_remote_listen.py` for the worker side) |
-| `zxnu_http_bridge.py` | NextSync HTTP bridge: reusable Flask web server (stdlib-only import; Flask optional, loaded on start — `flask_available()` gates the UI) republishing a `-listen` session as HTTP routes for the Next's `.http` dot command. Used by the app (Settings toggle, `SETTING_NEXTSYNC_HTTP_BRIDGE`, greyed without Flask) and `nextsync5.py -w`/`-http[=port]`; docs + call samples in `nextsync/sync/server/HTTP_BRIDGE.md`, e2e test in `test_http_bridge.py` |
+| `zxnu_http_bridge.py` | NextSync HTTP bridge: reusable Flask web server (stdlib-only import; Flask optional, loaded on start — `flask_available()` gates the UI) republishing a `-listen` session as HTTP routes for the Next's `.http` dot command. Used by the app (Settings toggle + port and max-connections boxes, `SETTING_NEXTSYNC_HTTP_BRIDGE`/`SETTING_NEXTSYNC_HTTP_PORT`/`SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT`, greyed without Flask) and `nextsync5.py -w`/`-http[=port]` (+`-flask-connection-limit:<n>`, default 1); docs + call samples in `nextsync/sync/server/HTTP_BRIDGE.md`, e2e test in `test_http_bridge.py` |
 | `nextsync5.py` | Standalone Sync4 NextSync command-line server (moved to the repo root so it sits next to `zxnu_http_bridge.py`); `-listen` console, `-w`/`-http[=port]` web bridge, `-v` also traces every HTTP request/response. Protocol tests in `nextsync/sync/server/test_listen.py` |
 | `zxnu_media.py` | ZX Spectrum `SCREEN$` decoder (`ZxSpectrumScreen`), placeholder-pixmap rendering, file-format tag helpers, and the shared pixmap cache |
 | `zxnu_gallery.py` | Reusable gallery widgets: `GalleryCell`, the scrollable grid view, and the `AnimatedBackground` widget |

--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ Co-developed with the assistance of **Claude** (Anthropic's AI).
 - ⭐ **Remote Explorer** — a two-pane file manager for your Next's **real
   filesystem over Wi-Fi**: browse, drag & drop, upload/download and manage files
   (new folder, delete) directly — no SD-card swapping. Run `.sync5 -listen` on
-  the Next to connect. See the
+  the Next to connect, and launch the app with the
+  `-start-remote-explorer-listener` switch to have the listen server running
+  from startup with no clicks. See the
   [Wiki](https://github.com/jclauzel/ZX-Next-Unite/wiki#remote-file-explorer).
 - ⭐ **HTTP bridge** — remote access to a Next's file system over plain **HTTP**:
   a built-in web server (Flask) republishes the Remote Explorer's `-listen`
   session as HTTP routes, so you can browse, download, upload and manage the
   Next's SD card from a browser, `curl` — or from **another Next** using the
-  built-in `.http` dot command. See the
+  built-in `.http` dot command. Enable it in the Settings tab (the port —
+  80 by default — is set in the box next to the toggle). See the
   [HTTP bridge documentation](nextsync/sync/server/HTTP_BRIDGE.md).
 - **Online libraries** — search and download from GetIt, ZXDB/ZXInfo, zxArt and
   (optionally) itch.io.

--- a/nextsync/sync/server/HTTP_BRIDGE.md
+++ b/nextsync/sync/server/HTTP_BRIDGE.md
@@ -32,14 +32,28 @@ tooltip), and `nextsync5.py -w` prints *"please install flask first
 * **ZX-Next-Unite app** — Settings tab → *"Enable NextSync HTTP bridge (web
   server for the Next's .http command)"*. Off by default; the choice is saved
   in `hdfg.cfg` (`nextsync_http_bridge`) and the server then starts
-  automatically with the app. The port defaults to **80**; set
-  `nextsync_http_port=8080` in `hdfg.cfg` to change it (strict `key=value`,
-  no spaces). The bridge drives the Next connected to the **Remote
-  Explorer**'s listen server.
+  automatically with the app. The port defaults to **80** and is set in the
+  **port box next to the toggle** (enabled while the bridge is on); the value
+  is persisted to `hdfg.cfg` (`nextsync_http_port`, strict `key=value`, no
+  spaces) and re-applied at every start — changing it while the bridge runs
+  restarts the server on the new port. The bridge drives the Next connected
+  to the **Remote Explorer**'s listen server; start that listen server
+  automatically too by launching the app with the
+  `-start-remote-explorer-listener` switch, so the whole chain comes up
+  with no clicks.
 * **Standalone server** — `python nextsync5.py -w` (port 80) or
   `-http=8080` for a custom port. `nextsync5.py` lives at the repo root,
   next to `zxnu_http_bridge.py`. Add `-v` to log every HTTP request, its
   payload and the response on the console for troubleshooting.
+
+Both hosts also cap how many HTTP requests the bridge serves **concurrently**
+— **1** by default, which is the recommended value to avoid concurrent
+access: the `-listen` session behind the bridge runs one command at a time
+anyway, so extra simultaneous requests are simply held until a slot frees
+(never rejected). In the app the cap is the **"Max connections" box** next to
+the port (persisted as `nextsync_http_connection_limit` in `hdfg.cfg`); for
+`nextsync5.py` use `-flask-connection-limit:<n>` (`=` also accepted), e.g.
+`-flask-connection-limit:5` to allow five at once.
 
 If something already listens on the chosen port (IIS and Skype love port
 80), nothing crashes: the app raises a red toast — *"You have specified to
@@ -59,14 +73,16 @@ other NextSync command. URL-encode special characters (space = `%20`).
 
 ## Route reference & call samples
 
-The `curl` lines below talk to a bridge at `192.168.1.10`; the `.http` lines
-are what the **calling Next** would run (`-f` saves the reply to a file,
-`-b`/`-l` use a memory bank — see the next-http README).
+The `curl` lines below talk to a bridge running on the **same PC**
+(`localhost`); the `.http` lines are what the **calling Next** would run,
+using the bridge machine's LAN address instead — `192.168.1.10` in the
+samples (`-f` saves the reply to a file, `-b`/`-l` use a memory bank — see
+the next-http README).
 
 ### `GET /status` — is a Next connected, how many partitions?
 
 ```
-curl "http://192.168.1.10/status"
+curl "http://localhost/status"
 .http -h 192.168.1.10 -u /status -f status.txt
 ```
 ```
@@ -82,7 +98,7 @@ in `.sync5 -listen`; `partitions` = number of mounted drives.
 ### `GET /drives` — mounted drive letters
 
 ```
-curl "http://192.168.1.10/drives"
+curl "http://localhost/drives"
 .http -h 192.168.1.10 -u /drives -f drives.txt
 ```
 ```
@@ -95,7 +111,7 @@ partitions: 2
 ### `GET /free?drive=C` — free space on a partition
 
 ```
-curl "http://192.168.1.10/free?drive=m"
+curl "http://localhost/free?drive=m"
 .http -h 192.168.1.10 -u /free?drive=m -f free.txt
 ```
 ```
@@ -109,7 +125,7 @@ metric a dotN can report safely — there is no total-size call.)
 ### `GET /ls?path=/games` — directory listing
 
 ```
-curl "http://192.168.1.10/ls?path=/games"
+curl "http://localhost/ls?path=/games"
 .http -h 192.168.1.10 -u /ls?path=/games -f list.txt
 ```
 ```
@@ -122,7 +138,7 @@ One entry per line: `D`irectory or `F`ile, size in bytes, name (tab-separated).
 ### `GET /get?path=/games/boot.bas` — download one file (raw bytes)
 
 ```
-curl -o boot.bas "http://192.168.1.10/get?path=/games/boot.bas"
+curl -o boot.bas "http://localhost/get?path=/games/boot.bas"
 .http -h 192.168.1.10 -u /get?path=/games/boot.bas -f boot.bas
 .http get -b 20 -h 192.168.1.10 -u /get?path=/games/scr.bin
 ```
@@ -132,7 +148,7 @@ with `/ls` and fetch file by file.
 ### `POST /put?path=/games/new.tap` — upload (request body = the file)
 
 ```
-curl --data-binary @new.tap "http://192.168.1.10/put?path=/games/new.tap"
+curl --data-binary @new.tap "http://localhost/put?path=/games/new.tap"
 .http post -b 22 -l 1024 -h 192.168.1.10 -u /put?path=/games/bank.bin
 ```
 ```
@@ -142,10 +158,89 @@ A `path` ending in `/` needs `&name=<filename>` (the file's name inside that
 folder). On the calling Next, `post -b 22 -l 1024` sends 1024 bytes from
 memory bank 22 — that is how a Next pushes data through the bridge.
 
+**Chunked upload** — add `&append=1&size=<total bytes>` and POST the file in
+pieces: the bridge spools the chunks and, once exactly `size` bytes have
+arrived, writes the whole file to the Next in one go. Intermediate chunks
+answer `OK append <path> (<got>/<size> bytes)`, the final one
+`OK put <path> (<size> bytes, <n> chunks)`. Re-declaring a different `size`
+for the same path (or a plain `/put` to it) discards the half-done spool, so
+a failed upload is retried simply by starting again. This exists because a
+Next's `.http` can POST **at most one 16K bank per request** — see the
+NextBASIC sample below.
+
+```
+curl --data-binary @part1 "http://localhost/put?path=/big.tap&append=1&size=51200"
+OK append /big.tap (16384/51200 bytes)
+```
+
+### Uploading a file bigger than a bank (NextBASIC sample)
+
+The bank limit is real: `.http post` takes its payload from **one memory
+bank** (`-b`, counted in 16K blocks) with `-l` giving the byte count, and
+`-f` (file) only works with `get` — next-http's rolling banks apply to
+downloads, not POSTs. So a single POST can carry at most **16 KB**, and a
+1 MB file must be sent as chunks. The `append=1` mode above reassembles them
+bridge-side.
+
+This NextBASIC program sends a local file of any size: it opens the file as
+a stream, reads its length with `DIM #`, then loops — filling a bank with
+the next chunk and POSTing it with `.http` (which substitutes single-letter
+string variables like `b$`/`l$`/`u$` on its command line):
+
+```
+  10 REM upload a big file through the HTTP bridge in 16K chunks
+  20 BANK NEW b: b$=STR$ b
+  30 h$="192.168.1.10": REM PC running the bridge
+  40 OPEN #4,"c:/downloads/big.tap"
+  50 DIM #4 TO %t: REM %t = file length in bytes
+  60 u$="/put?path=/incoming/big.tap&append=1&size="+STR$ %t
+  70 %o=0
+  80 REPEAT
+  90   %l=%t-%o: IF %l>16384 THEN %l=16384
+ 100   REM copy the next %l file bytes into the bank
+ 110   %i=0
+ 120   REPEAT
+ 130     BANK b POKE %i,CODE INKEY$#4
+ 140     %i=%i+1
+ 150   REPEAT UNTIL %i=%l
+ 160   l$=STR$ %l
+ 170   .http post -b b$ -l l$ -h h$ -u u$
+ 180   %o=%o+%l
+ 190 REPEAT UNTIL %o=%t
+ 200 CLOSE #4
+ 210 BANK CLEAR
+ 220 PRINT "sent ";%t;" bytes"
+```
+
+Notes:
+
+* `DIM #4 TO %t` (stream length) and the byte-wise `INKEY$#4` reads come
+  from the +3e/NextZXOS stream commands — see the *NextBASIC file-related
+  commands* document on the Next's SD card (`docs/nextzxos`).
+* The per-byte copy loop is the simple, portable way to fill the bank; it is
+  not fast (a 1 MB file takes a few minutes at 28 MHz). For fixed offsets
+  known in advance, the NextZXOS `.extract` dot command
+  (`.extract big.tap +49152 16384 -mb 40`) fills a bank much faster, but it
+  does not substitute BASIC variables, so it cannot drive this loop.
+* If the transfer dies midway, just RUN it again — the first chunk of the
+  retry resets the bridge's spool for that path.
+
+### CSpect note — emulated ESP is 7-bit (`-7`)
+
+CSpect's emulated ESP UART (enabled with CSpect's `-esp` option) is
+**7-bit**: binary bytes with the top bit set do not survive the emulated
+link as-is. next-http's `-7` flag makes `.http` **base64-decode responses**,
+so downloads work under CSpect — add `-7` to the `.http` lines when testing
+against the emulator (real hardware does not need it). For *uploads* of
+binary data under CSpect the payload would have to be base64-encoded on the
+Next before POSTing (the bridge stores request bodies verbatim), so test
+binary uploads like the sample above on real hardware. Details:
+[next-http documentation](https://github.com/remy/next-http).
+
 ### `GET /mkdir?path=/backup` — create a directory
 
 ```
-curl "http://192.168.1.10/mkdir?path=/backup"
+curl "http://localhost/mkdir?path=/backup"
 .http -h 192.168.1.10 -u /mkdir?path=/backup -f ok.txt
 ```
 ```
@@ -155,7 +250,7 @@ OK mkdir /backup
 ### `GET /rmdir?path=/backup` — remove an EMPTY directory
 
 ```
-curl "http://192.168.1.10/rmdir?path=/backup"
+curl "http://localhost/rmdir?path=/backup"
 ```
 ```
 OK rmdir /backup
@@ -164,7 +259,7 @@ OK rmdir /backup
 ### `GET /rmtree?path=/backup` — remove a directory recursively
 
 ```
-curl "http://192.168.1.10/rmtree?path=/backup"
+curl "http://localhost/rmtree?path=/backup"
 ```
 ```
 OK rmtree /backup
@@ -175,7 +270,7 @@ Available through the **app**'s bridge; `nextsync5.py` answers `501`.
 ### `GET /rm?path=/old.tap` — delete a file
 
 ```
-curl "http://192.168.1.10/rm?path=/old.tap"
+curl "http://localhost/rm?path=/old.tap"
 ```
 ```
 OK rm /old.tap
@@ -184,7 +279,7 @@ OK rm /old.tap
 ### `GET /ren?from=/a.tap&to=/b.tap` — rename / move
 
 ```
-curl "http://192.168.1.10/ren?from=/games/a.tap&to=/games/b.tap"
+curl "http://localhost/ren?from=/games/a.tap&to=/games/b.tap"
 .http -h 192.168.1.10 -u "/ren?from=/games/a.tap&to=/games/b.tap" -f ok.txt
 ```
 ```
@@ -195,7 +290,7 @@ Same-drive moves too (`from=/x.tap&to=/backup/x.tap`).
 ### `GET /rcpy?src=/games&dst=m:/backup/games` — copy ON the Next
 
 ```
-curl "http://192.168.1.10/rcpy?src=/games&dst=m:/backup/games"
+curl "http://localhost/rcpy?src=/games&dst=m:/backup/games"
 ```
 ```
 OK rcpy /games -> m:/backup/games (42 file(s))
@@ -208,7 +303,7 @@ Copying a folder into itself is refused with `400`.
 ### `GET /rfsize?path=/games` — total size of a file / tree
 
 ```
-curl "http://192.168.1.10/rfsize?path=/games"
+curl "http://localhost/rfsize?path=/games"
 .http -h 192.168.1.10 -u /rfsize?path=/games -f size.txt
 ```
 ```
@@ -222,7 +317,7 @@ The natural "will it fit" companion of `/rcpy` (check `/free` too).
 ### `GET /forceexit` — tell the Next to leave `-listen` and exit
 
 ```
-curl "http://192.168.1.10/forceexit"
+curl "http://localhost/forceexit"
 .http -h 192.168.1.10 -u /forceexit -f ok.txt
 ```
 ```
@@ -241,16 +336,18 @@ Flask needed on the calling side), `-forceexit=host[:port]` on any other
 running bridge:
 
 ```
-python nextsync5.py -forceexit=192.168.1.10:8080
+python nextsync5.py -forceexit=192.168.1.10
 ```
 
-(In PowerShell, quote the dotted form — `"-forceexit=192.168.1.10:8080"` —
-or PowerShell itself splits the argument at the dots.)
+(The port defaults to **80**, like everything else here; append `:port` only
+for a bridge started on a custom port. In PowerShell, quote the dotted form —
+`"-forceexit=192.168.1.10"` — or PowerShell itself splits the argument at
+the dots.)
 
 ### `GET /` or `GET /help` — the route list
 
 ```
-curl "http://192.168.1.10/"
+curl "http://localhost/"
 ```
 Prints the reference above in one screen — handy straight on a Next:
 `.http -h 192.168.1.10 -u /help -f help.txt`
@@ -260,7 +357,7 @@ Prints the reference above in one screen — handy straight on a Next:
 ## JSON example
 
 ```
-curl "http://192.168.1.10/rfsize?path=/games&json=1"
+curl "http://localhost/rfsize?path=/games&json=1"
 {"ok": true, "path": "/games", "files": 42, "dirs": 7, "bytes": 1234567, "human": "1.2 MB"}
 ```
 

--- a/nextsync5.py
+++ b/nextsync5.py
@@ -49,6 +49,7 @@ opt_always_sync = False
 opt_sync_once = False
 opt_verbose = False   # -v: per-packet / per-command logging (off by default)
 opt_http_port = 0     # -http[=port]: NextSync HTTP bridge (0 = off)
+opt_flask_conn_limit = 1  # -flask-connection-limit:<n>: HTTP bridge concurrency cap (1 recommended)
 opt_forceexit = ''    # -forceexit[=host[:port]]: call a bridge's /forceexit and exit
 # How to treat an incoming (-send) file/dir that already exists locally:
 #   "prompt"    - ask at the console (default)
@@ -1154,7 +1155,8 @@ def _start_http_bridge(port):
     bridge = _zb.NextSyncHttpBridge(
         _zb.QueueBridgeHost(enqueue, make_cmd, state), port=port,
         log=lambda s: print(f"{timestamp()} | {s}"),
-        verbose=opt_verbose)   # -v: log every HTTP request/payload/response
+        verbose=opt_verbose,   # -v: log every HTTP request/payload/response
+        connection_limit=opt_flask_conn_limit)
     ok, err = bridge.start()
     if ok:
         print(f"{timestamp()} | HTTP bridge on port {port}: /status /ls /get "
@@ -1469,6 +1471,20 @@ for x in sys.argv[1:]:
         except ValueError:
             print(f"Bad -http port in '{x}' (want -w, -http or -http=8080)")
             quit()
+    elif x.startswith('-flask-connection-limit:') or \
+            x.startswith('-flask-connection-limit='):
+        # Cap on concurrent HTTP bridge requests (default 1, the recommended
+        # value — the -listen session behind the bridge is serial, so extra
+        # concurrent requests only ever wait on each other). Example:
+        # -flask-connection-limit:5 allows five at once.
+        try:
+            opt_flask_conn_limit = int(x[len('-flask-connection-limit') + 1:])
+            if opt_flask_conn_limit < 1:
+                raise ValueError
+        except ValueError:
+            print(f"Bad -flask-connection-limit in '{x}' "
+                  "(want e.g. -flask-connection-limit:5, minimum 1)")
+            quit()
     elif x == '-forceexit' or x.startswith('-forceexit='):
         # One-shot client mode: call /forceexit on a running HTTP bridge
         # (default 127.0.0.1:80) so the Next connected there in
@@ -1517,6 +1533,13 @@ for x in sys.argv[1:]:
             - Same as -w, with an optional custom port.
               Combine with -v to log every HTTP request, its payload and
               the response on the console for troubleshooting.
+        -flask-connection-limit:<n>
+            - Cap on how many HTTP bridge requests are served concurrently
+              (default 1). The recommended value is 1 to avoid concurrent
+              access — the -listen session behind the bridge runs one
+              command at a time anyway; extra requests wait, they are not
+              rejected. Example: -flask-connection-limit:5 ('=' also
+              accepted).
         -forceexit / -forceexit=<host[:port]>
             - One-shot: tell the Next connected in '.sync5 -listen' to close
               the connection and exit gracefully to BASIC, by calling the
@@ -1524,7 +1547,7 @@ for x in sys.argv[1:]:
               127.0.0.1:80 - this server's -w/-http, or the ZX-Next-Unite
               app's). Prints the bridge's reply and exits; the sync server
               itself is not started. In PowerShell quote the dotted form:
-              "-forceexit=192.168.1.10:8080" (PowerShell splits it at the
+              "-forceexit=192.168.1.10" (PowerShell splits it at the
               dots otherwise).
         -s  - Use safe payload size (256 bytes). Slower, but more robust.
               Use this if you get a lot of retries.

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -3700,6 +3700,34 @@ class MainWindow(QMainWindow):
                         "the 'flask' package is not installed - install it "
                         "with: python -m pip install flask")
 
+                # HTTP bridge port (defaults to 80). The deferred bridge start
+                # above reads the port straight from the configuration
+                # dictionary, so only the widget needs syncing here.
+                try:
+                    _http_port = int(configuration_dictionary.get(
+                        SETTING_NEXTSYNC_HTTP_PORT) or 80)
+                except (TypeError, ValueError):
+                    _http_port = 80
+                if not (1 <= _http_port <= 65535):
+                    _http_port = 80
+                self.settings_http_port_spinbox.blockSignals(True)
+                self.settings_http_port_spinbox.setValue(_http_port)
+                self.settings_http_port_spinbox.blockSignals(False)
+
+                # HTTP bridge concurrent-connection limit (defaults to 1 —
+                # the recommended value, matching the serial -listen session).
+                try:
+                    _http_conn = int(configuration_dictionary.get(
+                        SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT) or 1)
+                except (TypeError, ValueError):
+                    _http_conn = 1
+                if _http_conn < 1:
+                    _http_conn = 1
+                self.settings_http_conn_spinbox.blockSignals(True)
+                self.settings_http_conn_spinbox.setValue(_http_conn)
+                self.settings_http_conn_spinbox.blockSignals(False)
+                self._http_port_widgets_set_enabled(_http_bridge_on)
+
                 # MAME ROM/system choice (combo) and command-line parameters
                 # (editable text). Both only exist as widgets when MAME was
                 # detected at startup, so guard with hasattr.
@@ -3969,6 +3997,25 @@ class MainWindow(QMainWindow):
                         self.nextsync_remote_button.setChecked(True)
                     finally:
                         self._re_open_restoring = False
+
+                # -start-remote-explorer-listener: the command-line switch asks
+                # for the '.sync5 -listen' server to be running from startup.
+                # Force the Remote Explorer view open (without persisting it —
+                # this run only, hence the _re_open_restoring guard) and start
+                # the server once the event loop is up, so the toasts, log
+                # pane and server closures it talks to all exist by then.
+                if _ZXNU_START_RE_LISTENER and hasattr(self, "nextsync_remote_button"):
+                    if not self.nextsync_remote_button.isChecked():
+                        self._re_open_restoring = True
+                        try:
+                            self.nextsync_remote_button.setChecked(True)
+                        finally:
+                            self._re_open_restoring = False
+
+                    def _autostart_re_listener():
+                        if not getattr(self, "_re_running", False):
+                            self._nextsync_re_toggle_server()
+                    QTimer.singleShot(0, _autostart_re_listener)
 
                 # Restore the saved splitter positions (SD Card explorers ⇄
                 # log, GetIt results ⇄ MOTD). The window is not shown yet, so
@@ -4976,17 +5023,20 @@ class MainWindow(QMainWindow):
                 return
             _start_mame_install(tag, asset_name, url, size, size_txt)
 
-        def _probe_mame_version_number(mame_path):
-            """Ask an installed MAME binary for its version and return the integer
-            minor version (e.g. 272), or None. Runs on a worker thread (blocking
-            subprocess). Used only when no installed release tag was persisted
-            (MAME was installed manually / before the update-check feature): a
-            copy installed via the app records its tag, so this probe is skipped.
+        def _probe_mame_version_text(mame_path):
+            """Ask an installed MAME binary for its version and return the raw
+            output text (e.g. "0.288 (mame0288)"), or "". Runs on a worker
+            thread (blocking subprocess). Used only when no installed release
+            tag was persisted (MAME was installed manually / before the
+            update-check feature): a copy installed via the app records its
+            tag, so this probe is skipped.
 
             'mame -version' prints the version and exits; on an older build that
             doesn't know the option, MAME still prints its usage banner ("MAME
             v0.NNN …") which carries the version too, so parsing the combined
-            output is robust either way."""
+            output is robust either way. The raw text is returned (not just the
+            parsed number) so the caller can also spot a custom-patched build
+            from the parenthesised git tag."""
             try:
                 proc = subprocess.run(
                     [mame_path, "-version"],
@@ -4994,10 +5044,10 @@ class MainWindow(QMainWindow):
                     cwd=os.path.dirname(mame_path) or None,
                     text=True, timeout=20,
                     **subprocess_no_window_kwargs())
-                return parse_mame_version_number(proc.stdout or "")
+                return proc.stdout or ""
             except Exception as exc:
                 logging.info(f"MAME version probe failed: {exc}")
-                return None
+                return ""
 
         def _prompt_mame_update(info, installed_num):
             """UI-thread dialog offering to update MAME to a newer release found
@@ -5056,23 +5106,35 @@ class MainWindow(QMainWindow):
             def _job():
                 # Prefer the persisted tag of an app-managed install; otherwise
                 # ask the binary itself. Do this first so a probe failure still
-                # lets us fetch the release (and vice-versa).
+                # lets us fetch the release (and vice-versa). An app-managed
+                # install is an official build, so only the probe path can
+                # detect a custom-patched binary.
                 installed_num = parse_mame_version_number(installed_tag)
+                patched = False
                 if installed_num is None:
-                    installed_num = _probe_mame_version_number(mame_path)
+                    raw = _probe_mame_version_text(mame_path)
+                    installed_num = parse_mame_version_number(raw)
+                    patched = mame_version_is_patched(raw)
                 tag, asset_name, url, size = _fetch_latest_mame_asset(arch)
                 return {
                     "installed_num": installed_num,
+                    "patched": patched,
                     "latest_num": parse_mame_version_number(tag),
                     "tag": tag, "asset_name": asset_name,
                     "url": url, "size": size,
                 }
 
             def _on_result(info):
+                # Every branch logs something: the "Checking for a newer MAME
+                # release…" line above must never be the last word, or the
+                # check looks stuck.
                 try:
                     installed_num = info.get("installed_num")
                     latest_num = info.get("latest_num")
                     if latest_num is None:
+                        add_main_log_window(
+                            "MAME update check: could not determine the "
+                            "latest release; skipping.")
                         return
                     if installed_num is None:
                         add_main_log_window(
@@ -5080,9 +5142,15 @@ class MainWindow(QMainWindow):
                             "MAME version; skipping.")
                         return
                     if latest_num <= installed_num:
-                        add_main_log_window(
-                            f"MAME is up to date (installed 0.{installed_num}, "
-                            f"latest 0.{latest_num}).")
+                        if info.get("patched"):
+                            add_main_log_window(
+                                "MAME is up-to-date with a patched version "
+                                f"(installed 0.{installed_num}, "
+                                f"latest 0.{latest_num}).")
+                        else:
+                            add_main_log_window(
+                                f"MAME is up-to-date (installed 0.{installed_num}, "
+                                f"latest 0.{latest_num}).")
                         return
                     _prompt_mame_update(info, installed_num)
                 except Exception as exc:
@@ -5091,6 +5159,9 @@ class MainWindow(QMainWindow):
             def _on_error(err):
                 detail = err[1] if isinstance(err, (tuple, list)) and len(err) > 1 else err
                 logging.info(f"MAME update check skipped: {detail}")
+                add_main_log_window(
+                    "MAME update check: could not reach the release site; "
+                    "skipping.")
 
             add_main_log_window("Checking for a newer MAME release…")
             getit_run_in_thread(_job, _on_result, _on_error)
@@ -11490,10 +11561,15 @@ class MainWindow(QMainWindow):
                     SETTING_NEXTSYNC_HTTP_PORT) or 80)
             except (TypeError, ValueError):
                 port = 80
+            try:
+                conn_limit = int(configuration_dictionary.get(
+                    SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT) or 1)
+            except (TypeError, ValueError):
+                conn_limit = 1
             self._re_bridge = NextSyncHttpBridge(
                 QueueBridgeHost(_re_bridge_enqueue, _re_bridge_make_cmd,
                                 _re_bridge_session_state),
-                port=port,
+                port=port, connection_limit=conn_limit,
                 log=lambda s: add_nextsync_log_window(str(s)))
             ok, err = self._re_bridge.start()
             if ok:
@@ -23824,11 +23900,21 @@ class MainWindow(QMainWindow):
         self.settings_disable_no_emulator_toast_checkbox.stateChanged.connect(settings_disable_no_emulator_toast_statechanged)
         grid_tab_Settings.addWidget(self.settings_disable_no_emulator_toast_checkbox, 25, 0, 1, 2)
 
-        # ── NextSync HTTP bridge toggle ─────────────────────────────────
+        # ── NextSync HTTP bridge toggle + port ──────────────────────────
+        def _http_port_widgets_set_enabled(on):
+            # The port and connection-limit boxes are only editable while
+            # the bridge itself is enabled (and Flask is present at all).
+            on = bool(on) and flask_available()
+            self.settings_http_port_label.setEnabled(on)
+            self.settings_http_port_spinbox.setEnabled(on)
+            self.settings_http_conn_label.setEnabled(on)
+            self.settings_http_conn_spinbox.setEnabled(on)
+
         def settings_http_bridge_statechanged():
             enabled = self.settings_http_bridge_checkbox.isChecked()
             configuration_dictionary[SETTING_NEXTSYNC_HTTP_BRIDGE] = "true" if enabled else "false"
             save_configuration_file()
+            _http_port_widgets_set_enabled(enabled)
             if enabled:
                 self._nextsync_http_bridge_start()
             else:
@@ -23840,7 +23926,7 @@ class MainWindow(QMainWindow):
         if flask_available():
             self.settings_http_bridge_checkbox.setToolTip(
                 "Starts a small self-hosted web server (Flask, port 80 by default —\n"
-                "set nextsync_http_port in hdfg.cfg to change it) that republishes\n"
+                "change it with the port box on the right) that republishes\n"
                 "the Remote Explorer's '.sync5 -listen' session as HTTP routes:\n"
                 "/status /ls /get /put /mkdir /rmdir /rmtree /rm /ren /rcpy /rfsize /forceexit\n"
                 "/free /drives. A Spectrum Next running the built-in .http dot\n"
@@ -23861,7 +23947,81 @@ class MainWindow(QMainWindow):
             )
         self.settings_http_bridge_checkbox.stateChanged.connect(
             settings_http_bridge_statechanged)
-        grid_tab_Settings.addWidget(self.settings_http_bridge_checkbox, 36, 0, 1, 2)
+
+        self.settings_http_port_label = QLabel("Port:")
+        self.settings_http_port_spinbox = QSpinBox()
+        self.settings_http_port_spinbox.setRange(1, 65535)
+        self.settings_http_port_spinbox.setValue(80)
+        self.settings_http_port_spinbox.setFixedWidth(70)
+        _http_port_tip = (
+            "TCP port the HTTP bridge listens on (default 80, what the Next's\n"
+            ".http dot command talks to by default). Saved to hdfg.cfg\n"
+            f"({SETTING_NEXTSYNC_HTTP_PORT}) and used every time the bridge\n"
+            "starts; a bridge already running is restarted on the new port a\n"
+            "moment after you stop typing.")
+        self.settings_http_port_label.setToolTip(_http_port_tip)
+        self.settings_http_port_spinbox.setToolTip(_http_port_tip)
+        self.settings_http_port_label.setEnabled(False)
+        self.settings_http_port_spinbox.setEnabled(False)
+
+        # Debounce the restart of a running bridge: typing "8080" fires
+        # valueChanged four times, but the server should bounce only once,
+        # on the final value.
+        self._http_port_restart_timer = QTimer(self)
+        self._http_port_restart_timer.setSingleShot(True)
+        self._http_port_restart_timer.setInterval(1500)
+
+        def _http_bridge_apply_new_port():
+            if self.settings_http_bridge_checkbox.isChecked() and \
+                    self._re_bridge is not None and self._re_bridge.running:
+                self._nextsync_http_bridge_stop()
+                self._nextsync_http_bridge_start()
+        self._http_port_restart_timer.timeout.connect(_http_bridge_apply_new_port)
+
+        def settings_http_port_changed(port):
+            configuration_dictionary[SETTING_NEXTSYNC_HTTP_PORT] = str(port)
+            save_configuration_file()
+            self._http_port_restart_timer.start()
+        self.settings_http_port_spinbox.valueChanged.connect(
+            settings_http_port_changed)
+
+        self.settings_http_conn_label = QLabel("Max connections:")
+        self.settings_http_conn_spinbox = QSpinBox()
+        self.settings_http_conn_spinbox.setRange(1, 32)
+        self.settings_http_conn_spinbox.setValue(1)
+        self.settings_http_conn_spinbox.setFixedWidth(55)
+        _http_conn_tip = (
+            "Maximum number of HTTP requests the bridge serves concurrently\n"
+            "(default 1). The recommended value is 1 to avoid concurrent\n"
+            "access: the '.sync5 -listen' session behind the bridge runs one\n"
+            "command at a time anyway, so extra requests are held until a\n"
+            "slot frees rather than rejected. Saved to hdfg.cfg\n"
+            f"({SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT}); a bridge already\n"
+            "running is restarted on the new value a moment after you stop\n"
+            "typing.")
+        self.settings_http_conn_label.setToolTip(_http_conn_tip)
+        self.settings_http_conn_spinbox.setToolTip(_http_conn_tip)
+        self.settings_http_conn_label.setEnabled(False)
+        self.settings_http_conn_spinbox.setEnabled(False)
+
+        def settings_http_conn_changed(limit):
+            configuration_dictionary[SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT] = str(limit)
+            save_configuration_file()
+            self._http_port_restart_timer.start()
+        self.settings_http_conn_spinbox.valueChanged.connect(
+            settings_http_conn_changed)
+
+        _http_bridge_row = QHBoxLayout()
+        _http_bridge_row.addWidget(self.settings_http_bridge_checkbox)
+        _http_bridge_row.addSpacing(12)
+        _http_bridge_row.addWidget(self.settings_http_port_label)
+        _http_bridge_row.addWidget(self.settings_http_port_spinbox)
+        _http_bridge_row.addSpacing(12)
+        _http_bridge_row.addWidget(self.settings_http_conn_label)
+        _http_bridge_row.addWidget(self.settings_http_conn_spinbox)
+        _http_bridge_row.addStretch(1)
+        grid_tab_Settings.addLayout(_http_bridge_row, 36, 0, 1, 2)
+        self._http_port_widgets_set_enabled = _http_port_widgets_set_enabled
 
         # ── MAME options (shown when MAME is launchable: a detected binary, or
         # on Linux the Flatpak launch option added below) ──
@@ -25502,6 +25662,34 @@ def _zxnu_parse_anim_arg():
 
 
 _zxnu_parse_anim_arg()
+
+
+# ── optional -start-remote-explorer-listener switch ──────────────────────────
+# `python zx-next-unite.py -start-remote-explorer-listener` opens the NextSync
+# tab's Remote Explorer view and starts its '.sync5 -listen' server right at
+# startup, using the saved sync root — so a Next can run '.sync5 -listen' and
+# connect without a single click (pairs nicely with the HTTP bridge Settings
+# toggle for a fully remote setup). The view is forced open for this run only;
+# the saved Settings are not modified. Without a saved sync root the server
+# cannot start and the usual "pick a sync root folder first" advisory is
+# logged instead.
+_ZXNU_START_RE_LISTENER = False
+
+
+def _zxnu_parse_start_re_listener_arg():
+    global _ZXNU_START_RE_LISTENER
+    rest = [a for a in sys.argv
+            if a not in ("-start-remote-explorer-listener",
+                         "--start-remote-explorer-listener")]
+    if len(rest) != len(sys.argv):
+        _ZXNU_START_RE_LISTENER = True
+        # Strip our flag so QApplication doesn't try to interpret it.
+        sys.argv[:] = rest
+        print("-start-remote-explorer-listener: starting the Remote Explorer "
+              "'.sync5 -listen' server at startup.")
+
+
+_zxnu_parse_start_re_listener_arg()
 
 app = QApplication(sys.argv)
 

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -167,6 +167,7 @@ SETTING_NEXTSYNC_SEND_CONFLICT = "nextsync_send_conflict"   # "prompt" (default)
 # file system. Off by default; when enabled the server starts with the app.
 SETTING_NEXTSYNC_HTTP_BRIDGE   = "nextsync_http_bridge"     # "true"/"false" (default false)
 SETTING_NEXTSYNC_HTTP_PORT     = "nextsync_http_port"       # int, default 80 (.http's default)
+SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT = "nextsync_http_connection_limit"  # int, default 1 (serial -listen session)
 SETTING_GALLERY_ANIM_MODE      = "gallery_anim_mode"        # "hover" (default), "timer" or "none"
 SETTING_GALLERY_ROWS_PER_PAGE  = "gallery_rows_per_page"    # int 1..10, default 2
 SETTING_GALLERY_COLS           = "gallery_cols"             # int: 2 | 4 (default) | 8
@@ -747,7 +748,7 @@ SETTING_GALLERY_ROWS_PER_PAGE, SETTING_GALLERY_COLS, SETTING_GALLERY_IMG_SIZE, S
 SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVORITES_VIEW_MODE,
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
 SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_MAME_ESC, SETTING_MAME_FLATPAK, SETTING_MAME_FLATPAK_ROMPATH, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
-SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_NEXTSYNC_REMOTE_EXPLORER, SETTING_NEXTSYNC_REMOTE_CWD, SETTING_NEXTSYNC_RE_LOCAL_SORT, SETTING_NEXTSYNC_RE_NEXT_SORT, SETTING_NEXTSYNC_EXTRA_DRIVES, SETTING_NEXTSYNC_HTTP_BRIDGE, SETTING_NEXTSYNC_HTTP_PORT, SETTING_SDCARD_PYGAME_LOG, SETTING_SDCARD_SPLITTER, SETTING_GETIT_SPLITTER, SETTING_HELP_PYGAME_LOG, SETTING_RETRO_LOG_FONT_SIZE,
+SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_NEXTSYNC_REMOTE_EXPLORER, SETTING_NEXTSYNC_REMOTE_CWD, SETTING_NEXTSYNC_RE_LOCAL_SORT, SETTING_NEXTSYNC_RE_NEXT_SORT, SETTING_NEXTSYNC_EXTRA_DRIVES, SETTING_NEXTSYNC_HTTP_BRIDGE, SETTING_NEXTSYNC_HTTP_PORT, SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT, SETTING_SDCARD_PYGAME_LOG, SETTING_SDCARD_SPLITTER, SETTING_GETIT_SPLITTER, SETTING_HELP_PYGAME_LOG, SETTING_RETRO_LOG_FONT_SIZE,
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
 
@@ -973,6 +974,25 @@ def parse_mame_version_number(text):
         return int(m.group(1))
     except ValueError:
         return None
+
+
+def mame_version_is_patched(text):
+    """True when a ``mame -version`` output looks like a custom-patched build.
+
+    An official build reports e.g. ``"0.288 (mame0288)"`` — the parenthesised
+    tag matches the dotted version. A custom build's parenthesised part is a
+    ``git describe`` of whatever base tag it was built from, e.g.
+    ``"0.288 (mame0238-18438-g4d332b6484f)"`` — a different base number
+    and/or a ``-<commits>-g<hash>`` suffix. Either disagreement means
+    "patched"."""
+    if not text:
+        return False
+    s = str(text).lower()
+    dotted = re.search(r"0\.(\d+)", s)
+    tag = re.search(r"mame0*(\d+)(-\S+)?", s)
+    if not dotted or not tag:
+        return False
+    return tag.group(2) is not None or int(tag.group(1)) != int(dotted.group(1))
 
 
 def select_mame_release_asset(release, arch):

--- a/zxnu_http_bridge.py
+++ b/zxnu_http_bridge.py
@@ -176,6 +176,41 @@ class QueueBridgeHost:
                     shutil.rmtree(tmp, ignore_errors=True)
 
 
+class _ConnectionLimitMiddleware:
+    """WSGI wrapper bounding how many HTTP requests are processed at once.
+
+    Excess requests are not rejected — they block until a slot frees. With
+    the default limit of 1 the bridge is strictly serial, which matches the
+    '.sync5 -listen' session it drives (one command at a time) and avoids
+    concurrent access altogether.
+
+    The slot is held while the wrapped app produces the response and the
+    body is fully materialised, then released in this frame's ``finally`` —
+    deliberately NOT via a close() callback on the returned iterable:
+    werkzeug's serving handler drains the socket before calling close(),
+    and a client connection reset during that drain (routine on Windows)
+    skips the close() entirely, which would leak the slot forever.
+    Buffering is free here — every bridge response is small text or file
+    bytes already fully in memory."""
+
+    def __init__(self, wsgi_app, limit):
+        self._wsgi_app = wsgi_app
+        self._sem = threading.BoundedSemaphore(max(1, int(limit)))
+
+    def __call__(self, environ, start_response):
+        self._sem.acquire()
+        try:
+            rv = self._wsgi_app(environ, start_response)
+            try:
+                return list(rv)
+            finally:
+                close = getattr(rv, "close", None)
+                if close is not None:
+                    close()
+        finally:
+            self._sem.release()
+
+
 class NextSyncHttpBridge:
     """The Flask web server. Construct with a :class:`QueueBridgeHost` (or
     anything exposing ``state()`` and ``run()``), then :meth:`start` /
@@ -191,6 +226,8 @@ class NextSyncHttpBridge:
         "  GET  /ls?path=/games             directory listing\n"
         "  GET  /get?path=/games/a.tap      download one file (raw bytes)\n"
         "  POST /put?path=/games/a.tap      upload (request body = the file)\n"
+        "  POST /put?path=/f&append=1&size=N  chunked upload: POST pieces\n"
+        "       until N bytes arrived, then the file is written in one go\n"
         "  GET  /mkdir?path=/newdir         create a directory\n"
         "  GET  /rmdir?path=/olddir         remove an EMPTY directory\n"
         "  GET  /rmtree?path=/olddir        remove a directory recursively\n"
@@ -201,10 +238,14 @@ class NextSyncHttpBridge:
         "  GET  /forceexit                  make the Next leave -listen and exit\n")
 
     def __init__(self, host_adapter, listen_host="0.0.0.0", port=DEFAULT_PORT,
-                 log=None, verbose=False):
+                 log=None, verbose=False, connection_limit=1):
         self._adapter = host_adapter
         self._listen_host = listen_host
         self._port = int(port)
+        # How many HTTP requests may be served concurrently. 1 (the default
+        # and the recommended value) fully serialises the bridge, matching
+        # the serial -listen session behind it.
+        self._connection_limit = max(1, int(connection_limit or 1))
         self._log = log or (lambda s: None)
         # verbose: log every HTTP request (method, path, query, payload) and
         # its response (status, body) through self._log — the troubleshooting
@@ -221,6 +262,17 @@ class NextSyncHttpBridge:
         # disconnects), so /status can report partition counts without a
         # round-trip on every poll.
         self._drives_cache = None
+        # /put?append=1 chunked uploads: per-remote-path spool of the chunks
+        # received so far (the Next's .http can POST at most one 16K bank per
+        # request, so big files arrive in pieces). Guarded by its own lock —
+        # connection_limit may be >1.
+        self._put_spool = {}
+        self._spool_lock = threading.Lock()
+
+    # Hard cap on a single chunked upload's declared size: everything is
+    # assembled in memory before the one-shot push to the Next (just like a
+    # plain /put buffers its whole body), so refuse absurd declarations.
+    MAX_SPOOL = 256 * 1024 * 1024
 
     # ------------------------------------------------------------------
     @property
@@ -257,6 +309,8 @@ class NextSyncHttpBridge:
             lg.propagate = False
         app = Flask("zxnu_http_bridge")
         self._install_routes(app)
+        app.wsgi_app = _ConnectionLimitMiddleware(app.wsgi_app,
+                                                  self._connection_limit)
         # Pre-flight probe: werkzeug binds with SO_REUSEADDR, which on
         # Windows silently SUCCEEDS even when another program already owns
         # the port (the classic WinError 10048 only surfaces for exclusive
@@ -305,7 +359,9 @@ class NextSyncHttpBridge:
         self._thread = threading.Thread(target=server.serve_forever,
                                         daemon=True, name="zxnu-http-bridge")
         self._thread.start()
-        self._log(f"HTTP bridge: serving on port {self._port}")
+        self._log(f"HTTP bridge: serving on port {self._port} "
+                  f"(max {self._connection_limit} concurrent "
+                  f"connection{'s' if self._connection_limit != 1 else ''})")
         return True, ""
 
     def stop(self):
@@ -317,6 +373,8 @@ class NextSyncHttpBridge:
                 pass
             self._log("HTTP bridge: stopped")
         self._thread = None
+        with self._spool_lock:
+            self._put_spool.clear()   # drop any unfinished chunked uploads
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -502,6 +560,52 @@ class NextSyncHttpBridge:
                 headers={"Content-Disposition":
                          f'attachment; filename="{name}"'})
 
+        def _put_append(path, body):
+            """Chunked upload for callers that cannot send a whole file in
+            one request — the Next's .http POSTs at most one 16K bank.
+            Chunks accumulate in a bridge-side spool; when the declared
+            total (&size=) has arrived, the assembled file is pushed to the
+            Next in a single put (the -listen transfer handles any size).
+            Re-declaring a different size for the same path restarts the
+            upload, so a failed transfer can simply be sent again."""
+            try:
+                total = int(request.args.get("size") or "")
+            except ValueError:
+                total = -1
+            if total < 0:
+                return bad("append=1 needs &size=<total file bytes> "
+                           "(read the file's length first)")
+            if total > self.MAX_SPOOL:
+                return bad(f"size {total} exceeds the chunked-upload cap "
+                           f"of {self.MAX_SPOOL} bytes")
+            with self._spool_lock:
+                sp = self._put_spool.get(path)
+                if sp is None or sp["size"] != total:
+                    sp = {"size": total, "data": bytearray(), "chunks": 0}
+                    self._put_spool[path] = sp
+                sp["data"] += body
+                sp["chunks"] += 1
+                got, chunks = len(sp["data"]), sp["chunks"]
+                if got > total:
+                    del self._put_spool[path]
+                    return bad(f"append overflow: got {got} of {total} "
+                               "declared bytes - upload dropped, send it "
+                               "again from the first chunk")
+                if got < total:
+                    return answer(
+                        {"ok": True, "path": path, "done": False,
+                         "bytes": got, "size": total, "chunks": chunks},
+                        [f"OK append {path} ({got}/{total} bytes)"])
+                data = bytes(sp["data"])
+                del self._put_spool[path]
+            res = run("put", path, body=data)
+            if not res.get("ok"):
+                return fail(res, f"put {path}")
+            return answer({"ok": True, "path": path, "done": True,
+                           "bytes": total, "chunks": chunks},
+                          [f"OK put {path} ({total} bytes, "
+                           f"{chunks} chunks)"])
+
         @app.route("/put", methods=["POST", "PUT"])
         def _put():
             v = need(("path", "file"))
@@ -515,6 +619,12 @@ class NextSyncHttpBridge:
                                "or give the full file path")
                 path = path + name
             body = request.get_data() or b""
+            if request.args.get("append") in ("1", "true", "yes"):
+                return _put_append(path, body)
+            with self._spool_lock:
+                # A plain put overwrites: also discard any half-done chunked
+                # upload spooled for the same path.
+                self._put_spool.pop(path, None)
             res = run("put", path, body=body)
             if not res.get("ok"):
                 return fail(res, f"put {path}")


### PR DESCRIPTION
## Summary
- **Settings tab**: the NextSync HTTP bridge row gains a **Port** box (default 80) and a **Max connections** box (default **1**, the recommended value to avoid concurrent access to the serial `-listen` session). Both persist to `hdfg.cfg` (`nextsync_http_port` / `nextsync_http_connection_limit`), are restored at startup, grey out with the bridge/Flask, and bounce a running bridge (debounced) when changed.
- **Concurrency cap** implemented as a semaphore WSGI middleware in `zxnu_http_bridge.py`. It deliberately releases in its own `finally` rather than via WSGI `close()`: werkzeug drains the socket before calling `close()`, and a client reset during that drain (routine on Windows) skips it — the close()-based version leaked slots until the bridge hung. `nextsync5.py` defaults to 1; override with `-flask-connection-limit:<n>` (`=` also accepted).
- **`-start-remote-explorer-listener`** startup switch: opens the Remote Explorer view (without persisting the choice) and starts its `.sync5 -listen` server at startup using the saved sync root — pairs with the bridge for a no-clicks remote setup.
- **Chunked uploads**: `/put?path=X&append=1&size=N` spools POSTed pieces and writes the assembled file to the Next in one transfer. Needed because a Next''s `.http` can POST at most **one 16K bank** per request (verified against the next-http README — `-f` is GET-only, rolling banks are download-only).
- **HTTP_BRIDGE.md**: curl examples now use `localhost` (Next-side `.http` lines keep the LAN IP), the `-forceexit` example uses the default port 80, new **NextBASIC big-file upload sample** (stream length via `DIM #`, 16K bank chunks, `.http` variable substitution), and a **CSpect note** (emulated ESP is 7-bit; add `-7` per the [next-http docs](https://github.com/remy/next-http)).
- **MAME update check** always ends with a message: `MAME is up-to-date…`, `…up-to-date with a patched version…` (new `mame_version_is_patched` git-describe detection), or explicit skip messages when the release site is unreachable / unparseable — no more dangling "Checking for a newer MAME release…".

## Testing
- New bridge tests (scratchpad): connection limit 1 serialises three 1s requests (~3s) vs limit 3 (~1s), no leaked slots; chunked-upload happy path reassembles byte-exact plus 400 paths (missing size, overflow) and stale-spool cleanup.
- Existing `nextsync/sync/server/test_http_bridge.py` e2e suite: **ALL PASS**.
- Offscreen startup smoke tests: listener autostarts with the switch, port/connection spinboxes restored from cfg, enabled state tracks the bridge toggle, bridge serves HTTP 200 on the configured port.
- `mame_version_is_patched` verified against official/patched/dev/banner/garbage version strings.
- NextBASIC sample follows the official NextZXOS file-commands doc and next-http''s own examples but has not been run on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)