### PR TITLE
tests/ suite checked in + self-update check and dotN update advisory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ toggle is greyed out until Flask is installed) with:
 python -m pip install -r REQUIREMENTS.txt
 ```
 
-No build step is needed for development. There are no tests or linters configured in this project.
+No build step is needed for development. The test suite lives in `tests/` — run it all with `python tests/run_all.py` (plain scripts, no pytest; see `tests/README.md`). No linters are configured.
 
 For quickly eyeballing the retro "Alien Floyd" Sir Clive promenade animations
 (the ones drawn in `zxnu_pygame.py`), pass `--anim` to force one to play first
@@ -84,9 +84,9 @@ pyside6-rcc rc_backgrounds.qrc -o rc_backgrounds.py
 | `zx-next-unite.py` | Entry point; contains the single `MainWindow(QMainWindow)` class and all tab/pane UI logic |
 | `zxnu_config.py` | Constants, `SETTING_*` keys, API base URLs, UI string tables, color defaults, and pure helpers (`resource_path`, `qcolor_to_hex`, etc.) |
 | `zxnu_workers.py` | Background threading primitives: `WorkerSignals`, `NextSyncSignals`, `HdfTaskSignals`, `HdfTaskWorker`, `HdfProgressDialog`, `DotDotFirstProxyModel`; also the NextSync `-listen` worker (`run_remote_listen_server` + `RemoteExplorerSignals`) behind the Remote Explorer |
-| `zxnu_remote_explorer.py` | `RemoteExplorerWidget`: the dual-pane local ⇄ Next file manager of the NextSync tab (drives the `-listen` worker via a command queue; covered headlessly by `nextsync/sync/server/test_remote_listen.py` for the worker side) |
-| `zxnu_http_bridge.py` | NextSync HTTP bridge: reusable Flask web server (stdlib-only import; Flask optional, loaded on start — `flask_available()` gates the UI) republishing a `-listen` session as HTTP routes for the Next's `.http` dot command. Used by the app (Settings toggle + port and max-connections boxes, `SETTING_NEXTSYNC_HTTP_BRIDGE`/`SETTING_NEXTSYNC_HTTP_PORT`/`SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT`, greyed without Flask) and `nextsync5.py -w`/`-http[=port]` (+`-flask-connection-limit:<n>`, default 1); docs + call samples in `nextsync/sync/server/HTTP_BRIDGE.md`, e2e test in `test_http_bridge.py` |
-| `nextsync5.py` | Standalone Sync4 NextSync command-line server (moved to the repo root so it sits next to `zxnu_http_bridge.py`); `-listen` console, `-w`/`-http[=port]` web bridge, `-v` also traces every HTTP request/response. Protocol tests in `nextsync/sync/server/test_listen.py` |
+| `zxnu_remote_explorer.py` | `RemoteExplorerWidget`: the dual-pane local ⇄ Next file manager of the NextSync tab (drives the `-listen` worker via a command queue; covered headlessly by `tests/test_remote_listen.py` for the worker side) |
+| `zxnu_http_bridge.py` | NextSync HTTP bridge: reusable Flask web server (stdlib-only import; Flask optional, loaded on start — `flask_available()` gates the UI) republishing a `-listen` session as HTTP routes for the Next's `.http` dot command. Used by the app (Settings toggle + port and max-connections boxes, `SETTING_NEXTSYNC_HTTP_BRIDGE`/`SETTING_NEXTSYNC_HTTP_PORT`/`SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT`, greyed without Flask) and `nextsync5.py -w`/`-http[=port]` (+`-flask-connection-limit:<n>`, default 1); docs + call samples in `nextsync/sync/server/HTTP_BRIDGE.md`, e2e test in `tests/test_http_bridge.py` |
+| `nextsync5.py` | Standalone Sync4 NextSync command-line server (moved to the repo root so it sits next to `zxnu_http_bridge.py`); `-listen` console, `-w`/`-http[=port]` web bridge, `-v` also traces every HTTP request/response. Protocol tests in `tests/test_listen.py` |
 | `zxnu_media.py` | ZX Spectrum `SCREEN$` decoder (`ZxSpectrumScreen`), placeholder-pixmap rendering, file-format tag helpers, and the shared pixmap cache |
 | `zxnu_gallery.py` | Reusable gallery widgets: `GalleryCell`, the scrollable grid view, and the `AnimatedBackground` widget |
 | `zxnu_itchio.py` | Optional itch.io integration: `itch-dl` detection, itch.io API access (collections/owned/search via the user's API key) and install-via-`itch-dl`. Drives the optional itch.io tab |

--- a/nextsync/sync/server/HTTP_BRIDGE.md
+++ b/nextsync/sync/server/HTTP_BRIDGE.md
@@ -444,4 +444,4 @@ curl "http://localhost/rfsize?path=/games&json=1"
   Remote Explorer / `listen>` console would.
 * Troubleshooting: `nextsync5.py -w -v` logs every request and response
   (`HTTP > GET /ls?path=/ …` / `HTTP < 200 GET /ls OK 2 entries…`).
-* Covered end-to-end by `test_http_bridge.py` (mock Next, both hosts).
+* Covered end-to-end by `tests/test_http_bridge.py` (repo root; mock Next, both hosts).

--- a/nextsync/sync/z88dk/README.md
+++ b/nextsync/sync/z88dk/README.md
@@ -227,16 +227,17 @@ user's responsibility exactly as for every other drive-prefixed command.
 Server side: `nextsync5.py` gains a `listen_session()` (triggered by `"Listen"`)
 with a console CLI (`ls`/`get`/`put`/`mkdir`/`rmdir`/`rm`/`ren`/`drives`/
 `psize`/`pfull`/`rcpy`/`rfsize`/`quit`). The whole wire
-protocol is covered by `server/test_listen.py`, which drives `listen_session()`
-over a socketpair with a mock Next — run it with `python test_listen.py`.
+protocol is covered by `tests/test_listen.py` (repo root), which drives
+`listen_session()` over a socketpair with a mock Next — run it with
+`python tests/test_listen.py`.
 (The app-side twin, `zxnu_workers.run_remote_listen_server`, is covered by
-`server/test_remote_listen.py`.)
+`tests/test_remote_listen.py`.)
 
 ## Status / testing
 
 - Builds clean as a valid dotN (~13 KB of code+data past the old 8 KB page;
   24 KB command file).
-- **Server `-listen` protocol is validated on localhost** by `test_listen.py`
+- **Server `-listen` protocol is validated on localhost** by `tests/test_listen.py`
   (ls/get/put/mkdir/rmdir/rm all pass against a mock Next). The **dot** side
   compiles clean and reuses the proven send/receive paths, but the Next half of
   `-listen` still needs a real-Next run to confirm.

--- a/nextsync/sync/z88dk/nextsync.c
+++ b/nextsync/sync/z88dk/nextsync.c
@@ -1120,6 +1120,10 @@ int main(int arglen, char *rawcmd)
         con_cls();                                        // paint the whole screen black + home
     }
 
+    // On a version bump ALSO update ZX_NEXT_UNITE_DOTN_VERSION in
+    // zxnu_config.py (and the help text below): the app compares it against
+    // the cfg's dotn_last_version to advise the user to refresh the .sync5
+    // copy on their Next after updating the app.
     print("NextSync 5.4 Clauzel/Komppa");
 
     len = parse_cmdline(fn);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# Tests
+
+Run everything:
+
+```
+python tests/run_all.py
+```
+
+Each file also runs standalone (`python tests/<file>.py`); they are plain
+scripts printing `PASS`/`FAIL` lines and exiting non-zero on failure — no
+pytest dependency. Every suite runs in its own process (they monkey-patch Qt
+and the import system, so isolation matters).
+
+| File | What it covers | Needs |
+|---|---|---|
+| `test_listen.py` | The Sync4 `-listen` wire protocol of the standalone server (`nextsync5.listen_session`) over a socketpair against a mock Next implementing the dot's half: ls/get/put/mkdir/rmdir/rm framing, checksums, retries. | PySide6-free (pure stdlib) |
+| `test_remote_listen.py` | The app-side `-listen` worker (`zxnu_workers.run_remote_listen_server`) over a real localhost socket against the same mock Next: command queue in, Qt signals out, incl. rmtree walks, drives/free/rcpy/rfsize, failure paths. | PySide6 |
+| `test_http_bridge.py` | End-to-end HTTP bridge (`zxnu_http_bridge`) against the mock Next, over both hosts: real HTTP → bridge → app worker, and real HTTP → bridge → `nextsync5.listen_session`. | PySide6, Flask (skipped by `run_all.py` when Flask is missing) |
+| `test_retro_log_widget.py` | `RetroLogWidget.set_text_color` unit checks (hex/tuple parsing, clamping, fallback to phosphor green, per-instance tint). Uses the REAL Qt platform — pygame-adjacent widgets crash under offscreen Qt — but never shows a window. | PySide6 |
+| `test_ui_offscreen.py` | Offscreen end-to-end UI suite: launches a COPY of `zx-next-unite.py` (own scratch dir + `hdfg.cfg` under the OS temp folder — the real config is never touched) under `QT_QPA_PLATFORM=offscreen` and drives the real widgets. Seven phases: (1) SD Card tab path rows, Up/Refresh, local + in-image path navigation on a generated test HDF, persistence to `hdfg.cfg`, Settings color picker; (2) startup restore of the saved in-image path + retro-log color; (3) startup fallback for a missing saved path; (4) NextSync classic explorer drag & drop; (5) watched-folder delete regression (full deletion, zero `QFileSystemWatcher` access-denied warnings); (6) self-update Settings toggle + the ".sync5 dot updated" advisory popup; (7) dotN advisory first-run silent persist and the toggle's default-ON. Every phase disables the GitHub release check (or quits before it fires), so the suite never touches the network. | PySide6; phases 1–3 additionally need **hdfmonkey** (PATH or a populated `downloads/` folder — gitignored) and SKIP cleanly without it |
+
+Notes:
+
+- `test_ui_offscreen.py` without arguments runs all five phases in separate
+  subprocesses (a fresh `QApplication` per phase); pass a phase number to run
+  just one, e.g. `python tests/test_ui_offscreen.py 5`. Phase 1 builds the
+  scratch state (including the test HDF) that phases 2–3 reuse.
+- The UI suite import-blocks pygame: pygame crashes natively under offscreen
+  Qt, and the app degrades gracefully when it is "not installed".
+- On Windows the UI suite creates a directory junction from its scratch dir to
+  the repo's `downloads/` folder so the app copy discovers hdfmonkey the same
+  way the real app does.

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -1,0 +1,53 @@
+"""Run the whole ZX-Next-Unite test suite and print one summary.
+
+Usage:  python tests/run_all.py
+
+Each test file is run in its own process (they patch/monkey with Qt and
+sys.meta_path, so isolation matters). Suites whose optional dependency is
+missing are reported as SKIPPED rather than failed:
+  - test_http_bridge.py needs Flask (the bridge itself is optional in-app)
+  - test_ui_offscreen.py phases 1-3 skip internally without hdfmonkey
+
+Exit code: 0 when nothing failed (skips allowed), 1 otherwise.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+SUITES = [
+    # (file, timeout seconds, required import or None)
+    ("test_listen.py",          120, None),
+    ("test_remote_listen.py",   120, None),
+    ("test_http_bridge.py",     240, "flask"),
+    ("test_retro_log_widget.py", 120, None),
+    ("test_ui_offscreen.py",    3600, None),   # runs its 5 phases itself
+]
+
+results = []
+for name, timeout, needs in SUITES:
+    print(f"\n======== {name} ========", flush=True)
+    if needs is not None and importlib.util.find_spec(needs) is None:
+        print(f"SKIPPED: optional dependency '{needs}' is not installed")
+        results.append((name, "SKIP", 0.0))
+        continue
+    t0 = time.monotonic()
+    try:
+        rc = subprocess.call([sys.executable, os.path.join(HERE, name)],
+                             timeout=timeout)
+    except subprocess.TimeoutExpired:
+        print(f"TIMED OUT after {timeout}s")
+        rc = 1
+    results.append((name, "PASS" if rc == 0 else "FAIL",
+                    time.monotonic() - t0))
+
+print("\n======== summary ========")
+width = max(len(n) for n, _s, _t in results)
+failed = False
+for name, status, secs in results:
+    print(f"{name.ljust(width)}  {status}  ({secs:5.1f}s)")
+    failed = failed or status == "FAIL"
+sys.exit(1 if failed else 0)

--- a/tests/test_http_bridge.py
+++ b/tests/test_http_bridge.py
@@ -16,7 +16,7 @@ import time
 import urllib.error
 import urllib.request
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from PySide6.QtCore import QCoreApplication, Qt          # noqa: E402

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -9,7 +9,7 @@ import os, sys, socket, threading, tempfile, shutil, time, io, contextlib
 
 # nextsync5.py lives at the repo root (next to zxnu_http_bridge.py, which it
 # imports for the optional -w/-http web server).
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import nextsync5 as ns
 
 if os.environ.get("TL_DEBUG"):

--- a/tests/test_remote_listen.py
+++ b/tests/test_remote_listen.py
@@ -4,7 +4,7 @@ dot's half of the protocol; we drive the worker via its command queue and check
 the emitted signals."""
 import os, sys, socket, threading, queue, tempfile, shutil, time
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from PySide6.QtCore import QCoreApplication, Qt
 from zxnu_workers import RemoteExplorerSignals, run_remote_listen_server
 

--- a/tests/test_retro_log_widget.py
+++ b/tests/test_retro_log_widget.py
@@ -1,0 +1,47 @@
+"""RetroLogWidget.set_text_color unit test.
+
+Runs with the REAL Qt platform (no window is ever shown): pygame-dependent
+classes crash natively only under QT_QPA_PLATFORM=offscreen, so unlike the
+UI suite this one must NOT set offscreen.
+
+Run with: python test_retro_log_widget.py
+"""
+import os, sys
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")))
+
+from PySide6.QtWidgets import QApplication
+app = QApplication(sys.argv)
+from zxnu_pygame import RetroLogWidget
+
+FAIL = []
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+w = RetroLogWidget()
+check("default is phosphor green", w._C_LOG == (120, 255, 140), str(w._C_LOG))
+w.set_text_color("#112233")
+check("hex string applied", w._C_LOG == (0x11, 0x22, 0x33), str(w._C_LOG))
+w.set_text_color((1, 2, 3))
+check("rgb tuple applied", w._C_LOG == (1, 2, 3), str(w._C_LOG))
+w.set_text_color((300, -5, 128))
+check("tuple clamped to 0..255", w._C_LOG == (255, 0, 128), str(w._C_LOG))
+w.set_text_color("garbage")
+check("bad string falls back to green", w._C_LOG == (120, 255, 140), str(w._C_LOG))
+w.set_text_color("#112233")
+w.set_text_color(None)
+check("None falls back to green", w._C_LOG == (120, 255, 140), str(w._C_LOG))
+w2 = RetroLogWidget()
+w.set_text_color("#ff0000")
+check("per-instance tint (other widget untouched)",
+      w2._C_LOG == (120, 255, 140) and w._C_LOG == (255, 0, 0),
+      f"{w._C_LOG} / {w2._C_LOG}")
+
+print()
+if FAIL:
+    print(f"RESULT: {len(FAIL)} FAILURE(S)")
+    sys.exit(1)
+print("RESULT: ALL WIDGET COLOR CHECKS PASSED")

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1,0 +1,712 @@
+"""Offscreen end-to-end UI suite for zx-next-unite.
+
+Run everything:   python test_ui_offscreen.py
+Run one phase:    python test_ui_offscreen.py <1..5>
+
+Phases:
+  1  SD Card tab: explorer path rows (Up / Refresh / labels / editable path
+     boxes), local path box paste/file/invalid navigation, disk-image path
+     navigation e2e on a generated test HDF (nested folder, file, root,
+     unknown path), in-image path + retro-log color persistence to hdfg.cfg,
+     and the Settings color-picker layout.                  (needs hdfmonkey)
+  2  Startup restore: image_explorerpath and color_retro_log from hdfg.cfg
+     are applied after the startup image load.    (needs hdfmonkey + phase 1)
+  3  Startup fallback: a saved in-image path missing from the image logs the
+     advisory, stays at "/" and re-persists "/".  (needs hdfmonkey + phase 1)
+  4  NextSync classic local explorer: drag & drop configuration and an
+     OS-style drop that imports the file.                (no hdfmonkey needed)
+  5  Watched-folder delete regression on BOTH local explorers: expanding
+     subfolders makes QFileSystemModel watch them; deleting the tree must
+     fully remove it with ZERO 'FindNextChangeNotification failed' watcher
+     warnings (the Windows UI-freeze bug).               (no hdfmonkey needed)
+  6  Self-update Settings toggle (top row, cfg restore off, persist on) and
+     the ".sync5 dot updated" advisory popup when dotn_last_version in the
+     cfg is older than the bundled dotN.                 (no hdfmonkey needed)
+  7  dotN advisory first-run silent persist (no popup) + the update-check
+     toggle defaulting ON when the cfg has no key.       (no hdfmonkey needed)
+
+Every phase cfg carries zxnu_update_check=false (except phase 7, which quits
+before the delayed check can fire) so the suite never talks to GitHub.
+
+Isolation: each phase runs a COPY of zx-next-unite.py from a scratch dir
+under the OS temp folder with its own hdfg.cfg (the app resolves its cfg and
+downloads/ from argv[0]'s directory), so the real configuration is never
+touched. pygame is import-blocked (it crashes natively under offscreen Qt).
+Phases that need hdfmonkey SKIP cleanly (exit 0, "SKIPPED" in the output)
+when none can be found — e.g. on a fresh checkout or CI, where downloads/
+(gitignored) doesn't exist.
+"""
+import os, sys, shutil, subprocess, runpy, time, tempfile, importlib.machinery
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+SCRATCH = os.path.join(tempfile.gettempdir(), "zxnu-ui-tests")
+CFG = os.path.join(SCRATCH, "hdfg.cfg")
+HDF = os.path.join(SCRATCH, "test.hdf")
+PASTE_SUB = os.path.join(SCRATCH, "pastedir", "sub")
+PASTE_FILE = os.path.join(PASTE_SUB, "afile.txt")
+DROPZONE = os.path.join(SCRATCH, "dropzone")
+DROPSRC = os.path.join(SCRATCH, "dropsrc.txt")
+DELZONE = os.path.join(SCRATCH, "delzone")
+
+PHASE = int(sys.argv[1]) if len(sys.argv) > 1 else None
+ALL_PHASES = (1, 2, 3, 4, 5, 6, 7)
+
+# Base cfg for the isolated app copy: update checks off (MAME/CSpect AND the
+# app's own GitHub release check) so no phase ever hits the network.
+BASE_CFG = ("mame_update_check=false\ncspect_update_check=false\n"
+            "zxnu_update_check=false\n")
+
+
+def find_hdfmonkey():
+    """hdfmonkey from PATH, or via the app's own downloads-discovery helpers
+    (downloads/ is gitignored, so this can legitimately come up empty).
+
+    CRITICAL: zxnu_config computes ZX_NEXT_UNITE_CONFIG_FILE_NAME at IMPORT
+    time from sys.argv[0]. Importing it here caches the module with the cfg
+    path pointing at tests/hdfg.cfg; the app run by runpy later would reuse
+    that cached module and read/write the WRONG cfg (this exact bug cost a
+    debugging round). So purge every zxnu* module after the lookup — the app
+    then re-imports them fresh with argv[0] already rewritten to its scratch
+    copy."""
+    p = shutil.which("hdfmonkey")
+    if p:
+        return p
+    sys.path.insert(0, REPO)
+    try:
+        from zxnu_config import (find_hdfmonkey_in_downloads,
+                                 find_emulators_in_downloads)
+        p = find_hdfmonkey_in_downloads(REPO)
+        if not p:
+            _cspect, p = find_emulators_in_downloads(REPO, scan_for_cspect=False)
+        return p
+    except Exception:
+        return None
+    finally:
+        for _m in [k for k in sys.modules if k.startswith("zxnu")]:
+            del sys.modules[_m]
+
+
+def skip(reason):
+    print(f"PHASE {PHASE} SKIPPED: {reason}")
+    sys.exit(0)
+
+
+# ---- runner mode: no phase argument = run every phase in a subprocess ------
+if PHASE is None:
+    failed = []
+    for ph in ALL_PHASES:
+        print(f"\n=== UI offscreen phase {ph} ===", flush=True)
+        try:
+            rc = subprocess.call([sys.executable, os.path.abspath(__file__), str(ph)],
+                                 timeout=900)
+        except subprocess.TimeoutExpired:
+            print(f"PHASE {ph} TIMED OUT (possible UI hang)")
+            rc = 1
+        if rc != 0:
+            failed.append(ph)
+    print()
+    if failed:
+        print(f"UI SUITE RESULT: FAILED phase(s): {failed}")
+        sys.exit(1)
+    print("UI SUITE RESULT: ALL PHASES PASSED (or skipped cleanly)")
+    sys.exit(0)
+
+
+# ---- per-phase scratch setup ------------------------------------------------
+def ensure_scratch(fresh):
+    """(Re)create the isolated scratch dir: app copy, base cfg, and a junction
+    to the repo's downloads/ (when it exists) so the app's hdfmonkey/emulator
+    discovery works. The app copy is ALWAYS refreshed — later phases must run
+    the current source, never a stale copy from an earlier phase."""
+    if fresh and os.path.isdir(SCRATCH):
+        j = os.path.join(SCRATCH, "downloads")
+        if os.path.isdir(j):
+            os.rmdir(j)          # junction: removes the link only, not the target
+        shutil.rmtree(SCRATCH)
+    os.makedirs(SCRATCH, exist_ok=True)
+    shutil.copy(os.path.join(REPO, "zx-next-unite.py"),
+                os.path.join(SCRATCH, "zx-next-unite.py"))
+    if fresh or not os.path.isfile(CFG):
+        with open(CFG, "w") as f:
+            f.write(BASE_CFG)
+    j = os.path.join(SCRATCH, "downloads")
+    repo_dl = os.path.join(REPO, "downloads")
+    if os.path.isdir(repo_dl) and not os.path.isdir(j):
+        subprocess.run(["cmd", "/c", "mklink", "/J", j, repo_dl],
+                       check=True, capture_output=True)
+
+
+if PHASE == 1:
+    HDFMONKEY = find_hdfmonkey()
+    if not HDFMONKEY:
+        skip("hdfmonkey not found (PATH or downloads/) — phases 1-3 need it")
+    ensure_scratch(fresh=True)
+    os.makedirs(PASTE_SUB)
+    with open(PASTE_FILE, "w") as f:
+        f.write("x")
+    subprocess.run([HDFMONKEY, "create", HDF, "64M"], check=True, capture_output=True)
+    subprocess.run([HDFMONKEY, "mkdir", HDF, "/games"], check=True, capture_output=True)
+    subprocess.run([HDFMONKEY, "mkdir", HDF, "/games/sub"], check=True, capture_output=True)
+    subprocess.run([HDFMONKEY, "put", HDF, PASTE_FILE, "/games/sub/hello.txt"],
+                   check=True, capture_output=True)
+elif PHASE in (2, 3):
+    # Reuse phase 1's scratch (test HDF + junction) with a cfg that points at
+    # the HDF and pre-seeds the state whose startup restore is under test.
+    if not os.path.isfile(HDF):
+        skip("no test HDF (phase 1 did not run or was skipped)")
+    ensure_scratch(fresh=False)
+    saved = "/games/sub" if PHASE == 2 else "/gone"
+    with open(CFG, "w") as f:
+        f.write(BASE_CFG
+                + f"hddffile={HDF}\nimage_explorerpath={saved}\n"
+                + "color_retro_log=#112233\n")
+elif PHASE == 4:
+    ensure_scratch(fresh=False)
+    with open(CFG, "w") as f:
+        f.write(BASE_CFG)
+    if os.path.isdir(DROPZONE):
+        shutil.rmtree(DROPZONE)
+    os.makedirs(os.path.join(DROPZONE, "subdir"))
+    with open(DROPSRC, "w") as f:
+        f.write("drop me")
+elif PHASE == 5:
+    ensure_scratch(fresh=False)
+    with open(CFG, "w") as f:
+        f.write(BASE_CFG)
+    if os.path.isdir(DELZONE):
+        shutil.rmtree(DELZONE)
+    for victim, sub in (("victim", "sub"), ("victim2", "sub2")):
+        deep = os.path.join(DELZONE, victim, sub, "subsub")
+        os.makedirs(deep)
+        with open(os.path.join(DELZONE, victim, sub, "a.txt"), "w") as f:
+            f.write("x")
+        with open(os.path.join(deep, "b.txt"), "w") as f:
+            f.write("y")
+elif PHASE in (6, 7):
+    # Phase 6: dotn_last_version older than the bundled dotN -> the ".sync5
+    # needs updating on your Next" advisory popup must fire, and the Settings
+    # toggle must restore a saved "false" and persist a re-check. Phase 7:
+    # NO dotn key (first-run silent persist, no popup) and NO
+    # zxnu_update_check key (the toggle must default ON); the phase quits
+    # long before the 3.4s-delayed release check could fire, so it still
+    # never talks to GitHub.
+    ensure_scratch(fresh=False)
+    with open(CFG, "w") as f:
+        if PHASE == 6:
+            f.write(BASE_CFG + "dotn_last_version=1.0\n")
+        else:
+            f.write("mame_update_check=false\ncspect_update_check=false\n")
+else:
+    print(f"Unknown phase {PHASE}")
+    sys.exit(2)
+
+# ---- block pygame (crashes natively under offscreen Qt) --------------------
+class _NoPygame(importlib.machinery.PathFinder):
+    def find_spec(self, name, path=None, target=None):
+        if name == "pygame" or name.startswith("pygame."):
+            raise ModuleNotFoundError(name)
+        return None
+sys.meta_path.insert(0, _NoPygame())
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, REPO)
+
+from PySide6.QtWidgets import QApplication, QLineEdit
+from PySide6.QtCore import QTimer, QCoreApplication
+
+FAILURES = []
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAILURES.append(label)
+
+def wait_until(cond, timeout=60.0, what=""):
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        QCoreApplication.processEvents()
+        if cond():
+            return True
+        time.sleep(0.02)
+    print(f"TIMEOUT waiting for: {what}")
+    return False
+
+def cfg_lines():
+    with open(CFG, encoding="utf-8") as f:
+        return f.read().splitlines()
+
+def recent_log(win, needle, n=10):
+    return any(needle in win.listWidgetLog.item(i).text()
+               for i in range(min(n, win.listWidgetLog.count())))
+
+def find_win():
+    for w in QApplication.instance().topLevelWidgets():
+        if w.__class__.__name__ == "MainWindow":
+            return w
+    return None
+
+def inspect_phase1():
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+
+    # Let the background emulator/hdfmonkey scan finish first: its callback
+    # re-runs load_image once, which would otherwise race the checks below.
+    wait_until(lambda: not getattr(win, "_emulator_scan_pending", False),
+               what="emulator scan settled")
+
+    # ---- layout ---------------------------------------------------------
+    check("local box is QLineEdit", isinstance(win.local_file_explorer_path, QLineEdit))
+    check("image box is QLineEdit", isinstance(win.diskimageexplorerpathinput, QLineEdit))
+    check("image label text", win.diskimageexplorerlabel.text() == "Disk Image Explorer: ",
+          win.diskimageexplorerlabel.text())
+    grid = win.sdcard_explorer_grid
+    def pos(widget):
+        i = grid.indexOf(widget)
+        return None if i < 0 else grid.getItemPosition(i)[:2]
+    check("local path row at grid (0,0)", pos(win.local_path_row_container) == (0, 0), str(pos(win.local_path_row_container)))
+    check("image path row at grid (0,2)", pos(win.image_path_row_container) == (0, 2), str(pos(win.image_path_row_container)))
+    _lrow = win.local_path_row_container.layout()
+    check("local row = Up|Refresh|label|path box",
+          _lrow.indexOf(win.local_explorer_up_button) == 0
+          and _lrow.indexOf(win.local_explorer_refresh_button) == 1
+          and _lrow.indexOf(win.localexplorerlabel) == 2
+          and _lrow.indexOf(win.local_file_explorer_path) == 3)
+    check("local label text", win.localexplorerlabel.text() == "Local path: ",
+          win.localexplorerlabel.text())
+    _irow = win.image_path_row_container.layout()
+    check("image row = Up|Refresh|label|path box",
+          _irow.indexOf(win.image_explorer_up_button) == 0
+          and _irow.indexOf(win.image_explorer_refresh_button) == 1
+          and _irow.indexOf(win.diskimageexplorerlabel) == 2
+          and _irow.indexOf(win.diskimageexplorerpathinput) == 3)
+    check("local explorer at grid (1,0)", pos(win.treeview) == (1, 0), str(pos(win.treeview)))
+    check("image explorer at grid (1,2)", pos(win.image_explorer_container) == (1, 2), str(pos(win.image_explorer_container)))
+    check("image buttons at grid (2,2)", pos(win.imageexplorerbuttonscontainer) == (2, 2), str(pos(win.imageexplorerbuttonscontainer)))
+    check("old widgets out of top row",
+          win.horizontal2.indexOf(win.diskimageexplorerlabel) == -1
+          and win.horizontal2.indexOf(win.diskimageexplorerpathinput) == -1)
+    check("no old attribute left", not hasattr(win, "diskimageexplorerlabelpath"))
+
+    def view_dir():
+        return win.model.filePath(win.proxy_model.mapToSource(win.treeview.rootIndex()))
+
+    # ---- local box ---------------------------------------------------------
+    check("local box seeded with drive root",
+          win.local_file_explorer_path.text() == view_dir() and len(win.local_file_explorer_path.text()) >= 2,
+          win.local_file_explorer_path.text())
+    check("image box says load an image",
+          win.diskimageexplorerpathinput.text() == "Please load an image.",
+          win.diskimageexplorerpathinput.text())
+
+    win.diskimageexplorerpathinput.setText("/games")
+    win.diskimageexplorerpathinput.editingFinished.emit()
+    QCoreApplication.processEvents()
+    check("image box edit without image restores advisory",
+          win.diskimageexplorerpathinput.text() == "Please load an image.",
+          win.diskimageexplorerpathinput.text())
+
+    win.local_file_explorer_path.setText(PASTE_SUB)
+    win.local_file_explorer_path.editingFinished.emit()
+    QCoreApplication.processEvents()
+    want = PASTE_SUB.replace("\\", "/")
+    check("paste folder navigates explorer", view_dir() == want, view_dir())
+    check("paste folder updates box", win.local_file_explorer_path.text() == want,
+          win.local_file_explorer_path.text())
+    check("drive selector matches", win.zx_next_unite_diskdrive.currentText()[:1].upper() == want[0].upper(),
+          win.zx_next_unite_diskdrive.currentText())
+
+    win.local_file_explorer_path.setText(PASTE_FILE)
+    win.local_file_explorer_path.editingFinished.emit()
+    QCoreApplication.processEvents()
+    check("paste file lands on parent folder", view_dir() == want, view_dir())
+
+    win.local_file_explorer_path.setText(r"Q:\definitely_not_there_xyz")
+    win.local_file_explorer_path.editingFinished.emit()
+    QCoreApplication.processEvents()
+    check("invalid path restores box", win.local_file_explorer_path.text() == want,
+          win.local_file_explorer_path.text())
+    check("invalid path leaves explorer put", view_dir() == want, view_dir())
+
+    # ---- image box e2e ----------------------------------------------------
+    win.imageinput.setCurrentText(HDF)
+    win.imageinput.lineEdit().returnPressed.emit()
+    ok = wait_until(lambda: win.diskimageexplorerpathinput.text() == "/",
+                    what="image load -> path box '/'")
+    check("image loaded, box shows /", ok, win.diskimageexplorerpathinput.text())
+
+    if ok:
+        win.diskimageexplorerpathinput.setText("/games/sub")
+        win.diskimageexplorerpathinput.editingFinished.emit()
+        ok2 = wait_until(lambda: win.image_selected_path == "/games/sub",
+                         what="navigate to /games/sub")
+        check("navigate to nested image folder", ok2, win.image_selected_path)
+        check("box shows nested folder", win.diskimageexplorerpathinput.text() == "/games/sub",
+              win.diskimageexplorerpathinput.text())
+        check("tree selection valid", win.image_treeview.currentIndex().isValid())
+
+        win.diskimageexplorerpathinput.setText("/games/sub/hello.txt")
+        win.diskimageexplorerpathinput.editingFinished.emit()
+        ok3 = wait_until(lambda: win.image_selected_path == "/games/sub/hello.txt",
+                         what="navigate to file in image")
+        check("navigate to file selects it", ok3, win.image_selected_path)
+        check("box shows file's folder", win.diskimageexplorerpathinput.text() == "/games/sub",
+              win.diskimageexplorerpathinput.text())
+
+        win.diskimageexplorerpathinput.setText("/")
+        win.diskimageexplorerpathinput.editingFinished.emit()
+        ok4 = wait_until(lambda: win.image_selected_path == "" and win.diskimageexplorerpathinput.text() == "/",
+                         what="navigate back to image root")
+        check("root path clears selection", ok4,
+              f"sel={win.image_selected_path!r} box={win.diskimageexplorerpathinput.text()!r}")
+
+        win.diskimageexplorerpathinput.setText("/nope")
+        win.diskimageexplorerpathinput.editingFinished.emit()
+        ok5 = wait_until(lambda: recent_log(win, "Image path not found: /nope"),
+                         timeout=15.0, what="unknown-path advisory in log")
+        check("unknown image path logs advisory", ok5)
+        check("unknown image path restores box", win.diskimageexplorerpathinput.text() == "/",
+              win.diskimageexplorerpathinput.text())
+
+        # ---- persistence -------------------------------------------------
+        win.diskimageexplorerpathinput.setText("/games/sub")
+        win.diskimageexplorerpathinput.editingFinished.emit()
+        ok6 = wait_until(lambda: win.image_selected_path == "/games/sub",
+                         what="re-navigate for persistence")
+        check("re-navigate for persistence", ok6, win.image_selected_path)
+        check("image path persisted to cfg", "image_explorerpath=/games/sub" in cfg_lines(),
+              str([l for l in cfg_lines() if l.startswith("image_explorerpath")]))
+
+        # ---- Up / Refresh buttons (enabled now that an image is loaded) ----
+        check("buttons enabled with image loaded",
+              win.local_explorer_up_button.isEnabled()
+              and win.local_explorer_refresh_button.isEnabled()
+              and win.image_explorer_up_button.isEnabled()
+              and win.image_explorer_refresh_button.isEnabled())
+
+        win.local_explorer_up_button.click()
+        QCoreApplication.processEvents()
+        parent1 = os.path.dirname(PASTE_SUB).replace("\\", "/")
+        check("local Up navigates to parent", view_dir() == parent1, view_dir())
+        check("local Up updates box", win.local_file_explorer_path.text() == parent1,
+              win.local_file_explorer_path.text())
+        check("local Up persists to cfg",
+              any(l.startswith("explorerpath=") and l.rstrip("/").endswith("pastedir") for l in cfg_lines()),
+              str([l for l in cfg_lines() if l.startswith("explorerpath")]))
+        win.local_explorer_refresh_button.click()
+        QCoreApplication.processEvents()
+        check("local Refresh keeps folder", view_dir() == parent1, view_dir())
+
+        win.image_explorer_refresh_button.click()
+        ok7 = wait_until(lambda: win.image_selected_path == "/games/sub"
+                         and win.diskimageexplorerpathinput.text() == "/games/sub",
+                         timeout=15, what="image Refresh keeps target")
+        check("image Refresh keeps target", ok7,
+              f"sel={win.image_selected_path!r} box={win.diskimageexplorerpathinput.text()!r}")
+
+        win.image_explorer_up_button.click()
+        ok8 = wait_until(lambda: win.image_selected_path == "/games",
+                         timeout=15, what="image Up selects parent")
+        check("image Up selects parent", ok8, win.image_selected_path)
+        check("image Up updates box", win.diskimageexplorerpathinput.text() == "/games",
+              win.diskimageexplorerpathinput.text())
+
+        win.image_explorer_up_button.click()
+        ok9 = wait_until(lambda: win.image_selected_path == ""
+                         and win.diskimageexplorerpathinput.text() == "/",
+                         timeout=15, what="image Up back to root")
+        check("image Up to root clears selection", ok9,
+              f"sel={win.image_selected_path!r} box={win.diskimageexplorerpathinput.text()!r}")
+
+        win.image_explorer_up_button.click()
+        QCoreApplication.processEvents()
+        check("image Up at root is a no-op",
+              win.image_selected_path == "" and win.diskimageexplorerpathinput.text() == "/",
+              win.diskimageexplorerpathinput.text())
+
+    # ---- retro log console color picker (Settings tab) ---------------------
+    lay = win.settings_btn_color_retro_log.parentWidget().layout()
+    def spos(w):
+        i = lay.indexOf(w)
+        return None if i < 0 else lay.getItemPosition(i)[:2]
+    check("general-text swatch at settings (21,1)",
+          spos(win.settings_btn_color_general_text) == (21, 1), str(spos(win.settings_btn_color_general_text)))
+    check("retro-log swatch right under it (22,1)",
+          spos(win.settings_btn_color_retro_log) == (22, 1), str(spos(win.settings_btn_color_retro_log)))
+    check("retro font combo pushed to (23,1)",
+          spos(win.settings_retro_log_font_combo) == (23, 1), str(spos(win.settings_retro_log_font_combo)))
+    check("default retro color is phosphor green",
+          win.img_color_retro_log.name().lower() == "#78ff8c", win.img_color_retro_log.name())
+    check("default swatch shows phosphor green",
+          "#78ff8c" in win.settings_btn_color_retro_log.styleSheet().lower(),
+          win.settings_btn_color_retro_log.styleSheet())
+    check("retro color persisted to cfg", "color_retro_log=#78ff8c" in cfg_lines(),
+          str([l for l in cfg_lines() if l.startswith("color_retro_log")]))
+
+    app.quit()
+
+def inspect_phase2():
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+    ok = wait_until(lambda: win.image_selected_path == "/games/sub", timeout=90,
+                    what="startup restore of /games/sub")
+    check("startup restores saved image path", ok, win.image_selected_path)
+    check("box shows restored path", win.diskimageexplorerpathinput.text() == "/games/sub",
+          win.diskimageexplorerpathinput.text())
+    check("tree selection valid", win.image_treeview.currentIndex().isValid())
+    check("retro color restored from cfg",
+          win.img_color_retro_log.name().lower() == "#112233", win.img_color_retro_log.name())
+    check("retro swatch shows restored color",
+          "#112233" in win.settings_btn_color_retro_log.styleSheet().lower(),
+          win.settings_btn_color_retro_log.styleSheet())
+    app.quit()
+
+def inspect_phase3():
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+    ok = wait_until(lambda: recent_log(win, "Image path not found: /gone"), timeout=90,
+                    what="missing-path advisory at startup")
+    check("missing saved path logs advisory", ok)
+    check("box falls back to image root", win.diskimageexplorerpathinput.text() == "/",
+          win.diskimageexplorerpathinput.text())
+    check("selection stays clear", win.image_selected_path == "", win.image_selected_path)
+    ok2 = wait_until(lambda: "image_explorerpath=/" in cfg_lines(), timeout=15,
+                     what="root re-persisted to cfg")
+    check("stale path re-persisted as /", ok2,
+          str([l for l in cfg_lines() if l.startswith("image_explorerpath")]))
+    app.quit()
+
+def inspect_phase4():
+    from PySide6.QtWidgets import QAbstractItemView
+    from PySide6.QtCore import QMimeData, QUrl, QPointF, Qt
+    from PySide6.QtGui import QDropEvent
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+    tv = win.nextsync_treeview
+    check("nextsync tree accepts drops", tv.acceptDrops())
+    check("nextsync tree drag enabled", tv.dragEnabled())
+    check("nextsync tree mode is DragDrop",
+          tv.dragDropMode() == QAbstractItemView.DragDrop, str(tv.dragDropMode()))
+    check("nextsync tree default action Copy",
+          tv.defaultDropAction() == Qt.CopyAction, str(tv.defaultDropAction()))
+
+    # Navigate the classic explorer to the drop zone via the sync-root box,
+    # then synthesize an OS-style drop (source None = external drag). The
+    # import dialog is modal but closes itself when the worker finishes.
+    win.nextsync_file_explorer_path.setText(DROPZONE)
+    win.nextsync_file_explorer_path.editingFinished.emit()
+    QCoreApplication.processEvents()
+    md = QMimeData()
+    md.setUrls([QUrl.fromLocalFile(DROPSRC)])
+    ev = QDropEvent(QPointF(5.0, 5.0), Qt.CopyAction, md,
+                    Qt.LeftButton, Qt.NoModifier)
+    tv.dropEvent(ev)
+    def _landed():
+        return (os.path.isfile(os.path.join(DROPZONE, "dropsrc.txt"))
+                or os.path.isfile(os.path.join(DROPZONE, "subdir", "dropsrc.txt")))
+    ok = wait_until(_landed, timeout=30, what="dropped file lands in drop zone")
+    check("OS drop imports the file", ok)
+    check("source file untouched (copy, not move)", os.path.isfile(DROPSRC))
+    app.quit()
+
+def _expand_and_watch(tv, proxy, model, path):
+    """Expand *path* in the tree and wait until its children are listed
+    (which is what makes QFileSystemModel watch it). Offscreen the view never
+    reaches the layout phase that calls fetchMore, so kick the source model
+    directly — the gatherer's listing is also what attaches the watcher."""
+    if not wait_until(lambda: model.index(path).isValid(), 20,
+                      f"index for {path}"):
+        return False
+    tv.expand(proxy.mapFromSource(model.index(path)))
+
+    def _fetched():
+        ix = model.index(path)
+        if model.canFetchMore(ix):
+            model.fetchMore(ix)
+        return model.rowCount(ix) >= 1
+    return wait_until(_fetched, 20, f"children of {path}")
+
+def _press_delete(tv):
+    from PySide6.QtCore import QEvent, Qt
+    from PySide6.QtGui import QKeyEvent
+    ev = QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Delete,
+                   Qt.KeyboardModifier.NoModifier)
+    tv.keyPressEvent(ev)
+
+def inspect_phase5():
+    from PySide6.QtCore import qInstallMessageHandler
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+    win.settings_no_prompt_on_deletion_checkbox.setChecked(True)
+
+    # Capture Qt warnings: the bug's signature is the watcher thread spamming
+    # 'FindNextChangeNotification failed ... (Access is denied.)' when watched
+    # directories get deleted under it. Post-fix there must be none.
+    watcher_errs = []
+    def _mh(_mode, _ctx, msg):
+        if "FindNextChangeNotification" in msg:
+            watcher_errs.append(msg)
+    qInstallMessageHandler(_mh)
+
+    # --- classic NextSync explorer: delete victim (sub + subsub watched) ---
+    victim = os.path.join(DELZONE, "victim")
+    win.nextsync_file_explorer_path.setText(DELZONE)
+    win.nextsync_file_explorer_path.editingFinished.emit()
+    QCoreApplication.processEvents()
+    tv, proxy, model = (win.nextsync_treeview, win.nextsync_model,
+                        win.nextsync_filesystem_model)
+    ok = (_expand_and_watch(tv, proxy, model, victim)
+          and _expand_and_watch(tv, proxy, model, os.path.join(victim, "sub"))
+          and _expand_and_watch(tv, proxy, model,
+                                os.path.join(victim, "sub", "subsub")))
+    check("classic: victim subtree listed/watched", ok)
+    end = time.monotonic() + 1.0
+    while time.monotonic() < end:      # let the watcher attach its handles
+        QCoreApplication.processEvents()
+    tv.setCurrentIndex(proxy.mapFromSource(model.index(victim)))
+    _press_delete(tv)
+    ok = wait_until(lambda: not os.path.exists(victim), 30,
+                    "classic delete removes watched tree")
+    check("classic: watched folder tree fully deleted", ok,
+          "left behind: " + str(os.path.exists(victim)))
+
+    # --- SD Card local explorer: delete victim2 (sub2 + subsub watched) ----
+    victim2 = os.path.join(DELZONE, "victim2")
+    win.local_file_explorer_path.setText(DELZONE)
+    win.local_file_explorer_path.editingFinished.emit()
+    QCoreApplication.processEvents()
+    tv, proxy, model = win.treeview, win.proxy_model, win.model
+    ok = (_expand_and_watch(tv, proxy, model, victim2)
+          and _expand_and_watch(tv, proxy, model, os.path.join(victim2, "sub2"))
+          and _expand_and_watch(tv, proxy, model,
+                                os.path.join(victim2, "sub2", "subsub")))
+    check("sd-tab: victim2 subtree listed/watched", ok)
+    end = time.monotonic() + 1.0
+    while time.monotonic() < end:
+        QCoreApplication.processEvents()
+    tv.setCurrentIndex(proxy.mapFromSource(model.index(victim2)))
+    _press_delete(tv)
+    ok = wait_until(lambda: not os.path.exists(victim2), 30,
+                    "sd-tab delete removes watched tree")
+    check("sd-tab: watched folder tree fully deleted", ok,
+          "left behind: " + str(os.path.exists(victim2)))
+
+    check("delzone parent intact", os.path.isdir(DELZONE))
+    end = time.monotonic() + 1.0
+    while time.monotonic() < end:      # give the watcher thread time to spam
+        QCoreApplication.processEvents()
+    check("no watcher access-denied spam", not watcher_errs,
+          f"{len(watcher_errs)} warning(s), first: {watcher_errs[:1]}")
+    qInstallMessageHandler(None)
+    app.quit()
+
+def _arm_msgbox_autoclose(seen):
+    """Poll for visible QMessageBoxes, record their window titles and close
+    them. Modal boxes run their own event loop, so without this the inspector
+    would deadlock the moment one opens — QTimer callbacks keep firing inside
+    modal loops, which is what lets the sweep reach the box."""
+    from PySide6.QtWidgets import QMessageBox
+    t = QTimer()
+    def _sweep():
+        for w in QApplication.topLevelWidgets():
+            if isinstance(w, QMessageBox) and w.isVisible():
+                seen.append(w.windowTitle())
+                w.close()
+    t.timeout.connect(_sweep)
+    t.start(100)
+    return t
+
+def inspect_phase6():
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+    seen = []
+    timer = _arm_msgbox_autoclose(seen)
+
+    cb = win.settings_zxnu_update_check_checkbox
+    lay = cb.parentWidget().layout()
+    def spos(w):
+        i = lay.indexOf(w)
+        return None if i < 0 else lay.getItemPosition(i)[:2]
+    check("update-check toggle at settings row 0", spos(cb) == (0, 0), str(spos(cb)))
+    check("desktop theme pushed to row 1",
+          spos(win.settings_desktop_theme_combo) == (1, 1),
+          str(spos(win.settings_desktop_theme_combo)))
+    check("cfg 'false' restored as unchecked", not cb.isChecked())
+    cb.setChecked(True)
+    QCoreApplication.processEvents()
+    check("toggle persists to cfg", "zxnu_update_check=true" in cfg_lines(),
+          str([l for l in cfg_lines() if l.startswith("zxnu_update_check")]))
+
+    # The advisory fires ~1.2s after startup; the sweep timer closes it and
+    # records its title. The bundled dotN version is read from the app's own
+    # zxnu_config module (imported by runpy — safe to touch AFTER launch).
+    dotv = sys.modules["zxnu_config"].ZX_NEXT_UNITE_DOTN_VERSION
+    ok = wait_until(lambda: any(".sync5" in t for t in seen), timeout=15,
+                    what=".sync5 advisory popup")
+    check("dotN advisory popup shown", ok, str(seen))
+    ok2 = wait_until(lambda: f"dotn_last_version={dotv}" in cfg_lines(),
+                     timeout=10, what="dotn_last_version bumped in cfg")
+    check("dotn_last_version bumped in cfg", ok2,
+          str([l for l in cfg_lines() if l.startswith("dotn_last_version")]))
+    check("advisory logged", recent_log(win, ".sync5 dot command updated", n=20))
+    timer.stop()
+    app.quit()
+
+def inspect_phase7():
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+    seen = []
+    timer = _arm_msgbox_autoclose(seen)
+    check("update-check toggle defaults ON (no cfg key)",
+          win.settings_zxnu_update_check_checkbox.isChecked())
+    dotv = sys.modules["zxnu_config"].ZX_NEXT_UNITE_DOTN_VERSION
+    ok = wait_until(lambda: f"dotn_last_version={dotv}" in cfg_lines(),
+                    timeout=15, what="first-run silent dotN persist")
+    check("first run persists dotN version silently", ok,
+          str([l for l in cfg_lines() if l.startswith("dotn_last_version")]))
+    check("no advisory popup on first run",
+          not any(".sync5" in t for t in seen), str(seen))
+    timer.stop()
+    app.quit()   # well before the 3.4s-delayed release check could fire
+
+INSPECTORS = {1: inspect_phase1, 2: inspect_phase2, 3: inspect_phase3,
+              4: inspect_phase4, 5: inspect_phase5, 6: inspect_phase6,
+              7: inspect_phase7}
+
+_orig_exec = QApplication.exec
+def _patched_exec(*_a):
+    QTimer.singleShot(0, INSPECTORS[PHASE])
+    return _orig_exec()
+QApplication.exec = _patched_exec
+
+try:
+    runpy.run_path(os.path.join(SCRATCH, "zx-next-unite.py"), run_name="__main__")
+except SystemExit:
+    pass
+
+print()
+if FAILURES:
+    print(f"PHASE {PHASE} RESULT: {len(FAILURES)} FAILURE(S): " + "; ".join(FAILURES))
+    sys.exit(1)
+print(f"PHASE {PHASE} RESULT: ALL CHECKS PASSED")

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -3792,6 +3792,16 @@ class MainWindow(QMainWindow):
                     self.settings_mame_update_check_checkbox.setChecked(_mame_upd_on)
                     self.settings_mame_update_check_checkbox.blockSignals(False)
 
+                # ZX Next Unite "check for updates at startup on Github" toggle
+                # (default on). Always present as a widget.
+                if hasattr(self, "settings_zxnu_update_check_checkbox"):
+                    _zxnu_upd = configuration_dictionary.get(
+                        SETTING_ZXNU_UPDATE_CHECK, "").strip().lower()
+                    _zxnu_upd_on = _zxnu_upd not in ("false", "0", "no")  # default on
+                    self.settings_zxnu_update_check_checkbox.blockSignals(True)
+                    self.settings_zxnu_update_check_checkbox.setChecked(_zxnu_upd_on)
+                    self.settings_zxnu_update_check_checkbox.blockSignals(False)
+
                 # CSpect "check for a newer version on itch.io at startup" toggle
                 # (default on). Always present as a widget (unlike MAME's, which
                 # is gated on detection).
@@ -5193,6 +5203,292 @@ class MainWindow(QMainWindow):
         # Expose so the startup sequence can kick the check once the config
         # (enable flag + installed tag) has been loaded.
         self._check_mame_update_async = _check_mame_update_async
+
+        # ── ZX Next Unite self-update check (GitHub releases) ───────────────
+        # Mirrors the MAME startup check above, but for this app's own
+        # releases: Windows-binary users are offered a download + restart,
+        # source checkouts are advised to 'git pull' instead. Every branch
+        # logs to the SD Card log window so the check never looks stuck.
+
+        def _parse_zxnu_version(text):
+            """'v9.0.8' / '9.0.8' -> (9, 0, 8); None when unparseable."""
+            try:
+                parts = str(text).strip().lstrip("vV").split(".")
+                out = tuple(int(p) for p in parts if p != "")
+                return out or None
+            except (ValueError, AttributeError):
+                return None
+
+        def _fetch_latest_zxnu_release():
+            """Decoded JSON of this app's 'latest release' GitHub API reply
+            (GitHub requires a User-Agent header). Raises on network errors;
+            404 simply means no release has been published yet."""
+            req = urllib.request.Request(
+                ZXNU_GITHUB_LATEST_RELEASE_API,
+                headers={"User-Agent": ZXART_USER_AGENT,
+                         "Accept": "application/vnd.github+json"})
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                return json.loads(resp.read().decode("utf-8", "replace"))
+
+        def _zxnu_pick_release_exe(release):
+            """(name, url, size) of the Windows app binary attached to
+            *release* (the .exe asset, e.g. zx-next-unite-v9.0.8.exe), or
+            None when the release carries no exe."""
+            for asset in release.get("assets", []) or []:
+                name = str(asset.get("name", ""))
+                if name.lower().endswith(".exe"):
+                    return (name, asset.get("browser_download_url"),
+                            int(asset.get("size") or 0))
+            return None
+
+        def _zxnu_offer_restart(new_path):
+            """Post-download: offer to close the app and start the new binary,
+            naming it clearly so the user knows exactly what to run."""
+            name = os.path.basename(new_path)
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Question)
+            box.setWindowTitle("Update downloaded")
+            box.setText(
+                "The new version was saved as:\n\n"
+                f"{new_path}\n\n"
+                f"Close ZX Next Unite now and start the new version ({name})?\n"
+                "Your settings (hdfg.cfg) and downloads are picked up as-is —\n"
+                "both versions run from the same folder.")
+            yes = box.addButton(f"Close and start {name}", QMessageBox.AcceptRole)
+            box.addButton("Later", QMessageBox.RejectRole)
+            box.setDefaultButton(yes)
+            box.exec()
+            if box.clickedButton() is not yes:
+                add_main_log_window(
+                    f"ZX Next Unite update: downloaded — start it any time: {new_path}")
+                return
+            add_main_log_window(f"ZX Next Unite update: starting {name} and closing…")
+            try:
+                subprocess.Popen([new_path], cwd=os.path.dirname(new_path) or None)
+            except OSError as exc:
+                add_main_log_window(f"ZX Next Unite update: could not start {name}: {exc}")
+                QMessageBox.critical(self, "Could not start the new version",
+                                     f"{new_path}\n\n{exc}")
+                return
+            self.close()
+
+        def _zxnu_download_update(tag, asset_name, url, size):
+            """Download the release exe next to the current binary on a worker
+            thread (progress dialog, cancellable), then offer the restart.
+            Never overwrites the RUNNING binary: a name collision gets the
+            release tag appended to the filename."""
+            app_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+            dest = os.path.join(app_dir, asset_name)
+            current = os.path.abspath(
+                sys.executable if getattr(sys, "frozen", False) else sys.argv[0])
+            if os.path.normcase(dest) == os.path.normcase(current):
+                stem, ext = os.path.splitext(asset_name)
+                dest = os.path.join(app_dir, f"{stem}-{tag}{ext}")
+            holder = {"ok": False, "error": ""}
+
+            def _task(signals, cancel_event, _url=url, _dest=dest, _size=size,
+                      _h=holder):
+                tmp = _dest + ".part"
+                try:
+                    req = urllib.request.Request(
+                        _url, headers={"User-Agent": ZXART_USER_AGENT})
+                    with urllib.request.urlopen(req, timeout=30) as resp, \
+                            open(tmp, "wb") as out:
+                        total = _size or int(resp.headers.get("Content-Length") or 0)
+                        got = 0
+                        while True:
+                            if cancel_event.is_set():
+                                _h["error"] = "cancelled"
+                                break
+                            chunk = resp.read(65536)
+                            if not chunk:
+                                break
+                            out.write(chunk)
+                            got += len(chunk)
+                            if total:
+                                signals.progress.emit(int(got * 100 / total))
+                            signals.status.emit(
+                                f"Downloading {os.path.basename(_dest)}…\n"
+                                f"{got // 1048576} MB"
+                                + (f" / {total // 1048576} MB" if total else ""))
+                    if not _h["error"]:
+                        os.replace(tmp, _dest)
+                        _h["ok"] = True
+                except Exception as exc:   # network/disk problems must never crash
+                    _h["error"] = str(exc)
+                if not _h["ok"]:
+                    try:
+                        os.remove(tmp)
+                    except OSError:
+                        pass
+
+            dlg = HdfProgressDialog("Downloading ZX Next Unite update…", self)
+            worker = HdfTaskWorker(_task)
+            dlg.cancel_requested.connect(worker.cancel)
+            worker.signals.progress.connect(dlg.set_progress)
+            worker.signals.status.connect(dlg.set_status)
+            worker.signals.cancelled.connect(dlg.mark_cancelled)
+
+            def _on_zxnu_download_done():
+                dlg.close()
+                if holder["ok"]:
+                    add_main_log_window(
+                        f"ZX Next Unite update: downloaded {os.path.basename(dest)} "
+                        f"to {os.path.dirname(dest)}.")
+                    _zxnu_offer_restart(dest)
+                elif holder["error"] == "cancelled":
+                    add_main_log_window("ZX Next Unite update: download cancelled.")
+                else:
+                    add_main_log_window(
+                        f"ZX Next Unite update: download FAILED: {holder['error']}")
+                    QMessageBox.critical(self, "Update download failed",
+                                         f"Could not download the update:\n{holder['error']}")
+
+            worker.signals.finished.connect(_on_zxnu_download_done)
+            self.threadpool.start(worker)
+            dlg.exec()
+
+        def _prompt_zxnu_update(tag, release):
+            """UI-thread prompt for an available app update. Windows-binary
+            (frozen) users get download + restart; a source checkout (git
+            clone) is advised to 'git pull' instead of fetching the exe."""
+            frozen = bool(getattr(sys, "frozen", False))
+            if not frozen:
+                add_main_log_window(
+                    f"ZX Next Unite {tag} is available — running from source, so "
+                    "update with 'git pull' instead of the Windows binary.")
+                box = QMessageBox(self)
+                box.setIcon(QMessageBox.Information)
+                box.setWindowTitle("ZX Next Unite update available")
+                box.setText(
+                    f"ZX Next Unite {tag} is available "
+                    f"(you are running {ZX_NEXT_UNITE_VERSION}).\n\n"
+                    "You appear to be running from source (git clone), so the\n"
+                    "recommended way to update is:\n\n"
+                    "    git pull\n\n"
+                    "instead of downloading the Windows binary.")
+                openrel = box.addButton("Open the releases page", QMessageBox.AcceptRole)
+                box.addButton("Close", QMessageBox.RejectRole)
+                box.setDefaultButton(openrel)
+                box.exec()
+                if box.clickedButton() is openrel:
+                    webbrowser.open(ZXNU_GITHUB_RELEASES_PAGE)
+                return
+            asset = _zxnu_pick_release_exe(release)
+            if not asset:
+                add_main_log_window(
+                    f"ZX Next Unite {tag} is available, but the release has no "
+                    ".exe asset — opening the releases page instead.")
+                if QMessageBox.question(
+                        self, "ZX Next Unite update available",
+                        f"{tag} is available but carries no Windows binary.\n"
+                        "Open the releases page in your browser?",
+                        QMessageBox.Yes | QMessageBox.No,
+                        QMessageBox.Yes) == QMessageBox.Yes:
+                    webbrowser.open(ZXNU_GITHUB_RELEASES_PAGE)
+                return
+            asset_name, url, size = asset
+            size_txt = f"{size / 1048576:.0f} MB" if size else "?"
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Question)
+            box.setWindowTitle("ZX Next Unite update available")
+            box.setText(
+                f"ZX Next Unite {tag} is available — download?\n\n"
+                f"Installed: {ZX_NEXT_UNITE_VERSION}\n"
+                f"Latest: {tag}\n"
+                f"Package: {asset_name} (~{size_txt})\n\n"
+                "The new version is saved next to the current one — you choose\n"
+                "when to switch (you'll be offered a restart after the download).")
+            dl = box.addButton("Download", QMessageBox.AcceptRole)
+            box.addButton("Cancel", QMessageBox.RejectRole)
+            box.setDefaultButton(dl)
+            box.exec()
+            if box.clickedButton() is dl:
+                add_main_log_window(f"ZX Next Unite update ▸ downloading {asset_name}…")
+                _zxnu_download_update(tag, asset_name, url, size)
+            else:
+                add_main_log_window("ZX Next Unite update ▸ skipped by user.")
+
+        def _check_zxnu_update_async():
+            """At startup, when the Settings toggle is on, look up this app's
+            latest GitHub release (off the UI thread) and offer to update when
+            it is newer. Mirrors the MAME check: every branch logs to the SD
+            Card log window and failures never disrupt startup."""
+            pref = configuration_dictionary.get(
+                SETTING_ZXNU_UPDATE_CHECK, "").strip().lower()
+            if pref in ("false", "0", "no"):
+                return  # user disabled the check
+
+            def _job():
+                return _fetch_latest_zxnu_release()
+
+            def _on_result(release):
+                try:
+                    tag = str(release.get("tag_name", "")).strip()
+                    remote = _parse_zxnu_version(tag)
+                    local = _parse_zxnu_version(ZX_NEXT_UNITE_VERSION)
+                    if not remote or not local:
+                        add_main_log_window(
+                            "ZX Next Unite update check: could not parse the "
+                            f"versions (latest tag {tag!r}); skipping.")
+                        return
+                    if remote <= local:
+                        add_main_log_window(
+                            f"ZX Next Unite is up to date "
+                            f"(installed {ZX_NEXT_UNITE_VERSION}, latest {tag}).")
+                        return
+                    add_main_log_window(
+                        f"ZX Next Unite update available: {tag} "
+                        f"(installed {ZX_NEXT_UNITE_VERSION}).")
+                    _prompt_zxnu_update(tag, release)
+                except Exception as exc:
+                    logging.info(f"ZXNU update check result handling failed: {exc}")
+
+            def _on_error(err):
+                detail = err[1] if isinstance(err, (tuple, list)) and len(err) > 1 else err
+                logging.info(f"ZXNU update check skipped: {detail}")
+                add_main_log_window(
+                    "ZX Next Unite update check: could not reach GitHub "
+                    "(offline, or no release published yet); skipping.")
+
+            add_main_log_window("Checking for a newer ZX Next Unite release on GitHub…")
+            getit_run_in_thread(_job, _on_result, _on_error)
+
+        self._check_zxnu_update_async = _check_zxnu_update_async
+
+        def _check_dotn_version_advisory():
+            """After an app update, warn ONCE when the bundled NextSync .sync5
+            dotN version changed: the dot lives on the Next's SD card, so the
+            app cannot deploy it automatically. First run (no saved value in
+            the cfg) records the current version silently — existing installs
+            aren't nagged retroactively."""
+            saved = configuration_dictionary.get(
+                SETTING_DOTN_LAST_VERSION, "").strip()
+            if saved == ZX_NEXT_UNITE_DOTN_VERSION:
+                return
+            configuration_dictionary[SETTING_DOTN_LAST_VERSION] = \
+                ZX_NEXT_UNITE_DOTN_VERSION
+            save_configuration_file()
+            if not saved:
+                return  # first run with this feature: remember, don't nag
+            add_main_log_window(
+                f"NextSync .sync5 dot command updated: v{saved} -> "
+                f"v{ZX_NEXT_UNITE_DOTN_VERSION} — please copy the new build "
+                "to your Next (it cannot be deployed automatically).")
+            QMessageBox.information(
+                self, ".sync5 needs updating on your Next",
+                "This ZX Next Unite version ships an updated NextSync dot "
+                f"command: .sync5 v{saved} → v{ZX_NEXT_UNITE_DOTN_VERSION}.\n\n"
+                "The dot runs on the Spectrum Next itself, so it cannot be "
+                "updated automatically. Please copy the new build to your "
+                "Next (e.g. into C:/dot as 'sync5'):\n\n"
+                "  • the 'sync5' file attached to the GitHub release, or\n"
+                "  • nextsync/sync/server/dot/syncdev from the repository "
+                "(also push-able via the Remote Explorer while the OLD dot "
+                "is connected).\n\n"
+                "Until then the previous dot keeps working with this app.")
+
+        self._check_dotn_version_advisory = _check_dotn_version_advisory
 
         # ── CSpect update check (itch.io) ──────────────────────────────────
         # Mirrors the MAME startup update check above, but sources the build
@@ -23514,6 +23810,31 @@ class MainWindow(QMainWindow):
         zxnextunite_Settings_tab.setAutoFillBackground(False)
         grid_tab_Settings = QGridLayout(zxnextunite_Settings_tab)
 
+        # ── ZX Next Unite self-update check (very top of the Settings pane) ──
+        # Startup check of the app's own GitHub releases (mirrors the MAME /
+        # CSpect update-check toggles below). Default on; persisted so a saved
+        # "off" survives restarts. The check itself runs in
+        # _check_zxnu_update_async (kicked from the startup sequence).
+        def settings_zxnu_update_check_changed():
+            on = self.settings_zxnu_update_check_checkbox.isChecked()
+            configuration_dictionary[SETTING_ZXNU_UPDATE_CHECK] = (
+                "true" if on else "false")
+            save_configuration_file()
+
+        self.settings_zxnu_update_check_checkbox = QCheckBox(
+            "Check for ZX Next Unite updates at startup on Github")
+        self.settings_zxnu_update_check_checkbox.setChecked(True)  # default on
+        self.settings_zxnu_update_check_checkbox.setToolTip(
+            "At startup, check the ZX Next Unite GitHub releases page for a\n"
+            "newer version and offer to download it (Windows binary users) or\n"
+            "advise a 'git pull' (running from source). The check and its\n"
+            "outcome are logged in the SD Card Utility tab's log window, like\n"
+            "the MAME and CSpect checks. On by default. Saved to the\n"
+            "configuration file.")
+        self.settings_zxnu_update_check_checkbox.stateChanged.connect(
+            lambda _s: settings_zxnu_update_check_changed())
+        grid_tab_Settings.addWidget(self.settings_zxnu_update_check_checkbox, 0, 0, 1, 2)
+
         # ── Desktop theme (top of the Settings pane) ───────────────────────
         # Drives the SD Card explorer font colours. Automatic follows the OS
         # (high-contrast -> all black, dark -> orange/yellow, else -> light
@@ -23636,7 +23957,7 @@ class MainWindow(QMainWindow):
             "  • Custom: keep your hand-picked colours. Changing any colour\n"
             "    below switches to Custom automatically."
         )
-        grid_tab_Settings.addWidget(desktop_theme_lbl, 0, 0)
+        grid_tab_Settings.addWidget(desktop_theme_lbl, 1, 0)
 
         self.settings_desktop_theme_combo = QComboBox()
         self.settings_desktop_theme_combo.addItem("Automatic (default)",   DESKTOP_THEME_AUTOMATIC)
@@ -23649,7 +23970,7 @@ class MainWindow(QMainWindow):
         self.settings_desktop_theme_combo.currentIndexChanged.connect(
             lambda _i: _settings_desktop_theme_changed()
         )
-        grid_tab_Settings.addWidget(self.settings_desktop_theme_combo, 0, 1)
+        grid_tab_Settings.addWidget(self.settings_desktop_theme_combo, 1, 1)
 
         def settings_warn_image_nearly_full_statechanged():
             configuration_dictionary[SETTING_WARN_IMAGE_NEARLY_FULL] = "true" if self.settings_warn_image_nearly_full_checkbox.isChecked() else "false"
@@ -23663,7 +23984,7 @@ class MainWindow(QMainWindow):
             "Uncheck this option to suppress that warning."
         )
         self.settings_warn_image_nearly_full_checkbox.stateChanged.connect(settings_warn_image_nearly_full_statechanged)
-        grid_tab_Settings.addWidget(self.settings_warn_image_nearly_full_checkbox, 1, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_warn_image_nearly_full_checkbox, 2, 0, 1, 2)
 
         def settings_no_prompt_on_deletion_statechanged():
             configuration_dictionary[SETTING_NO_PROMPT_ON_DELETION] = "true" if self.settings_no_prompt_on_deletion_checkbox.isChecked() else "false"
@@ -23677,7 +23998,7 @@ class MainWindow(QMainWindow):
             "Leave unchecked to keep the confirmation prompt (recommended)."
         )
         self.settings_no_prompt_on_deletion_checkbox.stateChanged.connect(settings_no_prompt_on_deletion_statechanged)
-        grid_tab_Settings.addWidget(self.settings_no_prompt_on_deletion_checkbox, 2, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_no_prompt_on_deletion_checkbox, 3, 0, 1, 2)
 
         def settings_avail_check_statechanged():
             configuration_dictionary[SETTING_AVAIL_CHECK] = "true" if self.settings_avail_check_checkbox.isChecked() else "false"
@@ -23694,7 +24015,7 @@ class MainWindow(QMainWindow):
         self.settings_avail_check_checkbox.stateChanged.connect(settings_avail_check_statechanged)
         _avail_check_visible = ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS or ZX_NEXT_UNITE_ZXART_ENABLE_DOWNLOAD_BUTTONS
         self.settings_avail_check_checkbox.setVisible(_avail_check_visible)
-        grid_tab_Settings.addWidget(self.settings_avail_check_checkbox, 4, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_avail_check_checkbox, 5, 0, 1, 2)
 
         def settings_multi_search_statechanged():
             configuration_dictionary[SETTING_MULTI_SEARCH] = "true" if self.settings_multi_search_checkbox.isChecked() else "false"
@@ -23708,7 +24029,7 @@ class MainWindow(QMainWindow):
             "with the number of results found, e.g. ZXDB (5)."
         )
         self.settings_multi_search_checkbox.stateChanged.connect(settings_multi_search_statechanged)
-        grid_tab_Settings.addWidget(self.settings_multi_search_checkbox, 5, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_multi_search_checkbox, 6, 0, 1, 2)
 
         def settings_search_autocomplete_statechanged():
             enabled = self.settings_search_autocomplete_checkbox.isChecked()
@@ -23724,7 +24045,7 @@ class MainWindow(QMainWindow):
             "Uncheck to disable autocomplete suggestions on all search inputs."
         )
         self.settings_search_autocomplete_checkbox.stateChanged.connect(settings_search_autocomplete_statechanged)
-        grid_tab_Settings.addWidget(self.settings_search_autocomplete_checkbox, 6, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_search_autocomplete_checkbox, 7, 0, 1, 2)
 
         # ---- Gallery (picture view) settings ----
         def _settings_gallery_anim_changed():
@@ -23741,7 +24062,7 @@ class MainWindow(QMainWindow):
             "  • Timed: cycles continuously while the gallery is visible.\n"
             "  • None: never cycles between images (animated GIFs still play)."
         )
-        grid_tab_Settings.addWidget(gallery_anim_lbl, 7, 0)
+        grid_tab_Settings.addWidget(gallery_anim_lbl, 8, 0)
 
         self.settings_gallery_anim_combo = QComboBox()
         self.settings_gallery_anim_combo.addItem("On hover (default)", "hover")
@@ -23751,7 +24072,7 @@ class MainWindow(QMainWindow):
         self.settings_gallery_anim_combo.currentIndexChanged.connect(
             lambda _i: _settings_gallery_anim_changed()
         )
-        grid_tab_Settings.addWidget(self.settings_gallery_anim_combo, 7, 1)
+        grid_tab_Settings.addWidget(self.settings_gallery_anim_combo, 8, 1)
 
         def _settings_gallery_rows_changed(val: int):
             val = max(GALLERY_MIN_ROWS, min(GALLERY_MAX_ROWS, int(val)))
@@ -23764,14 +24085,14 @@ class MainWindow(QMainWindow):
             "Number of thumbnail rows shown per gallery page.\n"
             f"Range {GALLERY_MIN_ROWS}–{GALLERY_MAX_ROWS}. Default {DEFAULT_GALLERY_ROWS_PER_PAGE}."
         )
-        grid_tab_Settings.addWidget(gallery_rows_lbl, 8, 0)
+        grid_tab_Settings.addWidget(gallery_rows_lbl, 9, 0)
 
         self.settings_gallery_rows_spin = QSpinBox()
         self.settings_gallery_rows_spin.setRange(GALLERY_MIN_ROWS, GALLERY_MAX_ROWS)
         self.settings_gallery_rows_spin.setValue(DEFAULT_GALLERY_ROWS_PER_PAGE)
         self.settings_gallery_rows_spin.setToolTip(gallery_rows_lbl.toolTip())
         self.settings_gallery_rows_spin.valueChanged.connect(_settings_gallery_rows_changed)
-        grid_tab_Settings.addWidget(self.settings_gallery_rows_spin, 8, 1)
+        grid_tab_Settings.addWidget(self.settings_gallery_rows_spin, 9, 1)
 
         def _make_color_button(setting_key, color_attr, label_text, tooltip_text, grid_row,
                                switch_theme=True, on_change=None):
@@ -23845,7 +24166,7 @@ class MainWindow(QMainWindow):
             "Number of thumbnail columns shown in the gallery grid.\n"
             "Default is 4. Choose 2 for larger tiles or 8 for more items per row."
         )
-        grid_tab_Settings.addWidget(gallery_cols_lbl, 9, 0)
+        grid_tab_Settings.addWidget(gallery_cols_lbl, 10, 0)
 
         self.settings_gallery_cols_combo = QComboBox()
         self.settings_gallery_cols_combo.addItem("2", 2)
@@ -23856,7 +24177,7 @@ class MainWindow(QMainWindow):
         self.settings_gallery_cols_combo.currentIndexChanged.connect(
             lambda _i: _settings_gallery_cols_changed()
         )
-        grid_tab_Settings.addWidget(self.settings_gallery_cols_combo, 9, 1)
+        grid_tab_Settings.addWidget(self.settings_gallery_cols_combo, 10, 1)
 
         def _settings_gallery_img_size_changed():
             val = self.settings_gallery_img_size_combo.currentData() or DEFAULT_GALLERY_IMG_SIZE
@@ -23871,7 +24192,7 @@ class MainWindow(QMainWindow):
             "  • Medium (default): standard size\n"
             "  • Large: double the medium height"
         )
-        grid_tab_Settings.addWidget(gallery_img_size_lbl, 10, 0)
+        grid_tab_Settings.addWidget(gallery_img_size_lbl, 11, 0)
 
         self.settings_gallery_img_size_combo = QComboBox()
         self.settings_gallery_img_size_combo.addItem("Small",          "small")
@@ -23882,7 +24203,7 @@ class MainWindow(QMainWindow):
         self.settings_gallery_img_size_combo.currentIndexChanged.connect(
             lambda _i: _settings_gallery_img_size_changed()
         )
-        grid_tab_Settings.addWidget(self.settings_gallery_img_size_combo, 10, 1)
+        grid_tab_Settings.addWidget(self.settings_gallery_img_size_combo, 11, 1)
 
         def _settings_gallery_slideshow_changed():
             val = self.settings_gallery_slideshow_combo.currentData()
@@ -23906,7 +24227,7 @@ class MainWindow(QMainWindow):
             "How long each screenshot is shown before the auto-advancing gallery\n"
             "slideshow moves to the next image. Default is 5 seconds."
         )
-        grid_tab_Settings.addWidget(gallery_slideshow_lbl, 11, 0)
+        grid_tab_Settings.addWidget(gallery_slideshow_lbl, 12, 0)
 
         self.settings_gallery_slideshow_combo = QComboBox()
         for _secs in GALLERY_SLIDESHOW_SECS_CHOICES:
@@ -23917,45 +24238,45 @@ class MainWindow(QMainWindow):
         self.settings_gallery_slideshow_combo.currentIndexChanged.connect(
             lambda _i: _settings_gallery_slideshow_changed()
         )
-        grid_tab_Settings.addWidget(self.settings_gallery_slideshow_combo, 11, 1)
+        grid_tab_Settings.addWidget(self.settings_gallery_slideshow_combo, 12, 1)
 
         settings_section_lbl = QLabel("Local file explorers & App Text Colors:")
         settings_section_lbl.setToolTip(
             "Customize the foreground color of each item type shown in the SD card\n"
             "image explorer, plus the general app text color (labels, checkboxes,\n"
             "section headers) used across the app in Classic (non-pygame) mode.")
-        grid_tab_Settings.addWidget(settings_section_lbl, 13, 0, 1, 2)
+        grid_tab_Settings.addWidget(settings_section_lbl, 14, 0, 1, 2)
 
         self.settings_btn_color_up_directory = _make_color_button(
             SETTING_COLOR_UP_DIRECTORY, "img_color_up_directory",
             "  Up Directory item",
             "Color used for the '[Up Directory..]' navigation row in the image explorer.",
-            14)
+            15)
         self.settings_btn_color_dir_name = _make_color_button(
             SETTING_COLOR_DIR_NAME, "img_color_dir_name",
             "  Directory name",
             "Color used for directory name entries in the image explorer.",
-            15)
+            16)
         self.settings_btn_color_dir_type = _make_color_button(
             SETTING_COLOR_DIR_TYPE, "img_color_dir_type",
             "  Directory type label",
             "Color used for the 'DIR' type label column of directory entries.",
-            16)
+            17)
         self.settings_btn_color_file_name = _make_color_button(
             SETTING_COLOR_FILE_NAME, "img_color_file_name",
             "  File name",
             "Color used for file name entries in the image explorer.",
-            17)
+            18)
         self.settings_btn_color_file_ext = _make_color_button(
             SETTING_COLOR_FILE_EXT, "img_color_file_ext",
             "  File extension",
             "Color used for the file extension column in the image explorer.",
-            18)
+            19)
         self.settings_btn_color_file_size = _make_color_button(
             SETTING_COLOR_FILE_SIZE, "img_color_file_size",
             "  File size",
             "Color used for the file size column in the image explorer.",
-            19)
+            20)
         self.settings_btn_color_general_text = _make_color_button(
             SETTING_COLOR_GENERAL_TEXT, "img_color_general_text",
             "  General UI text",
@@ -23964,7 +24285,7 @@ class MainWindow(QMainWindow):
             "light desktop/White theme would otherwise make this text black and\n"
             "unreadable. The White/Dark/Automatic/High-contrast themes set this\n"
             "automatically; picking a color here switches to the Custom theme.",
-            20)
+            21)
 
         # ---- Retro log console text color (pygame log windows) ----
         def _apply_retro_log_color(color=None):
@@ -23989,7 +24310,7 @@ class MainWindow(QMainWindow):
             "Font color for the retro 8-bit (pygame) log consoles on the\n"
             "SD Card, NextSync and Help tabs. Applies immediately. Default is\n"
             "the classic phosphor green. Independent of the Desktop Theme.",
-            21, switch_theme=False, on_change=_apply_retro_log_color)
+            22, switch_theme=False, on_change=_apply_retro_log_color)
 
         # ---- Retro log font size (SD Card + NextSync pygame log windows) ----
         def _apply_retro_log_font_size(px):
@@ -24018,7 +24339,7 @@ class MainWindow(QMainWindow):
             "Consolas text size for the retro 8-bit (pygame) log windows on the\n"
             "SD Card and NextSync tabs. Applies immediately. Default is 13."
         )
-        grid_tab_Settings.addWidget(retro_log_font_lbl, 22, 0)
+        grid_tab_Settings.addWidget(retro_log_font_lbl, 23, 0)
 
         self.settings_retro_log_font_combo = QComboBox()
         for _px in RETRO_LOG_FONT_SIZE_CHOICES:
@@ -24032,7 +24353,7 @@ class MainWindow(QMainWindow):
         self.settings_retro_log_font_combo.currentIndexChanged.connect(
             lambda _i: _settings_retro_log_font_changed()
         )
-        grid_tab_Settings.addWidget(self.settings_retro_log_font_combo, 22, 1)
+        grid_tab_Settings.addWidget(self.settings_retro_log_font_combo, 23, 1)
 
         # ---- Background image opacity ----
         bg_opacity_lbl = QLabel("Background image opacity (%):")
@@ -24040,7 +24361,7 @@ class MainWindow(QMainWindow):
             "Controls how visible the background image is behind the UI.\n"
             "0 = fully hidden, 100 = fully visible. Default is 5%."
         )
-        grid_tab_Settings.addWidget(bg_opacity_lbl, 23, 0)
+        grid_tab_Settings.addWidget(bg_opacity_lbl, 24, 0)
 
         bg_opacity_row = QWidget()
         bg_opacity_row_layout = QHBoxLayout(bg_opacity_row)
@@ -24171,7 +24492,7 @@ class MainWindow(QMainWindow):
 
         bg_opacity_row_layout.addWidget(self.settings_bg_opacity_slider, 1)
         bg_opacity_row_layout.addWidget(self.settings_bg_opacity_spinbox, 0)
-        grid_tab_Settings.addWidget(bg_opacity_row, 23, 1)
+        grid_tab_Settings.addWidget(bg_opacity_row, 24, 1)
 
         # ---- Background image selector ----
         bg_image_lbl = QLabel("Background image:")
@@ -24179,7 +24500,7 @@ class MainWindow(QMainWindow):
             "Choose a specific background image or 'Random' to cycle through\n"
             "all images in the script folder every 5 seconds."
         )
-        grid_tab_Settings.addWidget(bg_image_lbl, 24, 0)
+        grid_tab_Settings.addWidget(bg_image_lbl, 25, 0)
 
         bg_image_row = QWidget()
         bg_image_row_layout = QHBoxLayout(bg_image_row)
@@ -24222,7 +24543,7 @@ class MainWindow(QMainWindow):
         self.settings_bg_image_preview.setToolTip("Preview of the selected background image.")
         bg_image_row_layout.addWidget(self.settings_bg_image_preview, 0)
 
-        grid_tab_Settings.addWidget(bg_image_row, 24, 1)
+        grid_tab_Settings.addWidget(bg_image_row, 25, 1)
 
         def _update_bg_image_preview(path: str):
             """Refresh the thumbnail label for the given absolute image path."""
@@ -24283,7 +24604,7 @@ class MainWindow(QMainWindow):
         )
         self.settings_crash_log_enabled_checkbox.stateChanged.connect(
             settings_crash_log_enabled_statechanged)
-        grid_tab_Settings.addWidget(self.settings_crash_log_enabled_checkbox, 25, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_crash_log_enabled_checkbox, 26, 0, 1, 2)
 
         def settings_disable_no_emulator_toast_statechanged():
             configuration_dictionary[SETTING_DISABLE_NO_EMULATOR_TOAST] = "true" if self.settings_disable_no_emulator_toast_checkbox.isChecked() else "false"
@@ -24297,7 +24618,7 @@ class MainWindow(QMainWindow):
             "Check this if you do not use any emulator and do not want the reminder."
         )
         self.settings_disable_no_emulator_toast_checkbox.stateChanged.connect(settings_disable_no_emulator_toast_statechanged)
-        grid_tab_Settings.addWidget(self.settings_disable_no_emulator_toast_checkbox, 26, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_disable_no_emulator_toast_checkbox, 27, 0, 1, 2)
 
         # ── NextSync HTTP bridge toggle + port ──────────────────────────
         def _http_port_widgets_set_enabled(on):
@@ -24421,7 +24742,7 @@ class MainWindow(QMainWindow):
         _http_bridge_row.addWidget(self.settings_http_conn_label)
         _http_bridge_row.addWidget(self.settings_http_conn_spinbox)
         _http_bridge_row.addStretch(1)
-        grid_tab_Settings.addLayout(_http_bridge_row, 37, 0, 1, 2)
+        grid_tab_Settings.addLayout(_http_bridge_row, 38, 0, 1, 2)
         self._http_port_widgets_set_enabled = _http_port_widgets_set_enabled
 
         # ── MAME options (shown when MAME is launchable: a detected binary, or
@@ -24437,7 +24758,7 @@ class MainWindow(QMainWindow):
                 "This is inserted right after the MAME executable and is no longer part\n"
                 "of the command-line parameters below."
             )
-            grid_tab_Settings.addWidget(mame_rom_lbl, 27, 0)
+            grid_tab_Settings.addWidget(mame_rom_lbl, 28, 0)
 
             self.settings_mame_rom_combo = QComboBox()
             for _rom_name in MAME_ROM_CHOICE:
@@ -24445,7 +24766,7 @@ class MainWindow(QMainWindow):
             self.settings_mame_rom_combo.setToolTip(mame_rom_lbl.toolTip())
             self.settings_mame_rom_combo.currentIndexChanged.connect(
                 lambda _i: settings_mame_rom_changed())
-            grid_tab_Settings.addWidget(self.settings_mame_rom_combo, 27, 1)
+            grid_tab_Settings.addWidget(self.settings_mame_rom_combo, 28, 1)
 
             def settings_mame_params_changed():
                 configuration_dictionary[SETTING_MAME_COMMAND_LINE_PARAMETERS] = self.settings_mame_params_edit.text()
@@ -24462,7 +24783,7 @@ class MainWindow(QMainWindow):
                 "-mouse/-mouse_device or -joystick/-joystickprovider options typed here\n"
                 "are ignored (the combos take precedence)."
             )
-            grid_tab_Settings.addWidget(mame_params_lbl, 28, 0)
+            grid_tab_Settings.addWidget(mame_params_lbl, 29, 0)
 
             self.settings_mame_params_edit = QLineEdit()
             self.settings_mame_params_edit.setText(
@@ -24470,7 +24791,7 @@ class MainWindow(QMainWindow):
                     SETTING_MAME_COMMAND_LINE_PARAMETERS, MAME_DEFAULT_COMMAND_LINE))
             self.settings_mame_params_edit.setToolTip(mame_params_lbl.toolTip())
             self.settings_mame_params_edit.editingFinished.connect(settings_mame_params_changed)
-            grid_tab_Settings.addWidget(self.settings_mame_params_edit, 28, 1)
+            grid_tab_Settings.addWidget(self.settings_mame_params_edit, 29, 1)
 
             # The startup update check only exists where the app can actually
             # fetch a build (64-bit Windows / x86_64 Linux). On macOS MAME is
@@ -24497,7 +24818,7 @@ class MainWindow(QMainWindow):
                 )
                 self.settings_mame_update_check_checkbox.stateChanged.connect(
                     lambda _s: settings_mame_update_check_changed())
-                grid_tab_Settings.addWidget(self.settings_mame_update_check_checkbox, 29, 0, 1, 2)
+                grid_tab_Settings.addWidget(self.settings_mame_update_check_checkbox, 30, 0, 1, 2)
 
         # ── Launch MAME with Flatpak (Linux) ──────────────────────────────
         # Shown on Linux regardless of whether a MAME binary was detected, so a
@@ -24565,7 +24886,7 @@ class MainWindow(QMainWindow):
             self.settings_mame_flatpak_rompath_row.setVisible(_flatpak_on)
             _flatpak_layout.addWidget(self.settings_mame_flatpak_rompath_row)
 
-            grid_tab_Settings.addWidget(_flatpak_box, 29, 0, 1, 2)
+            grid_tab_Settings.addWidget(_flatpak_box, 30, 0, 1, 2)
 
         # ── CSpect default launch parameters ───────────────────────────────
         # Shown unconditionally (unlike the MAME block above, which is gated on
@@ -24587,14 +24908,14 @@ class MainWindow(QMainWindow):
             "launch. Leave empty to restore the built-in default. Saved to the\n"
             "configuration file."
         )
-        grid_tab_Settings.addWidget(cspect_params_lbl, 30, 0)
+        grid_tab_Settings.addWidget(cspect_params_lbl, 31, 0)
 
         self.settings_cspect_params_edit = QLineEdit()
         self.settings_cspect_params_edit.setText(
             configuration_dictionary.get(SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS))
         self.settings_cspect_params_edit.setToolTip(cspect_params_lbl.toolTip())
         self.settings_cspect_params_edit.editingFinished.connect(settings_cspect_params_changed)
-        grid_tab_Settings.addWidget(self.settings_cspect_params_edit, 30, 1)
+        grid_tab_Settings.addWidget(self.settings_cspect_params_edit, 31, 1)
 
         # ── Unite! pygame background animation toggle ──────────────────────
         def _settings_pygame_anim_changed():
@@ -24623,7 +24944,7 @@ class MainWindow(QMainWindow):
         )
         self.settings_pygame_anim_checkbox.stateChanged.connect(
             lambda _s: _settings_pygame_anim_changed())
-        grid_tab_Settings.addWidget(self.settings_pygame_anim_checkbox, 32, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_pygame_anim_checkbox, 33, 0, 1, 2)
 
         # ── NextSync retro-log starfield animation toggle ──────────────────
         def _settings_nextsync_anim_changed():
@@ -24655,7 +24976,7 @@ class MainWindow(QMainWindow):
         )
         self.settings_nextsync_pygame_anim_checkbox.stateChanged.connect(
             lambda _s: _settings_nextsync_anim_changed())
-        grid_tab_Settings.addWidget(self.settings_nextsync_pygame_anim_checkbox, 35, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_nextsync_pygame_anim_checkbox, 36, 0, 1, 2)
 
         # ── Alien Floyd's: optional pygame-ce animated background everywhere ──
         # A Pink Floyd homage. When on, a pygame-ce "Alien Floyd's" animation
@@ -24710,7 +25031,7 @@ class MainWindow(QMainWindow):
             "file. Requires the optional 'pygame-ce' package.")
         self.settings_alien_floyd_bg_checkbox.stateChanged.connect(
             lambda _s: _settings_alien_bg_changed())
-        grid_tab_Settings.addWidget(self.settings_alien_floyd_bg_checkbox, 33, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_alien_floyd_bg_checkbox, 34, 0, 1, 2)
 
         # ── Alien Floyd's: optional dedicated full-window tab ────────────────
         self._alien_floyd_tab_widget = None
@@ -24782,7 +25103,7 @@ class MainWindow(QMainWindow):
             "configuration file. Requires the optional 'pygame-ce' package.")
         self.settings_alien_floyd_tab_checkbox.stateChanged.connect(
             lambda _s: _settings_alien_tab_changed())
-        grid_tab_Settings.addWidget(self.settings_alien_floyd_tab_checkbox, 34, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_alien_floyd_tab_checkbox, 35, 0, 1, 2)
 
         # ── itch.io: optional online tab (driven by the 'itch-dl' package) ───
         def _itchio_tab_set_visible(on):
@@ -24825,7 +25146,7 @@ class MainWindow(QMainWindow):
                 "configuration file. Requires the optional 'itch-dl' package.")
         self.settings_show_itchio_tab_checkbox.stateChanged.connect(
             lambda _s: _settings_itchio_tab_changed())
-        grid_tab_Settings.addWidget(self.settings_show_itchio_tab_checkbox, 36, 0, 1, 2)
+        grid_tab_Settings.addWidget(self.settings_show_itchio_tab_checkbox, 37, 0, 1, 2)
 
         # ── CSpect: check itch.io for a newer version at startup (default on) ──
         def settings_cspect_update_check_changed():
@@ -24848,7 +25169,7 @@ class MainWindow(QMainWindow):
         self.settings_cspect_update_check_checkbox.stateChanged.connect(
             lambda _s: settings_cspect_update_check_changed())
         grid_tab_Settings.addWidget(
-            self.settings_cspect_update_check_checkbox, 31, 0, 1, 2)
+            self.settings_cspect_update_check_checkbox, 32, 0, 1, 2)
 
         # ── NextSync: what to do when a received file/dir already exists locally ──
         def _settings_nextsync_send_conflict_changed():
@@ -24865,7 +25186,7 @@ class MainWindow(QMainWindow):
             "  • Overwrite: always replace the local file.\n"
             "  • Ignore: never touch existing local files."
         )
-        grid_tab_Settings.addWidget(nextsync_send_conflict_lbl, 3, 0)
+        grid_tab_Settings.addWidget(nextsync_send_conflict_lbl, 4, 0)
 
         self.settings_nextsync_send_conflict_combo = QComboBox()
         self.settings_nextsync_send_conflict_combo.addItem("Prompt (default)", "prompt")
@@ -24874,7 +25195,7 @@ class MainWindow(QMainWindow):
         self.settings_nextsync_send_conflict_combo.setToolTip(nextsync_send_conflict_lbl.toolTip())
         self.settings_nextsync_send_conflict_combo.currentIndexChanged.connect(
             lambda _i: _settings_nextsync_send_conflict_changed())
-        grid_tab_Settings.addWidget(self.settings_nextsync_send_conflict_combo, 3, 1)
+        grid_tab_Settings.addWidget(self.settings_nextsync_send_conflict_combo, 4, 1)
 
         # ── Unite! search result sort / render preference ──────────────────
         def _settings_search_sort_changed():
@@ -24904,7 +25225,7 @@ class MainWindow(QMainWindow):
             "  • Classic: ZXDB and zxArt items are preferred to the top, with\n"
             "    GetIt content placed at the end."
         )
-        grid_tab_Settings.addWidget(search_sort_lbl, 12, 0)
+        grid_tab_Settings.addWidget(search_sort_lbl, 13, 0)
 
         self.settings_search_sort_combo = QComboBox()
         self.settings_search_sort_combo.addItem("GetIt first class (default)", SEARCH_SORT_GETIT_FIRST)
@@ -24913,7 +25234,7 @@ class MainWindow(QMainWindow):
         self.settings_search_sort_combo.setToolTip(search_sort_lbl.toolTip())
         self.settings_search_sort_combo.currentIndexChanged.connect(
             lambda _i: _settings_search_sort_changed())
-        grid_tab_Settings.addWidget(self.settings_search_sort_combo, 12, 1)
+        grid_tab_Settings.addWidget(self.settings_search_sort_combo, 13, 1)
 
         # "Open config file" — moved here from the SD-card tab. Opens hdfg.cfg in
         # the system text editor so advanced users can hand-edit settings. Placed
@@ -24921,7 +25242,7 @@ class MainWindow(QMainWindow):
         # width rather than stretching across both columns.
         self.button_open_config_file = QPushButton("Open config file", self)
         self.button_open_config_file.clicked.connect(open_cspect_configuration_file)
-        grid_tab_Settings.addWidget(self.button_open_config_file, 38, 0, 1, 2, Qt.AlignLeft)
+        grid_tab_Settings.addWidget(self.button_open_config_file, 39, 0, 1, 2, Qt.AlignLeft)
 
         grid_tab_Settings.setColumnStretch(2, 1)
         zxnextunite_Settings_tab.setLayout(grid_tab_Settings)
@@ -25579,6 +25900,14 @@ class MainWindow(QMainWindow):
         _check_cspect = getattr(self, "_check_cspect_update_async", None)
         if _check_cspect is not None:
             QTimer.singleShot(2600, _check_cspect)
+
+        # The ".sync5 dot was updated" advisory (compares the bundled dotN
+        # version with the one this cfg last saw) runs early — it concerns the
+        # update the user JUST installed — and ZX Next Unite's own release
+        # check runs last, staggered clear of the MAME/CSpect checks so their
+        # prompts and log lines don't collide.
+        QTimer.singleShot(1200, self._check_dotn_version_advisory)
+        QTimer.singleShot(3400, self._check_zxnu_update_async)
 
         # Expose the nested save function so closeEvent (a class method) can call it.
         self._save_configuration_file = save_configuration_file

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -17,6 +17,17 @@ from PySide6.QtGui import QColor
 
 
 ZX_NEXT_UNITE_VERSION = "9.0.7"
+# Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
+# dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
+# kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync
+# X.Y Clauzel/Komppa") whenever the dot is rebuilt with a version bump: the
+# startup dotN-updated advisory compares this against the dotn_last_version
+# persisted in hdfg.cfg, so the user is told to refresh the copy on their
+# Next (which the app cannot deploy automatically).
+ZX_NEXT_UNITE_DOTN_VERSION = "5.4"
+# Self-update check (Settings toggle, default on): the app's own releases.
+ZXNU_GITHUB_LATEST_RELEASE_API = "https://api.github.com/repos/jclauzel/ZX-Next-Unite/releases/latest"
+ZXNU_GITHUB_RELEASES_PAGE = "https://github.com/jclauzel/ZX-Next-Unite/releases"
 # Set to False to hide all Download / Send to SD Card / Send via NextSync
 # buttons and context-menu actions for the respective pane.
 ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS  = False
@@ -195,6 +206,8 @@ SETTING_ITCHIO_API_KEY         = "itchio_api_key"          # str: personal itch.
 SETTING_SHOW_ITCHIO_TAB        = "show_itchio_tab"         # "false" => hide the itch.io tab (default shown when itch-dl is installed)
 SETTING_ITCHIO_VIEW_MODE       = "itchio_view_mode"        # "gallery" (default) or "table"
 SETTING_CSPECT_UPDATE_CHECK    = "cspect_update_check"     # "false" => skip the startup itch.io CSpect update check (default on)
+SETTING_ZXNU_UPDATE_CHECK      = "zxnu_update_check"       # "false" => skip the startup ZX Next Unite GitHub release check (default on)
+SETTING_DOTN_LAST_VERSION      = "dotn_last_version"       # bundled .sync5 dotN version last seen by this cfg (drives the "update the dot on your Next" advisory)
 # Per-pane item-viewer mode: "true" => open items in the Retro (pygame) viewer
 # (renders .txt/instruction pages as a log console), else the Classic Qt viewer.
 SETTING_GETIT_ITEM_RETRO       = "getit_item_retro"
@@ -756,7 +769,7 @@ SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVO
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
 SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_MAME_ESC, SETTING_MAME_FLATPAK, SETTING_MAME_FLATPAK_ROMPATH, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_NEXTSYNC_REMOTE_EXPLORER, SETTING_NEXTSYNC_REMOTE_CWD, SETTING_NEXTSYNC_RE_LOCAL_SORT, SETTING_NEXTSYNC_RE_NEXT_SORT, SETTING_NEXTSYNC_EXTRA_DRIVES, SETTING_NEXTSYNC_HTTP_BRIDGE, SETTING_NEXTSYNC_HTTP_PORT, SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT, SETTING_SDCARD_PYGAME_LOG, SETTING_SDCARD_SPLITTER, SETTING_GETIT_SPLITTER, SETTING_HELP_PYGAME_LOG, SETTING_RETRO_LOG_FONT_SIZE,
-SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK,
+SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK, SETTING_ZXNU_UPDATE_CHECK, SETTING_DOTN_LAST_VERSION,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO)
 
 IMAGE_BUTTONS_SIZE = 190


### PR DESCRIPTION
## Summary

### tests/ — the whole suite is now in the repo
- Moved the three protocol tests (`test_listen.py`, `test_remote_listen.py`, `test_http_bridge.py`) from `nextsync/sync/server/` into `tests/` (history preserved)
- **New `tests/test_ui_offscreen.py`**: the offscreen end-to-end UI suite — runs an isolated copy of the app (own scratch + `hdfg.cfg` under the OS temp dir), 7 phases: SD Card path rows / Up-Refresh, in-image navigation on a generated test HDF, cfg persistence & startup restore, NextSync drag & drop, the watched-folder delete regression, the new self-update toggle, and the dotN advisory. hdfmonkey is auto-discovered and the HDF phases **skip cleanly** without it — CI-ready on a bare checkout; no phase ever touches the network
- `tests/test_retro_log_widget.py`, `tests/run_all.py` (one-command summary runner; Flask-less bridge test reported SKIPPED), `tests/README.md`; docs updated to the new paths

### Self-update against GitHub Releases
- New Settings toggle at the very top: **Check for ZX Next Unite updates at startup on Github** (on by default, persisted as `zxnu_update_check`)
- Startup check of `releases/latest` mirroring the MAME check — every branch logged in the SD Card log (checking / up-to-date / available / unreachable / download outcome)
- Windows binary users: "vX.Y.Z is available — download?" → streamed download with progress next to the current exe (never overwrites the running binary), then an explicit **"Close and start \<new exe name\>?"** restart offer
- Source checkouts are advised to `git pull` instead of downloading the Windows binary (releases-page button included)

### dotN update advisory
- `ZX_NEXT_UNITE_DOTN_VERSION` (sync-commented with the banner in `nextsync.c`) vs `dotn_last_version` persisted in `hdfg.cfg`: after an app update that bumped the bundled `.sync5`, a one-time popup explains the dot on the Next cannot be deployed automatically and points at the release's `sync5` asset / repo `syncdev`; first run records silently

## Testing
- Full suite green: 5 test files, 7 UI phases (~110 checks) — `python tests/run_all.py`
- Live API sanity check: latest tag v9.0.7 parses and compares correctly against 9.0.7 ("up to date")

🤖 Generated with [Claude Code](https://claude.com/claude-code)