### PR TITLE
Show release notes in the MAME and CSpect update prompts

### DIFF
--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -42,6 +42,14 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 SCRATCH = os.path.join(tempfile.gettempdir(), "zxnu-ui-tests")
+
+# The app writes its always-on log next to argv[0] — the SCRATCH copy — so it
+# must never touch the repo. A developer who ran the real app from the repo
+# will legitimately have a zx-next-unite.log there already, so we snapshot it
+# BEFORE launching the scratch app and later assert this run left it untouched
+# (rather than asserting the file is simply absent).
+_REPO_LOG = os.path.join(REPO, "zx-next-unite.log")
+_REPO_LOG_MTIME0 = os.path.getmtime(_REPO_LOG) if os.path.isfile(_REPO_LOG) else None
 CFG = os.path.join(SCRATCH, "hdfg.cfg")
 HDF = os.path.join(SCRATCH, "test.hdf")
 PASTE_SUB = os.path.join(SCRATCH, "pastedir", "sub")
@@ -571,8 +579,10 @@ def inspect_phase5():
         body = open(log_path, encoding="utf-8", errors="replace").read()
         check("log carries the startup banner", "starting" in body, body[:200])
         check("log captures live log lines", "offscreen-test-marker-line" in body)
-    check("repo has no stray zx-next-unite.log",
-          not os.path.isfile(os.path.join(REPO, "zx-next-unite.log")))
+    _repo_now = os.path.getmtime(_REPO_LOG) if os.path.isfile(_REPO_LOG) else None
+    check("scratch app did not write to a repo log",
+          _repo_now == _REPO_LOG_MTIME0,
+          f"repo log mtime changed: {_REPO_LOG_MTIME0} -> {_repo_now}")
 
     # ---- delete-confirmation wording (Recycle Bin vs permanent) ------------
     # The sweeper CLOSES each dialog (= answers No), so nothing is deleted and

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -3462,7 +3462,9 @@ class MainWindow(QMainWindow):
             if not picked:
                 raise RuntimeError(
                     f"the latest MAME release has no Windows {arch} build.")
-            return picked
+            # Also carry the release "what's changed" notes so the prompts can
+            # show them (like the ZX Next Unite self-update prompt).
+            return (*picked, str(release.get("body") or "").strip())
 
         def _mame_install_job(url, asset_name, dest_root, mame_sig,
                               expected_sha256=None):
@@ -3733,7 +3735,7 @@ class MainWindow(QMainWindow):
                 return
             add_main_log_window("Detecting the latest MAME release…")
             try:
-                tag, asset_name, url, size, sha256 = _fetch_latest_mame_asset(arch)
+                tag, asset_name, url, size, sha256, notes = _fetch_latest_mame_asset(arch)
             except Exception as e:
                 add_main_log_window(f"Could not detect the latest MAME release: {e}")
                 logging.error(f"MAME release detection failed: {e}")
@@ -3752,6 +3754,7 @@ class MainWindow(QMainWindow):
                 f"Package: {asset_name} ({arch})\n\n"
                 f"Download (~{size_txt}) and install it into the downloads "
                 f"folder?\nNote: the fully extracted install is large (~500 MB).")
+            _attach_release_notes(box, notes)
             go = box.addButton("Download and install", QMessageBox.AcceptRole)
             box.addButton("Cancel", QMessageBox.RejectRole)
             box.setDefaultButton(go)
@@ -3787,6 +3790,20 @@ class MainWindow(QMainWindow):
                 logging.info(f"MAME version probe failed: {exc}")
                 return ""
 
+        def _attach_release_notes(box, notes):
+            """Show a release's "what's changed" notes on a QMessageBox: a short
+            excerpt as the informative text, the full text behind the Show
+            Details button. No-op when *notes* is empty. Shared by the ZX Next
+            Unite, MAME and CSpect update/install prompts."""
+            notes = (notes or "").strip()
+            if not notes:
+                return
+            excerpt = "\n".join(notes.splitlines()[:10]).strip()[:800]
+            box.setInformativeText(
+                "What's changed:\n" + excerpt
+                + ("\n…" if len(excerpt) < len(notes) else ""))
+            box.setDetailedText(notes)
+
         def _prompt_mame_update(info, installed_num):
             """UI-thread dialog offering to update MAME to a newer release found
             by the startup check. 'Update' reuses the standard install flow for
@@ -3809,6 +3826,7 @@ class MainWindow(QMainWindow):
                 f"Download (~{size_txt}) and update your MAME install now?\n"
                 "The existing files in the downloads MAME folder will be "
                 "overwritten.")
+            _attach_release_notes(box, info.get("notes"))
             upd = box.addButton("Update", QMessageBox.AcceptRole)
             box.addButton("Cancel", QMessageBox.RejectRole)
             box.setDefaultButton(upd)
@@ -3854,13 +3872,14 @@ class MainWindow(QMainWindow):
                     raw = _probe_mame_version_text(mame_path)
                     installed_num = parse_mame_version_number(raw)
                     patched = mame_version_is_patched(raw)
-                tag, asset_name, url, size, sha256 = _fetch_latest_mame_asset(arch)
+                tag, asset_name, url, size, sha256, notes = _fetch_latest_mame_asset(arch)
                 return {
                     "installed_num": installed_num,
                     "patched": patched,
                     "latest_num": parse_mame_version_number(tag),
                     "tag": tag, "asset_name": asset_name,
                     "url": url, "size": size, "sha256": sha256,
+                    "notes": notes,
                 }
 
             def _on_result(info):
@@ -4077,15 +4096,9 @@ class MainWindow(QMainWindow):
             inline, the full text behind the box's Show Details button."""
             frozen = bool(getattr(sys, "frozen", False))
             notes = str(release.get("body") or "").strip()
-            excerpt = "\n".join(notes.splitlines()[:10]).strip()[:800]
 
             def _attach_notes(box):
-                if not notes:
-                    return
-                box.setInformativeText(
-                    "What's changed:\n" + excerpt
-                    + ("\n…" if len(excerpt) < len(notes) else ""))
-                box.setDetailedText(notes)
+                _attach_release_notes(box, notes)
             if not frozen:
                 add_main_log_window(
                     f"ZX Next Unite {tag} is available — running from source, so "
@@ -4362,6 +4375,7 @@ class MainWindow(QMainWindow):
                 f"Installed: {installed_name}\n"
                 f"Latest: {latest_name}\n\n"
                 "Download and install the newest version now?")
+            _attach_release_notes(box, info.get("notes"))
             yes = box.addButton("Yes", QMessageBox.AcceptRole)
             box.addButton("Cancel", QMessageBox.RejectRole)
             box.setDefaultButton(yes)
@@ -4436,6 +4450,17 @@ class MainWindow(QMainWindow):
                     add_main_log_window(
                         f"CSpect update ▸ newer build available: installed "
                         f"{installed_name}, latest {latest_name}.")
+                    # itch.io's download API carries no per-build changelog, so
+                    # point at the CSpect itch.io page where the release notes
+                    # live (the shared helper shows this as the "what's changed"
+                    # section, mirroring MAME / ZX Next Unite).
+                    _game_url = ((info.get("game") or {}).get("url")
+                                 or zxnu_itchio.CSPECT_ITCH_URL)
+                    info["notes"] = (
+                        f"New CSpect build: {latest_name}\n\n"
+                        "itch.io does not publish inline release notes for CSpect; "
+                        "the full changelog is on the CSpect itch.io page:\n"
+                        f"{_game_url}")
                     _prompt_cspect_update(info)
                 except Exception as exc:
                     logging.info(f"CSpect update check result handling failed: {exc}")


### PR DESCRIPTION
Mirrors the ZX Next Unite self-update prompt's "what's changed" onto the MAME and CSpect update prompts.

## Changes
- **Shared helper** `_attach_release_notes(box, notes)` — the excerpt-inline + full-text-behind-Show-Details rendering, hoisted into one place so all three update prompts render notes identically (the ZX Next Unite prompt now delegates to it)
- **MAME** — `_fetch_latest_mame_asset` now also returns the GitHub release body; it flows through the update-check `info` dict into `_prompt_mame_update`, and is wired into the manual **Install MAME** prompt too. Real "what's changed" straight from MAME's GitHub release
- **CSpect** — itch.io's download API carries no per-build changelog (verified the upload object's shape), so rather than fabricate one the note surfaces the honest, useful thing: the new build name plus a pointer to the CSpect itch.io page where the changelog actually lives

## Test fix
- Phase-5's "repo has no stray log" check couldn't distinguish a test leak from a developer's own `zx-next-unite.log` (from running the real app in the repo). It now snapshots the repo log's mtime before launching the scratch app and asserts this run left it untouched — proving the invariant (scratch app writes only to scratch) without failing on a pre-existing dev log

## Testing
- Full suite green: 7 test files, 7 offscreen UI phases; `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
