### PR TITLE
Fix retro item-viewer text pages stuck on "Loading text…" (ZXDB media host)

### DIFF
--- a/tests/test_api_parsers.py
+++ b/tests/test_api_parsers.py
@@ -13,6 +13,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(
 
 from zxnu_api import (  # noqa: E402
     _filter_download_urls,
+    _http_fetch_bytes_with_retry,
+    _zxdb_media_mirror_url,
     getit_parse_detail,
     getit_parse_file_list,
     zxart_entry_website_url,
@@ -20,6 +22,7 @@ from zxnu_api import (  # noqa: E402
     zxart_parse_prod_list,
     zxart_safe_url,
     zxdb_entry_website_url,
+    zxdb_parse_game_detail,
     zxdb_parse_search,
     zxdb_pick,
 )
@@ -84,6 +87,101 @@ check("zxdb website url: zero-padded",
 check("zxdb website url: non-numeric passthrough",
       zxdb_entry_website_url("AB12").endswith("/AB12"), zxdb_entry_website_url("AB12"))
 check("zxdb website url: empty", zxdb_entry_website_url("") == "")
+
+# ---- ZXDB media-host routing ------------------------------------------------
+# Root-relative asset paths from the ZXInfo API must all resolve against
+# zxinfo.dk/media (the primary media host). Regression guard for the retro
+# item viewer's "Loading text…" hang: /pub + /zxdb assets briefly routed to
+# spectrumcomputing.co.uk, which later became unreachable.
+_detail = zxdb_parse_game_detail({
+    "_id": "0035805",
+    "_source": {
+        "title": "Willy's New Mansion - Special Edition",
+        "screens": [
+            {"url": "/zxscreens/0035805/0035805-load-1.png", "type": "Loading screen"},
+        ],
+        "additionalDownloads": [
+            {"path": "/zxdb/sinclair/entries/0035805/0035805-run-1.scr",
+             "type": "Running screen", "format": "Screen dump (SCR)"},
+            {"path": "/pub/sinclair/games-info/w/WillysNewMansion-SpecialEdition.txt",
+             "type": "Instructions", "format": "Document (TXT)"},
+        ],
+        "releases": [{"yearOfRelease": 2016, "files": [
+            {"path": "/zxdb/sinclair/entries/0035805/WillysNewMansion-SpecialEdition.tap.zip",
+             "type": "Tape image", "format": "Tape (TAP)"},
+        ]}],
+    },
+})
+_shot_urls = [s["url"] for s in _detail.get("screenshots", [])]
+check("zxdb media routing: all screenshots on zxinfo.dk/media",
+      _shot_urls and all(u.startswith("https://zxinfo.dk/media/") for u in _shot_urls),
+      str(_shot_urls))
+_txt_urls = [t["url"] for t in _detail.get("text_files", [])]
+check("zxdb media routing: instructions .txt on zxinfo.dk/media",
+      _txt_urls == ["https://zxinfo.dk/media/pub/sinclair/games-info/w/"
+                    "WillysNewMansion-SpecialEdition.txt"], str(_txt_urls))
+_dl_urls = [d["url"] for d in _detail.get("downloads", [])]
+check("zxdb media routing: downloads on zxinfo.dk/media",
+      _dl_urls and all(u.startswith("https://zxinfo.dk/media/") for u in _dl_urls),
+      str(_dl_urls))
+
+check("zxdb mirror map: primary -> mirror (/zxdb)",
+      _zxdb_media_mirror_url("https://zxinfo.dk/media/zxdb/sinclair/entries/1/a.txt")
+      == "https://spectrumcomputing.co.uk/zxdb/sinclair/entries/1/a.txt")
+check("zxdb mirror map: mirror -> primary (/pub)",
+      _zxdb_media_mirror_url("https://spectrumcomputing.co.uk/pub/sinclair/g/a.scr")
+      == "https://zxinfo.dk/media/pub/sinclair/g/a.scr")
+check("zxdb mirror map: /zxscreens is single-host",
+      _zxdb_media_mirror_url("https://zxinfo.dk/media/zxscreens/1/a.png") is None)
+check("zxdb mirror map: unrelated host untouched",
+      _zxdb_media_mirror_url("https://zxart.ee/files/pub/x.tap") is None)
+check("zxdb mirror map: empty/None safe",
+      _zxdb_media_mirror_url("") is None and _zxdb_media_mirror_url(None) is None)
+
+# Fetch fallback: a permanent 404 on the primary host must transparently
+# retry the same asset on the mirror (once — no ping-pong). No network:
+# urllib.request.urlopen is monkeypatched.
+import io
+import urllib.error
+import urllib.request
+
+_urlopen_calls = []
+_real_urlopen = urllib.request.urlopen
+
+def _fake_urlopen(req, timeout=None):
+    _urlopen_calls.append(req.full_url)
+    if req.full_url.startswith("https://zxinfo.dk/media/"):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", None, io.BytesIO(b""))
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return b"mirror-bytes"
+    return _Resp()
+
+urllib.request.urlopen = _fake_urlopen
+try:
+    _data = _http_fetch_bytes_with_retry(
+        "https://zxinfo.dk/media/pub/sinclair/games-info/w/W.txt", _retries=1)
+    check("zxdb fetch fallback: 404 on primary served from mirror",
+          _data == b"mirror-bytes", repr(_data))
+    check("zxdb fetch fallback: exactly one attempt per host",
+          _urlopen_calls == [
+              "https://zxinfo.dk/media/pub/sinclair/games-info/w/W.txt",
+              "https://spectrumcomputing.co.uk/pub/sinclair/games-info/w/W.txt",
+          ], str(_urlopen_calls))
+    _urlopen_calls.clear()
+    try:
+        _http_fetch_bytes_with_retry("https://zxinfo.dk/media/zxscreens/1/a.png",
+                                     _retries=1)
+        _raised = None
+    except urllib.error.HTTPError as exc:
+        _raised = exc
+    check("zxdb fetch fallback: single-host asset fails without mirror attempt",
+          _raised is not None and _raised.code == 404
+          and _urlopen_calls == ["https://zxinfo.dk/media/zxscreens/1/a.png"],
+          f"raised={_raised} calls={_urlopen_calls}")
+finally:
+    urllib.request.urlopen = _real_urlopen
 
 # ---- zxArt ------------------------------------------------------------------
 check("zxart website url: direct url from _source",

--- a/tests/test_retro_log_widget.py
+++ b/tests/test_retro_log_widget.py
@@ -1,4 +1,4 @@
-"""RetroLogWidget.set_text_color unit test.
+"""RetroLogWidget.set_text_color + _decode_text_bytes unit tests.
 
 Runs with the REAL Qt platform (no window is ever shown): pygame-dependent
 classes crash natively only under QT_QPA_PLATFORM=offscreen, so unlike the
@@ -40,8 +40,28 @@ check("per-instance tint (other widget untouched)",
       w2._C_LOG == (120, 255, 140) and w._C_LOG == (255, 0, 0),
       f"{w._C_LOG} / {w2._C_LOG}")
 
+# ---- _decode_text_bytes (item-viewer text console) --------------------------
+# Some ZXDB instruction .txt files are UTF-16 with BOM (e.g. Willy's New
+# Mansion - Special Edition); without BOM handling they decoded via the
+# latin-1 fallback into NUL-riddled mojibake.
+from zxnu_pygame import _decode_text_bytes
+
+check("decode: plain utf-8", _decode_text_bytes("héllo\nx".encode("utf-8")) == ["héllo", "x"])
+_u8bom = b"\xef\xbb\xbf" + "hi".encode("utf-8")
+check("decode: utf-8 BOM stripped", _decode_text_bytes(_u8bom) == ["hi"],
+      str(_decode_text_bytes(_u8bom)))
+_u16le = b"\xff\xfe" + "Willy's\r\nMansion".encode("utf-16-le")
+check("decode: utf-16 LE BOM", _decode_text_bytes(_u16le) == ["Willy's", "Mansion"],
+      str(_decode_text_bytes(_u16le)))
+_u16be = b"\xfe\xff" + "AB".encode("utf-16-be")
+check("decode: utf-16 BE BOM", _decode_text_bytes(_u16be) == ["AB"],
+      str(_decode_text_bytes(_u16be)))
+check("decode: cp1252 fallback", _decode_text_bytes(b"caf\xe9") == ["café"],
+      str(_decode_text_bytes(b"caf\xe9")))
+check("decode: empty", _decode_text_bytes(b"") == [])
+
 print()
 if FAIL:
     print(f"RESULT: {len(FAIL)} FAILURE(S)")
     sys.exit(1)
-print("RESULT: ALL WIDGET COLOR CHECKS PASSED")
+print("RESULT: ALL WIDGET COLOR + TEXT DECODE CHECKS PASSED")

--- a/zxnu_api.py
+++ b/zxnu_api.py
@@ -36,6 +36,36 @@ from zxnu_config import (
 
 _HTTP_RETRYABLE = (429, 502, 503, 504)
 
+# The ZXInfo API returns root-relative archive asset paths (/pub/…, /zxdb/…,
+# /zxscreens/…). Two hosts serve the underlying WoS/ZXDB archive and their
+# coverage has flipped over time: in mid-2026 zxinfo.dk/media 404'd the raw
+# /pub + /zxdb assets (only the spectrumcomputing.co.uk mirror had them);
+# by July 2026 zxinfo.dk/media served everything while spectrumcomputing
+# became unreachable. So game-detail URLs are built against the primary and
+# the fetch helpers below transparently retry a failed /pub|/zxdb asset once
+# on the other host. /zxscreens/… (ZXInfo's own rendered screen images) and
+# /pub/sinclair/magazines/… (only on the mirror) are the known one-host paths.
+_ZXDB_MEDIA_PRIMARY = "https://zxinfo.dk/media"
+_ZXDB_MEDIA_MIRROR  = "https://spectrumcomputing.co.uk"
+
+
+def _zxdb_media_mirror_url(url: str):
+    """Return the same ZXDB archive asset on the other media host, or None.
+
+    Only /pub/… and /zxdb/… paths are mirrored; anything else — including
+    /zxscreens/…, which exists only on zxinfo.dk/media — returns None.
+    """
+    if not url:
+        return None
+    for host, other in ((_ZXDB_MEDIA_PRIMARY, _ZXDB_MEDIA_MIRROR),
+                        (_ZXDB_MEDIA_MIRROR, _ZXDB_MEDIA_PRIMARY)):
+        if url.startswith(host + "/"):
+            path = url[len(host):]
+            if path.startswith(("/pub/", "/zxdb/")):
+                return other + path
+            return None
+    return None
+
 
 def _is_retryable_connection_error(exc: OSError) -> bool:
     """Return True for transient connection-level errors that are worth retrying.
@@ -68,6 +98,7 @@ def _http_fetch_bytes_with_retry(
     timeout: int = 20,
     _retries: int = 3,
     _backoff: float = 1.5,
+    _try_mirror: bool = True,
 ) -> bytes:
     """Fetch *url* as bytes with retry/back-off on transient errors.
 
@@ -76,6 +107,9 @@ def _http_fetch_bytes_with_retry(
     connection was forcibly closed by the remote host") whether raised
     directly or wrapped inside ``urllib.error.URLError``.
     Closes the HTTPError response before sleeping on retryable HTTP codes.
+    When *url* is a mirrored ZXDB archive asset (see _zxdb_media_mirror_url)
+    and every attempt failed — including a permanent 404 —, the same asset is
+    tried once on the other media host before giving up.
     """
     import urllib.error as _ue
     req = urllib.request.Request(url, headers=headers or {}, method=method)
@@ -86,18 +120,17 @@ def _http_fetch_bytes_with_retry(
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return resp.read()
         except _ue.HTTPError as exc:
-            if exc.code in _HTTP_RETRYABLE:
-                last_exc = exc
-                exc.close()
-                # logging.warning(
-                #     "_http_fetch_bytes_with_retry: HTTP %d on attempt %d/%d for %s",
-                #     exc.code, attempt, _retries, url,
-                # )
-                if attempt < _retries:
-                    time.sleep(delay)
-                    delay *= 2
-            else:
-                raise
+            last_exc = exc
+            exc.close()
+            if exc.code not in _HTTP_RETRYABLE:
+                break                    # permanent HTTP error on this host
+            # logging.warning(
+            #     "_http_fetch_bytes_with_retry: HTTP %d on attempt %d/%d for %s",
+            #     exc.code, attempt, _retries, url,
+            # )
+            if attempt < _retries:
+                time.sleep(delay)
+                delay *= 2
         except OSError as exc:
             # Catches urllib.error.URLError (subclass of OSError) and direct
             # socket errors such as ConnectionResetError (WinError 10054).
@@ -109,6 +142,19 @@ def _http_fetch_bytes_with_retry(
             if attempt < _retries:
                 time.sleep(delay)
                 delay *= 2
+    mirror = _zxdb_media_mirror_url(url) if _try_mirror else None
+    if mirror:
+        logging.warning(
+            "_http_fetch_bytes_with_retry: %s failed (%s); trying mirror %s",
+            url, last_exc, mirror,
+        )
+        try:
+            return _http_fetch_bytes_with_retry(
+                mirror, headers=headers, method=method, timeout=timeout,
+                _retries=_retries, _backoff=_backoff, _try_mirror=False,
+            )
+        except Exception:
+            pass                         # report the primary host's error
     raise last_exc
 
 
@@ -119,11 +165,14 @@ def _http_fetch_with_cd_retry(
     timeout: int = 60,
     _retries: int = 3,
     _backoff: float = 1.5,
+    _try_mirror: bool = True,
 ):
     """Fetch *url*, returning ``(content_disposition_header, bytes)`` with retry.
 
     Retries on HTTP 429/502/503/504 and on connection-level OS errors,
-    including ``ConnectionResetError`` / WinError 10054.
+    including ``ConnectionResetError`` / WinError 10054. Mirrored ZXDB archive
+    assets (see _zxdb_media_mirror_url) get one attempt on the other media
+    host after every attempt on *url* failed.
     """
     import urllib.error as _ue
     req = urllib.request.Request(url, headers=headers or {})
@@ -136,18 +185,17 @@ def _http_fetch_with_cd_retry(
                 data = resp.read()
             return cd, data
         except _ue.HTTPError as exc:
-            if exc.code in _HTTP_RETRYABLE:
-                last_exc = exc
-                exc.close()
-                logging.warning(
-                    "_http_fetch_with_cd_retry: HTTP %d on attempt %d/%d for %s",
-                    exc.code, attempt, _retries, url,
-                )
-                if attempt < _retries:
-                    time.sleep(delay)
-                    delay *= 2
-            else:
-                raise
+            last_exc = exc
+            exc.close()
+            if exc.code not in _HTTP_RETRYABLE:
+                break                    # permanent HTTP error on this host
+            logging.warning(
+                "_http_fetch_with_cd_retry: HTTP %d on attempt %d/%d for %s",
+                exc.code, attempt, _retries, url,
+            )
+            if attempt < _retries:
+                time.sleep(delay)
+                delay *= 2
         except OSError as exc:
             # Catches urllib.error.URLError and direct socket errors
             # including ConnectionResetError (WinError 10054).
@@ -159,6 +207,19 @@ def _http_fetch_with_cd_retry(
             if attempt < _retries:
                 time.sleep(delay)
                 delay *= 2
+    mirror = _zxdb_media_mirror_url(url) if _try_mirror else None
+    if mirror:
+        logging.warning(
+            "_http_fetch_with_cd_retry: %s failed (%s); trying mirror %s",
+            url, last_exc, mirror,
+        )
+        try:
+            return _http_fetch_with_cd_retry(
+                mirror, headers=headers, timeout=timeout,
+                _retries=_retries, _backoff=_backoff, _try_mirror=False,
+            )
+        except Exception:
+            pass                         # report the primary host's error
     raise last_exc
 
 
@@ -169,6 +230,7 @@ def _http_head_ok_with_retry(
     timeout: int = 10,
     _retries: int = 3,
     _backoff: float = 1.5,
+    _try_mirror: bool = True,
 ) -> bool:
     """Send a HEAD request; return True when the server responds with status < 400.
 
@@ -176,15 +238,28 @@ def _http_head_ok_with_retry(
     including ``ConnectionResetError`` / WinError 10054 ("An existing
     connection was forcibly closed by the remote host").
     Returns False after exhausting retries so callers treat the URL as
-    unavailable rather than propagating an exception.
+    unavailable rather than propagating an exception. A mirrored ZXDB archive
+    asset (see _zxdb_media_mirror_url) counts as available when either media
+    host serves it — the fetch helpers apply the same fallback, so a download
+    button enabled by this check will genuinely work.
     """
     import urllib.error as _ue
+
+    def _mirror_ok() -> bool:
+        mirror = _zxdb_media_mirror_url(url) if _try_mirror else None
+        if not mirror:
+            return False
+        return _http_head_ok_with_retry(
+            mirror, headers=headers, timeout=timeout,
+            _retries=_retries, _backoff=_backoff, _try_mirror=False,
+        )
+
     req = urllib.request.Request(url, headers=headers or {}, method="HEAD")
     delay = _backoff
     for attempt in range(1, _retries + 1):
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                return resp.status < 400
+                return resp.status < 400 or _mirror_ok()
         except _ue.HTTPError as exc:
             if exc.code in _HTTP_RETRYABLE:
                 exc.close()
@@ -192,14 +267,14 @@ def _http_head_ok_with_retry(
                     time.sleep(delay)
                     delay *= 2
             else:
-                return exc.code < 400
+                return exc.code < 400 or _mirror_ok()
         except OSError:
             # Catches urllib.error.URLError and direct socket errors
             # including ConnectionResetError (WinError 10054).
             if attempt < _retries:
                 time.sleep(delay)
                 delay *= 2
-    return False
+    return _mirror_ok()
 
 
 # ---------------------------------------------------------------------------
@@ -582,15 +657,14 @@ def zxdb_parse_game_detail(payload) -> dict:
         if not u:
             return ""
         if u.startswith("/"):
-            # ZXInfo hosts its own *rendered* screen images (/zxscreens/…) under
-            # https://zxinfo.dk/media, but the raw archive paths it references
-            # for screen dumps (.scr) and downloads — /pub/… and /zxdb/… — are
-            # NOT on zxinfo.dk/media (they 404 there); they live on the
-            # spectrumcomputing.co.uk mirror. Route each to the host that serves
-            # it, otherwise e.g. a .scr loading screen never renders.
-            if u.lower().startswith("/zxscreens/"):
-                return "https://zxinfo.dk/media" + u
-            return "https://spectrumcomputing.co.uk" + u
+            # ZXInfo serves its rendered screen images (/zxscreens/…) and —
+            # despite having 404'd them for a while in mid-2026 — the raw
+            # archive assets (/pub/…, /zxdb/… screen dumps, instructions,
+            # downloads) under https://zxinfo.dk/media. Build every URL
+            # against it; if its coverage regresses again the fetch helpers
+            # transparently retry /pub|/zxdb assets on the
+            # spectrumcomputing.co.uk mirror (see _zxdb_media_mirror_url).
+            return _ZXDB_MEDIA_PRIMARY + u
         return u
 
     # Gather candidate "asset" lists from top-level AND from each release.

--- a/zxnu_pygame.py
+++ b/zxnu_pygame.py
@@ -518,19 +518,29 @@ def _url_is_text(url) -> bool:
 
 def _decode_text_bytes(data) -> list:
     """Decode raw *data* bytes into a list of display lines for the console.
-    Tries UTF-8, then common 8-bit code pages, expanding tabs and normalising
-    newlines."""
+    Honours a UTF-16 BOM, then tries UTF-8 and common 8-bit code pages,
+    expanding tabs and normalising newlines."""
     if not data:
         return []
-    text = None
-    for enc in ("utf-8", "cp1252", "latin-1"):
+    raw = bytes(data)
+    # UTF-16 BOM first: some ZXDB instruction .txt files are saved by Windows
+    # tools as UTF-16 (e.g. WillysNewMansion-SpecialEdition.txt). Without this
+    # the utf-8 try fails and the latin-1 fallback "succeeds" into
+    # NUL-riddled mojibake.
+    if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
         try:
-            text = bytes(data).decode(enc)
+            return _text_to_lines(raw.decode("utf-16"))
+        except Exception:
+            pass
+    text = None
+    for enc in ("utf-8-sig", "cp1252", "latin-1"):
+        try:
+            text = raw.decode(enc)
             break
         except Exception:
             text = None
     if text is None:
-        text = bytes(data).decode("latin-1", "replace")
+        text = raw.decode("latin-1", "replace")
     return _text_to_lines(text)
 
 


### PR DESCRIPTION
Fixes the regression where the Pygame (Retro) item viewer showed **"Loading text…"** forever instead of rendering a ZXDB instruction file — reported for [Willy's New Mansion - Special Edition](https://zxinfo.dk/details/0035805) / `WillysNewMansion-SpecialEdition.txt`.

Two stacked causes, both predating the Pure API extraction (the strangler move carried the first one over verbatim).

## 1. Wrong media host

`d8b64986` routed root-relative `/pub/…` and `/zxdb/…` asset paths to `spectrumcomputing.co.uk`, because `zxinfo.dk/media` 404'd them at the time. That has fully reversed:

| host | `/zxscreens/` | `/pub/` + `/zxdb/` game assets | `/pub/sinclair/magazines/` |
|---|---|---|---|
| `zxinfo.dk/media` | ✅ | ✅ (verified: .txt, .scr, .gif, .zip) | ❌ 404 |
| `spectrumcomputing.co.uk` | — | ❌ unreachable (connection timeout) | ✅ only host |

Every asset fetch was burning ~65 s of timeout retries and then failing silently, so **.scr screen dumps and ZXDB file downloads were quietly broken too** — not just the text console.

- `_abs_url` builds against `zxinfo.dk/media` again.
- Because coverage has now flipped twice, the three shared retry helpers (`_http_fetch_bytes_with_retry`, `_http_fetch_with_cd_retry`, `_http_head_ok_with_retry`) fall back **once** to the other mirror via the new `_zxdb_media_mirror_url` — including after a permanent 404, which the byte/cd helpers previously re-raised immediately.
- Magazine scans stay pointed at spectrumcomputing: they genuinely 404 on `zxinfo.dk/media`, and `zxinfo.dk/magazines/…` answers **200 with the SPA index page** (a soft-404), so there is no alternative host there.

## 2. UTF-16 text

Once the fetch worked, that file would *still* have rendered as NUL-riddled mojibake: it is UTF-16 with BOM, and `_decode_text_bytes` only tried utf-8 → cp1252 → latin-1 (latin-1 never fails, so it "succeeded" into garbage). It now honours UTF-16 LE/BE BOMs and strips a UTF-8 BOM.

## Testing

- Host-routing and mirror-fallback checks in `tests/test_api_parsers.py` (monkeypatched `urlopen`, no network — asserts one attempt per host and that single-host `/zxscreens/` assets never trigger a mirror attempt).
- BOM decode checks in `tests/test_retro_log_widget.py`.
- Verified end-to-end against the live API: the 702 KB file fetches and decodes into its "Willy's New Mansion" ASCII-art banner.
- Full suite green (7 files, 7 UI phases); `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)