### PR TITLE
Bump version to 9.1.0

### DIFF
--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.0.9"
+ZX_NEXT_UNITE_VERSION = "9.1.0"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Bumps `ZX_NEXT_UNITE_VERSION` from `9.0.9` to `9.1.0`.

Minor rather than patch: 9.0.9 shipped with every ZXDB `/pub` + `/zxdb` asset pointed at an unreachable host, so instruction text, `.scr` screen dumps and file downloads were all silently broken — fixed in #179.

- Single source of truth in `zxnu_config.py`; the window title, the three API user-agents, the itch.io user-agent, the welcome banner and the help text all interpolate the constant.
- The self-update check parses versions into integer tuples (`_parse_zxnu_version`), so `9.1.0 > 9.0.9` orders correctly — no string-compare trap.

Full suite green (7 files, 7 UI phases); `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)