### PR TITLE
zx98: v9.1.1 — Rename button, RE arrow pulse, Linux emoji fix, attributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ the **[Wiki](https://github.com/jclauzel/ZX-Next-Unite/wiki)**:
 
 Released under the **MIT** license (see [LICENSE](LICENSE)). Built on **PySide6**
 and **pygame-ce** (Qt 6, GPLv2/LGPL) and optionally
-[itch-dl](https://github.com/DragoonAethis/itch-dl) by Dragoon Aethis (MIT) and
+[itch-dl](https://github.com/DragoonAethis/itch-dl) by Dragoon Aethis (MIT),
 [Flask](https://flask.palletsprojects.com/) by the Pallets team (BSD-3-Clause),
-the web server that powers the NextSync HTTP bridge.
+the web server that powers the NextSync HTTP bridge, and
+[Send2Trash](https://github.com/arsenetar/send2trash) by Andrew Senetar and
+contributors (BSD), which sends locally-deleted files to the system Recycle
+Bin / Trash.
 
 ## Legal disclaimer — third-party content
 

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,29 +1,29 @@
 # ZX-Next-Unite dependencies.
 # Install everything with:  python -m pip install -r requirements.txt
 
-# Required — the GUI toolkit the whole app is built on.
+# Required - the GUI toolkit the whole app is built on.
 PySide6>=6.5.1
 
-# Optional — enables the retro 8-bit pygame log windows and the
+# Optional - enables the retro 8-bit pygame log windows and the
 # "Alien Floyd's" background/tab. The app runs fine without it.
 pygame-ce>=2.5.0
 
-# Optional — enables the itch.io tab (browse/install your itch.io
+# Optional - enables the itch.io tab (browse/install your itch.io
 # collections). The tab is only shown when this package is installed.
 itch-dl
 
-# Optional — sends files deleted in the local file explorers to the system
+# Optional - sends files deleted in the local file explorers to the system
 # Recycle Bin / Trash instead of removing them permanently (Settings toggle,
 # on by default; greyed out until this package is installed).
 Send2Trash
 
-# Optional — enables the NextSync HTTP bridge: a small self-hosted web
+# Optional - enables the NextSync HTTP bridge: a small self-hosted web
 # server (Settings toggle in the app, or "nextsync5.py -w") that lets a
 # Spectrum Next running the built-in .http dot command (or curl) drive the
 # file system of the Next connected in '.sync5 -listen' mode. The Settings
 # toggle is greyed out until this package is installed.
 flask
 
-# Dev-only — linter/formatter (config in pyproject.toml). Not needed to run
+# Dev-only - linter/formatter (config in pyproject.toml). Not needed to run
 # the app: used by contributors to keep new code clean ("ruff check .").
 ruff

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -1621,6 +1621,7 @@ class MainWindow(QMainWindow):
             self.button_to_image.setDisabled(True)
             self.image_treeview.setDisabled(True)
             self.button_new_folder.setDisabled(True)
+            self.button_rename.setDisabled(True)
             self.button_delete_files.setDisabled(True)
             self.new_folder_input.setDisabled(True)
             self.button_create_directory.setDisabled(True)
@@ -1658,6 +1659,7 @@ class MainWindow(QMainWindow):
             self.button_to_image.setDisabled(False)
             self.image_treeview.setDisabled(False)
             self.button_new_folder.setDisabled(False)
+            self.button_rename.setDisabled(False)
             self.button_delete_files.setDisabled(False)
             self.new_folder_input.setDisabled(False)
             self.button_create_directory.setDisabled(False)
@@ -1937,6 +1939,7 @@ class MainWindow(QMainWindow):
             the automatic download or the manual-drop fallback)."""
             self._hdfmonkey_executable_path = hdfmonkey_path
             self.button_new_folder.setVisible(True)
+            self.button_rename.setVisible(True)
             self.button_delete_files.setVisible(True)
             self.download_and_install_hdfmonkey_button.setVisible(False)
             # hdfmonkey is now installed — stop the yellow attention pulse and
@@ -2102,6 +2105,7 @@ class MainWindow(QMainWindow):
         def show_hdf_monkey_download_and_install_buttons():
             self.download_and_install_hdfmonkey_button.setVisible(True)
             self.button_new_folder.setVisible(False)
+            self.button_rename.setVisible(False)
             self.button_delete_files.setVisible(False)
             # Draw the eye to the install button with a yellow 'breathing' pulse
             # while hdfmonkey is missing; it stops itself once the button is
@@ -4885,6 +4889,7 @@ class MainWindow(QMainWindow):
             if right_disk_image_explorer_content:  # check that we have an image content first
                 # hide create folder and delete folder buttons
                 self.button_new_folder.setVisible(False)
+                self.button_rename.setVisible(False)
                 self.button_delete_files.setVisible(False)
                 self.new_folder_input.setVisible(True)
                 self.button_create_directory.setVisible(True)
@@ -4902,6 +4907,7 @@ class MainWindow(QMainWindow):
             if right_disk_image_explorer_content:  # check that we have an image content first
                 # hide create folder and delete folder buttons
                 self.button_new_folder.setVisible(True)
+                self.button_rename.setVisible(True)
                 self.button_delete_files.setVisible(True)
                 self.new_folder_input.setVisible(False)
                 self.button_create_directory.setVisible(False)
@@ -4943,6 +4949,7 @@ class MainWindow(QMainWindow):
                 return
 
             self.button_new_folder.setVisible(True)
+            self.button_rename.setVisible(True)
             self.button_delete_files.setVisible(True)
             self.new_folder_input.setVisible(False)
             self.button_create_directory.setVisible(False)
@@ -8430,6 +8437,11 @@ class MainWindow(QMainWindow):
         self.button_new_folder.setMinimumWidth(IMAGE_BUTTONS_SIZE)
         self.button_new_folder.clicked.connect(image_newfolder)
 
+        self.button_rename = QPushButton("Rename", self)
+        self.button_rename.setText("Rename")
+        self.button_rename.setMinimumWidth(IMAGE_BUTTONS_SIZE)
+        self.button_rename.clicked.connect(image_rename_dialog)
+
         self.download_and_install_hdfmonkey_button = QPushButton("Download & install HDF Monkey", self)
         self.download_and_install_hdfmonkey_button.setText("Download and install HDF Monkey")
         self.download_and_install_hdfmonkey_button.setMinimumWidth(IMAGE_BUTTONS_SIZE)
@@ -8441,11 +8453,12 @@ class MainWindow(QMainWindow):
         self.imageexplorerbuttons.addWidget(self.hiddenspacelabel2)
 
         self.button_delete_files = QPushButton("DeleteFiles", self)
-        self.button_delete_files.setText("Delete Files or Folder")
+        self.button_delete_files.setText("Delete")
         self.button_delete_files.setMinimumWidth(IMAGE_BUTTONS_SIZE)
         self.button_delete_files.clicked.connect(delete_files_button_show_confirmation_buttons)
 
         self.imageexplorerbuttons.addWidget(self.button_new_folder)
+        self.imageexplorerbuttons.addWidget(self.button_rename)
         self.imageexplorerbuttons.addWidget(self.button_delete_files)
 
         self.imageexplorerbuttons.addWidget(self.download_and_install_hdfmonkey_button)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.1.0"
+ZX_NEXT_UNITE_VERSION = "9.1.1"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_gallery.py
+++ b/zxnu_gallery.py
@@ -1693,9 +1693,19 @@ class GalleryItemViewer(QWidget):
     Close: ✕ button (top-right) or Escape key → pops stack back to index 0.
     """
 
+    # On some Linux Qt/fontconfig stacks a QPushButton that carries a style
+    # sheet but pins no font-size lets a leading colour-emoji (⬇ 💾 🕹 🔁 🌐 …)
+    # fall back to Noto Color Emoji's native bitmap strike — the glyph then
+    # renders enormously and swamps the whole button. Pinning a font-size in the
+    # style sheet scales the emoji back to the text size (the viewer's globe /
+    # heart / close QToolButtons already do this and render fine). Windows and
+    # macOS size these emoji correctly and should keep the platform-default
+    # button font, so the pin is applied on Linux only.
+    _BTN_FONT_SIZE = " font-size: 13px;" if sys.platform.startswith("linux") else ""
     _BTN_STYLE = (
         "QPushButton { color: #eee; background: #2a2a2a; border: 1px solid #444;"
-        " border-radius: 4px; padding: 6px 12px; text-align: left; }"
+        " border-radius: 4px; padding: 6px 12px; text-align: left;"
+        f"{_BTN_FONT_SIZE} }}"
         "QPushButton:hover { background: #3a3a3a; border-color: #666; }"
         "QPushButton:disabled { color: #555; background: #1a1a1a; border-color: #333; }"
     )

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -467,6 +467,12 @@ class RemoteExplorerWidget(QWidget):
         self.btn_to_local.setToolTip("Download the selected Next item(s) to the local folder (get)")
         self.btn_to_local.clicked.connect(self._get_selected)
 
+        # QTimer driving the soft green "breathing" glow on the two transfer
+        # arrow buttons while the Remote Explorer view is visible, mirroring the
+        # SD Card tab's transfer-arrow pulse (_start_transfer_idle_animation).
+        # Started/stopped from showEvent/hideEvent; None while stopped.
+        self._arrow_pulse_timer = None
+
         centre_box = QVBoxLayout()
         centre_box.setAlignment(Qt.AlignCenter)
         centre_box.addWidget(self.btn_to_next)
@@ -584,6 +590,72 @@ class RemoteExplorerWidget(QWidget):
         grid.setRowStretch(0, 1)
 
         self._set_connected(False)
+
+    # ==================================================================
+    #  transfer-arrow "breathing" pulse (mirrors the SD Card tab)
+    # ==================================================================
+    def showEvent(self, event):
+        # The view became visible (Remote Explorer sub-view selected and the
+        # NextSync tab in front): start the green pulse, exactly like the SD
+        # Card tab kicks its transfer-arrow glow when it becomes the active tab.
+        super().showEvent(event)
+        self._start_arrow_pulse()
+
+    def hideEvent(self, event):
+        # Hidden (returned to classic sync, or switched to another tab): stop
+        # the pulse and restore the buttons' normal look.
+        super().hideEvent(event)
+        self._stop_arrow_pulse()
+
+    def _start_arrow_pulse(self):
+        """Start a soft, continuously-looping green 'breathing' background pulse
+        on the two transfer-arrow buttons (Send '->:' / Get ':<-'), matching the
+        SD Card tab's _start_transfer_idle_animation. The pulse rewrites each
+        button's background colour on a QTimer (always visible, unlike a
+        QGraphicsEffect, and it leaves the tiny arrow text untouched). Safe to
+        call repeatedly; it restarts cleanly."""
+        self._stop_arrow_pulse()
+
+        # Triangle wave over (2*steps) ticks -> a smooth fade up and down. The
+        # two buttons are offset by half a cycle so they breathe out of phase.
+        steps = 22
+        phase = {"n": 0}
+
+        def _alpha_for(pos):
+            pos %= (2 * steps)
+            tri = pos / steps if pos <= steps else (2 * steps - pos) / steps
+            return int(150 * tri)
+
+        def _tick():
+            phase["n"] = (phase["n"] + 1) % (2 * steps)
+            for btn, off in ((self.btn_to_next, 0), (self.btn_to_local, steps)):
+                a = _alpha_for(phase["n"] + off)
+                try:
+                    btn.setStyleSheet(
+                        "QPushButton { "
+                        f"background-color: rgba(46,204,113,{a}); "
+                        f"border: 1px solid rgba(46,204,113,{min(a + 60, 255)}); "
+                        "border-radius: 4px; }")
+                except RuntimeError:
+                    pass
+
+        timer = QTimer(self)
+        timer.setInterval(55)
+        timer.timeout.connect(_tick)
+        timer.start()
+        self._arrow_pulse_timer = timer
+
+    def _stop_arrow_pulse(self):
+        """Stop the breathing pulse and restore the buttons' normal appearance."""
+        timer = getattr(self, "_arrow_pulse_timer", None)
+        if timer is not None:
+            timer.stop()
+            self._arrow_pulse_timer = None
+        for btn in (self.btn_to_next, self.btn_to_local):
+            try:
+                btn.setStyleSheet("")
+            except RuntimeError:
+                pass
 
     # ==================================================================
     #  command queue  (counts toward the running operation, if any)


### PR DESCRIPTION
Bumps to **v9.1.1**. Six self-contained changes (one commit each):

- **SD Card explorer** — new **Rename** button between *New Folder* and *Delete* on the disk-image explorer, wired to the existing `image_rename_dialog` (same handler as F2 / the tree context menu) and mirrored through every enable/disable and visibility toggle. *"Delete Files or Folder"* shortened to **Delete**, matching the Remote Explorer's *New folder / Rename / Delete* trio.
- **Remote Explorer** — the `->:` / `:<-` transfer arrows now show the same green *breathing* pulse as the SD Card tab, driven from the widget's show/hide events (runs only while the RE view is visible).
- **Gallery item viewer (Linux)** — fix oversized colour-emoji on the action buttons (Download / Send to SD card / Launch CSpect·Mame / Send via NextSync / Open on website). A styled `QPushButton` with no pinned `font-size` let the emoji fall back to Noto Color Emoji's native bitmap strike. Pin a `font-size` in `_BTN_STYLE` on **Linux only**; Windows/macOS keep the byte-identical stylesheet.
- **README** — credit **Send2Trash** in the license section (was listing itch-dl and Flask only).
- **REQUIREMENTS.txt** — replace UTF-8 em-dashes (rendered as `ΓÇö` under the Windows OEM code page) with ASCII hyphens.
- **Version** — 9.1.0 → 9.1.1.

The GitHub wiki's Send2Trash attribution was updated separately (already pushed).

Verification: `python tests/run_all.py` — all 7 suites pass; offscreen headless check confirmed the RE pulse starts on show / clears on hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)