### PR TITLE
zx99: fix oversized emoji on Retro item-viewer buttons (Linux)

### DIFF
--- a/zxnu_pygame.py
+++ b/zxnu_pygame.py
@@ -470,6 +470,14 @@ def _draw_text_mixed(surface, s, x, y, base_font, color):
                     img = None
         if img is None:
             continue
+        # Colour-emoji fallback fonts (e.g. Noto Color Emoji on Linux) render
+        # their glyphs at a fixed native bitmap strike, ignoring the requested
+        # pixel size, so an emoji run can come back many times taller than the
+        # surrounding text and swamp the line — the retro-mode "big icons".
+        # Shrink an oversized fallback-font run back down to the base line
+        # height (aspect preserved) before blitting.
+        if f is not base_font and img.get_height() > base_h:
+            img = _scale_keep_aspect(img, img.get_width(), base_h)
         h = img.get_height()
         oy = (base_h - h) // 2 if f is not base_font else 0
         surface.blit(img, (cur_x, int(y) + oy))


### PR DESCRIPTION
Follow-up to the Classic-mode fix in v9.1.1. In **Retro mode** the gallery item viewer draws its action buttons on a pygame surface (not Qt), so the earlier stylesheet fix didn't apply and the emoji were still huge on Linux.

**Root cause:** button labels flow through the shared `_draw_text` → `_draw_text_mixed` renderer, which selects a per-glyph fallback font for emoji. On Linux that fallback is **Noto Color Emoji**, whose colour glyphs render at a fixed native bitmap strike (~128px) regardless of the requested pixel size — the pygame analog of the Qt bug — and the run was blitted at full size.

**Fix** (`zxnu_pygame.py`): in `_draw_text_mixed`, shrink an oversized *fallback-font* glyph run to the base line height (aspect preserved, via the existing `_scale_keep_aspect`) before blitting. Only fires when a fallback glyph exceeds the line height, so normal text, arrows (◀▶✕♥) and monochrome symbols are untouched, and platforms that already size emoji correctly are unaffected. Being the shared retro text primitive, this fixes every retro emoji consistently.

**Verification:** headless test confirmed a stand-in 128px colour-emoji strike scales to the exact 16px line height with surrounding text unchanged; full `tests/run_all.py` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)