### PR TITLE
Remove dead self._zxart_cache_poll_timer.stop() call

### DIFF
--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -10483,9 +10483,6 @@ class MainWindow(QMainWindow):
         if ZX_NEXT_UNITE_SHOW_ZXART_PANE:
             wid_inner.tab.addTab(zxnextunite_ZXART_tab, ZX_NEXT_UNITE_TAB_TITLE_ZXART)
         else:
-            # Stop the poll timer before unparenting so it never fires against
-            # the destroyed child widgets (zxart_cache_progress_bar etc.).
-            self._zxart_cache_poll_timer.stop()
             zxnextunite_ZXART_tab.setParent(None)
 
         # Create ZXDB Tab (right of zxART)


### PR DESCRIPTION
## What

Deletes the orphaned `self._zxart_cache_poll_timer.stop()` call (and its stale comment) in the `ZX_NEXT_UNITE_SHOW_ZXART_PANE == False` branch of `MainWindow.__init__`.

## Why

The zxART **catalog-cache progress** feature — the `_zxart_catalog_downloading` / `_zxart_catalog_download_progress` globals, the `zxart_cache_progress_bar` QProgressBar, and the `_zxart_cache_poll_timer` QTimer — was added in `f2111a67` and **fully removed in `1e603692`** when the upfront catalog prefetch was retired (`zxart_client_search` switched to a server-side title filter).

That removal left behind the timer's `.stop()` call, which references `self._zxart_cache_poll_timer` — an attribute that is **now never assigned anywhere** in the codebase. Because the branch only runs when the zxART pane is hidden via the feature flag (which defaults to `True`), it never fired in normal use, but flipping the flag off raised:

```
AttributeError: 'MainWindow' object has no attribute '_zxart_cache_poll_timer'
```

at `MainWindow` construction. The `else` branch now simply unparents the tab, matching the ZXDB tab's branch immediately below it.

## Verification

- **Offscreen launch with the pane disabled** (isolated scratch config): `MainWindow` constructs with no `AttributeError`, zxART tab absent, GetIt tab present.
- **Negative check**: re-injecting the old line reproduces the exact `AttributeError`, confirming the guard is meaningful.
- `ruff check .` — clean.
- `python tests/run_all.py` — all 8 test files pass (incl. the 7-phase offscreen UI suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)