### PR TITLE
Add Get-PyLineCounts.ps1 dev helper

### DIFF
--- a/Get-PyLineCounts.ps1
+++ b/Get-PyLineCounts.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+    List every .py file with its line count (like
+    `type file.py | Measure-Object -Line`, but for all .py files).
+
+.EXAMPLE
+    .\Get-PyLineCounts.ps1
+    .\Get-PyLineCounts.ps1 -Recurse
+    .\Get-PyLineCounts.ps1 -Path tests -Recurse
+#>
+[CmdletBinding()]
+param(
+    [string]$Path = '.',
+    [switch]$Recurse
+)
+
+$results = Get-ChildItem -Path $Path -Filter *.py -File -Recurse:$Recurse |
+    ForEach-Object {
+        [pscustomobject]@{
+            Lines = (Get-Content -LiteralPath $_.FullName | Measure-Object -Line).Lines
+            File  = (Resolve-Path -LiteralPath $_.FullName -Relative)
+        }
+    } | Sort-Object Lines -Descending
+
+$results | Format-Table -AutoSize
+
+$total = ($results | Measure-Object -Property Lines -Sum).Sum
+"Total: {0:N0} lines across {1} file(s)" -f $total, @($results).Count


### PR DESCRIPTION
## What

Adds `Get-PyLineCounts.ps1`, a small PowerShell dev utility that lists every `.py` file with its line count.

## Details

- Per-file `Get-Content | Measure-Object -Line` (same approach as `type file.py | Measure-Object -Line`), sorted descending, with a grand total.
- `-Path <dir>` to target a different folder; `-Recurse` to include subdirectories.

```powershell
.\Get-PyLineCounts.ps1
.\Get-PyLineCounts.ps1 -Path tests -Recurse
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)