### PR TITLE
README: link the new per-tab User Manual on the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ the **[Wiki](https://github.com/jclauzel/ZX-Next-Unite/wiki)**:
 
 - [Home / overview](https://github.com/jclauzel/ZX-Next-Unite/wiki)
 - [Installation](https://github.com/jclauzel/ZX-Next-Unite/wiki/Installation)
+- 📖 **[User Manual](https://github.com/jclauzel/ZX-Next-Unite/wiki/User-Manual)**
+  — **new:** a page per tab, with screenshots, aimed at first-time users. What
+  each tab is for, a quick start, and a reference for every control:
+  [SD Card Utility](https://github.com/jclauzel/ZX-Next-Unite/wiki/SD-Card-Utility-tab) ·
+  [NextSync](https://github.com/jclauzel/ZX-Next-Unite/wiki/NextSync-tab) ·
+  [Unite!](https://github.com/jclauzel/ZX-Next-Unite/wiki/Unite-tab) ·
+  [GetIt](https://github.com/jclauzel/ZX-Next-Unite/wiki/GetIt-tab) ·
+  [ZXArt.ee](https://github.com/jclauzel/ZX-Next-Unite/wiki/zxArt-tab) ·
+  [ZXDB/ZXInfo.dk](https://github.com/jclauzel/ZX-Next-Unite/wiki/ZXDB-tab) ·
+  [itch.io](https://github.com/jclauzel/ZX-Next-Unite/wiki/itch-io-tab) ·
+  [Favorites](https://github.com/jclauzel/ZX-Next-Unite/wiki/Favorites-tab) ·
+  [Alien Floyd's](https://github.com/jclauzel/ZX-Next-Unite/wiki/Alien-Floyds-tab) ·
+  [Settings](https://github.com/jclauzel/ZX-Next-Unite/wiki/Settings-tab) ·
+  [Help](https://github.com/jclauzel/ZX-Next-Unite/wiki/Help-tab)
 
 ## License
 


### PR DESCRIPTION
The wiki now carries a **User Manual**: an overview page plus one page per tab,
each with what the tab is for, a quick start, a reference for every control, and
a screenshot.

This adds a pointer to it from the README's Documentation section, so it is
findable from the repo front page. No code changes.

**Wiki pages added** (in a separate commit to the `.wiki` repo):
[User Manual](https://github.com/jclauzel/ZX-Next-Unite/wiki/User-Manual) ·
SD Card Utility · NextSync · Unite! · GetIt · ZXArt.ee · ZXDB/ZXInfo.dk ·
itch.io · Favorites · Alien Floyd's · Settings · Help, plus a `_Sidebar` for
wiki-wide navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)