### PR TITLE
Coverage runner + worker/widget test suites; fix image-rename crash; v9.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ zx-next-unite.log.*
 # Local CSpect plugin downloads (UART Replacement etc.), kept out of the repo
 CSpectPlugins-*.zip
 CSpectPlugins-*/
+
+# Coverage artifacts from `python tests/run_all.py --coverage`
+# (data files land in tests/; .coveragerc itself is tracked)
+.coverage
+.coverage.*
+tests/htmlcov/

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -27,3 +27,8 @@ flask
 # Dev-only - linter/formatter (config in pyproject.toml). Not needed to run
 # the app: used by contributors to keep new code clean ("ruff check .").
 ruff
+
+# Dev-only - line-coverage measurement for the test suite
+# ("python tests/run_all.py --coverage", config in tests/.coveragerc).
+# Not needed to run the app.
+coverage

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,39 @@
+# Coverage configuration for the opt-in coverage run:
+#
+#     python tests/run_all.py --coverage
+#
+# run_all.py exports COVERAGE_PROCESS_START pointing at this file and prepends
+# tests/covhook/ (whose sitecustomize.py calls coverage.process_startup()) to
+# PYTHONPATH, so EVERY Python process the suites spawn — including the
+# offscreen UI suite's phase subprocesses and the scratch copy of
+# zx-next-unite.py they run — measures itself and drops a parallel data file
+# next to tests/.coverage (COVERAGE_FILE).
+
+[run]
+parallel = true
+# Measure only the application modules; the test scripts and their mock
+# Nexts/dots are the harness, not the subject. rc_backgrounds.py is
+# auto-generated, so it is deliberately not listed.
+include =
+    */zx-next-unite.py
+    */zxnu_*.py
+    */nextsync5.py
+# Many child processes (mock dots, skipped phases) touch none of the files
+# above; that is expected, not worth a warning per process.
+disable_warnings = no-data-collected
+
+[paths]
+# Fold the offscreen UI suite's scratch copy (%TEMP%/zxnu-ui-tests/
+# zx-next-unite.py) back onto the repo file when combining. run_all.py runs
+# `coverage combine` from the repo root, so "." is the repo.
+app =
+    .
+    */zxnu-ui-tests
+
+[report]
+precision = 1
+# Lowest coverage first: the files most at risk sit at the top of the table.
+sort = cover
+
+[html]
+directory = tests/htmlcov

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,19 +11,43 @@ scripts printing `PASS`/`FAIL` lines and exiting non-zero on failure — no
 pytest dependency. Every suite runs in its own process (they monkey-patch Qt
 and the import system, so isolation matters).
 
+## Coverage
+
+```
+python tests/run_all.py --coverage
+```
+
+measures line coverage of the application modules (`zx-next-unite.py`,
+`zxnu_*.py`, `nextsync5.py`) across the whole run and prints a per-file table
+(worst-covered first), plus an annotated-source HTML report in
+`tests/htmlcov/`. Needs [coverage.py](https://coverage.readthedocs.io/)
+(`python -m pip install coverage`); config lives in `tests/.coveragerc`.
+
+Child processes are measured too: `run_all.py` exports
+`COVERAGE_PROCESS_START` and injects `tests/covhook/sitecustomize.py` via
+`PYTHONPATH`, so every Python process the suites spawn self-measures — and the
+`[paths]` section of `.coveragerc` folds the offscreen UI suite's scratch copy
+of `zx-next-unite.py` back onto the repo file when the data is combined. App
+modules never imported by any suite produce no data at all (they can't appear
+as 0% rows), so the runner names them explicitly after the table. Coverage is
+reporting only; it never changes the exit code.
+
 | File | What it covers | Needs |
 |---|---|---|
 | `test_api_parsers.py` | Unit tests for `zxnu_api` — the pure GetIt/ZXDB/zxArt parsers, URL builders and download-URL filters. No network, no QApplication. | PySide6 importable (via `zxnu_config`) |
+| `test_pane_imports.py` | Free-variable tripwire for the extracted pane builders (`zxnu_zxdb_pane`, `zxnu_zxart_pane`, `zxnu_unite_pane`, …): asserts every name each builder uses resolves via its params, imports or star exports — catching the star-import-skips-underscores trap. | PySide6 |
+| `test_hdf_workers.py` | Headless unit tests for the SD-Card tab's operation layer in `zxnu_workers` — the hdfmonkey transfer/delete worker bodies (`_run_get_task`, `_run_put_task`, `_run_put_external_task`, `_run_delete_task`), their recursive scan helpers, `is_directory` and the path/zip-name helpers. hdfmonkey is replaced by an in-memory fake image, so the full-disk detection, mkdir-exists ls fallback, cancel and error-continuation branches all run deterministically with no external tool, HDF file, or display. | PySide6 |
 | `test_classic_sync.py` | The classic (Sync3/Sync4) NextSync server loop (`zxnu_workers.run_classic_sync_server`) over localhost against a mock dot: Sync4 handshake, chunked PC→Next pull honouring `max_payload`, Next→PC framed upload, conflict policies (overwrite/ignore), syncpoint bookkeeping and hostile-path sanitation. | PySide6 importable |
 | `test_listen.py` | The Sync4 `-listen` wire protocol of the standalone server (`nextsync5.listen_session`) over a socketpair against a mock Next implementing the dot's half: ls/get/put/mkdir/rmdir/rm framing, checksums, retries. | PySide6-free (pure stdlib) |
 | `test_remote_listen.py` | The app-side `-listen` worker (`zxnu_workers.run_remote_listen_server`) over a real localhost socket against the same mock Next: command queue in, Qt signals out, incl. rmtree walks, drives/free/rcpy/rfsize, failure paths. | PySide6 |
+| `test_remote_explorer_widget.py` | Offscreen widget-layer tests for `zxnu_remote_explorer.RemoteExplorerWidget` (the NextSync tab's dual-pane file manager) — the counterpart of `test_remote_listen.py`'s worker-side coverage. A real widget under `QT_QPA_PLATFORM=offscreen` is driven through its seam: outgoing commands recorded from the injected `enqueue`, worker replies hand-fed via the `on_*` slots, `QInputDialog`/`QMessageBox` replaced by scripted fakes. Covers connection/drive state, listing + sort persistence, navigation and ls-failure fallback, the operation lifecycle (block/cancel/disconnect/background-rcpy overlay), get/put transfers, copy/cut/paste in all four directions with move markers, the rcpy free-space precheck, sync-root handling, local file ops (incl. a zip round-trip) and drag & drop. | PySide6 |
 | `test_http_bridge.py` | End-to-end HTTP bridge (`zxnu_http_bridge`) against the mock Next, over both hosts: real HTTP → bridge → app worker, and real HTTP → bridge → `nextsync5.listen_session`. | PySide6, Flask (skipped by `run_all.py` when Flask is missing) |
 | `test_retro_log_widget.py` | `RetroLogWidget.set_text_color` unit checks (hex/tuple parsing, clamping, fallback to phosphor green, per-instance tint). Uses the REAL Qt platform — pygame-adjacent widgets crash under offscreen Qt — but never shows a window. | PySide6 |
 | `test_ui_offscreen.py` | Offscreen end-to-end UI suite: launches a COPY of `zx-next-unite.py` (own scratch dir + `hdfg.cfg` under the OS temp folder — the real config is never touched) under `QT_QPA_PLATFORM=offscreen` and drives the real widgets. Seven phases: (1) SD Card tab path rows, Up/Refresh, local + in-image path navigation on a generated test HDF, persistence to `hdfg.cfg`, Settings color picker; (2) startup restore of the saved in-image path + retro-log color; (3) startup fallback for a missing saved path; (4) NextSync classic explorer drag & drop; (5) watched-folder delete regression (full deletion, zero `QFileSystemWatcher` access-denied warnings); (6) self-update Settings toggle + the ".sync5 dot updated" advisory popup; (7) dotN advisory first-run silent persist and the toggle's default-ON. Every phase disables the GitHub release check (or quits before it fires), so the suite never touches the network. | PySide6; phases 1–3 additionally need **hdfmonkey** (PATH or a populated `downloads/` folder — gitignored) and SKIP cleanly without it |
 
 Notes:
 
-- `test_ui_offscreen.py` without arguments runs all five phases in separate
+- `test_ui_offscreen.py` without arguments runs all seven phases in separate
   subprocesses (a fresh `QApplication` per phase); pass a phase number to run
   just one, e.g. `python tests/test_ui_offscreen.py 5`. Phase 1 builds the
   scratch state (including the test HDF) that phases 2–3 reuse.

--- a/tests/covhook/sitecustomize.py
+++ b/tests/covhook/sitecustomize.py
@@ -1,0 +1,16 @@
+"""Coverage subprocess hook (see tests/.coveragerc).
+
+tests/run_all.py --coverage prepends this directory to PYTHONPATH so that
+every Python process started while the suite runs — the per-suite processes,
+the offscreen UI phases and the scratch app copy they launch — calls
+coverage.process_startup() at interpreter startup and measures itself.
+
+process_startup() is a no-op unless COVERAGE_PROCESS_START is set in the
+environment, so importing this module outside a coverage run does nothing.
+"""
+try:
+    import coverage
+except ImportError:      # coverage not installed: plain test run, no-op
+    pass
+else:
+    coverage.process_startup()

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -1,6 +1,6 @@
 """Run the whole ZX-Next-Unite test suite and print one summary.
 
-Usage:  python tests/run_all.py
+Usage:  python tests/run_all.py [--coverage]
 
 Each test file is run in its own process (they patch/monkey with Qt and
 sys.meta_path, so isolation matters). Suites whose optional dependency is
@@ -8,8 +8,17 @@ missing are reported as SKIPPED rather than failed:
   - test_http_bridge.py needs Flask (the bridge itself is optional in-app)
   - test_ui_offscreen.py phases 1-3 skip internally without hdfmonkey
 
-Exit code: 0 when nothing failed (skips allowed), 1 otherwise.
+--coverage measures line coverage of the application modules
+(zx-next-unite.py, zxnu_*.py, nextsync5.py) across every suite INCLUDING
+their child processes: the offscreen UI phases run a scratch copy of
+zx-next-unite.py, which tests/.coveragerc folds back onto the repo file.
+Prints a per-file table (worst first) and writes an annotated-source HTML
+report to tests/htmlcov/. Needs coverage.py: python -m pip install coverage
+
+Exit code: 0 when nothing failed (skips allowed), 1 otherwise. Coverage is
+reporting only — it never changes the exit code.
 """
+import glob
 import importlib.util
 import os
 import subprocess
@@ -17,18 +26,47 @@ import sys
 import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
 
 SUITES = [
     # (file, timeout seconds, required import or None)
     ("test_api_parsers.py",     120, None),
     ("test_pane_imports.py",    120, None),
+    ("test_hdf_workers.py",     120, None),
     ("test_classic_sync.py",    180, None),
     ("test_listen.py",          120, None),
     ("test_remote_listen.py",   120, None),
+    ("test_remote_explorer_widget.py", 180, None),
     ("test_http_bridge.py",     240, "flask"),
     ("test_retro_log_widget.py", 120, None),
-    ("test_ui_offscreen.py",    3600, None),   # runs its 5 phases itself
+    ("test_ui_offscreen.py",    3600, None),   # runs its 7 phases itself
 ]
+
+WITH_COVERAGE = "--coverage" in sys.argv[1:]
+unknown = [a for a in sys.argv[1:] if a != "--coverage"]
+if unknown:
+    sys.exit(f"unknown argument(s): {' '.join(unknown)} — only --coverage is supported")
+
+child_env = None
+if WITH_COVERAGE:
+    if importlib.util.find_spec("coverage") is None:
+        sys.exit("--coverage needs coverage.py:  python -m pip install coverage")
+    # Stale data files from an aborted earlier run would pollute the combine.
+    # (.coverage / .coverage.* only — never the .coveragerc config next door.)
+    for stale in ([os.path.join(HERE, ".coverage")]
+                  + glob.glob(os.path.join(HERE, ".coverage.*"))):
+        try:
+            os.remove(stale)
+        except OSError:
+            pass
+    child_env = dict(os.environ)
+    child_env["COVERAGE_PROCESS_START"] = os.path.join(HERE, ".coveragerc")
+    child_env["COVERAGE_FILE"] = os.path.join(HERE, ".coverage")
+    # sys.monitoring measurement core: near-zero overhead on Python 3.12+.
+    # coverage falls back (with a warning) where it is unsupported.
+    child_env.setdefault("COVERAGE_CORE", "sysmon")
+    child_env["PYTHONPATH"] = (os.path.join(HERE, "covhook") + os.pathsep
+                               + child_env.get("PYTHONPATH", ""))
 
 results = []
 for name, timeout, needs in SUITES:
@@ -40,7 +78,7 @@ for name, timeout, needs in SUITES:
     t0 = time.monotonic()
     try:
         rc = subprocess.call([sys.executable, os.path.join(HERE, name)],
-                             timeout=timeout)
+                             timeout=timeout, env=child_env)
     except subprocess.TimeoutExpired:
         print(f"TIMED OUT after {timeout}s")
         rc = 1
@@ -53,4 +91,28 @@ failed = False
 for name, status, secs in results:
     print(f"{name.ljust(width)}  {status}  ({secs:5.1f}s)")
     failed = failed or status == "FAIL"
+
+if WITH_COVERAGE:
+    print("\n======== coverage ========", flush=True)
+    cov = [sys.executable, "-m", "coverage"]
+    rcfile = "--rcfile=" + os.path.join(HERE, ".coveragerc")
+    # cwd=REPO: the [paths] remap in .coveragerc resolves "." to the repo root.
+    if subprocess.call(cov + ["combine", rcfile], cwd=REPO, env=child_env) == 0:
+        subprocess.call(cov + ["report", rcfile], cwd=REPO, env=child_env)
+        subprocess.call(cov + ["html", rcfile], cwd=REPO, env=child_env)
+        # App modules no suite ever imported produce no data at all, so they
+        # are invisible in the table above — name them rather than hide them.
+        from coverage import CoverageData
+        data = CoverageData(os.path.join(HERE, ".coverage"))
+        data.read()
+        measured = {os.path.basename(f) for f in data.measured_files()}
+        app_files = sorted(["zx-next-unite.py", "nextsync5.py"]
+                           + [os.path.basename(p)
+                              for p in glob.glob(os.path.join(REPO, "zxnu_*.py"))])
+        unmeasured = [f for f in app_files if f not in measured]
+        if unmeasured:
+            print("\nNever imported by any suite (0%, absent from the table above):")
+            for f in unmeasured:
+                print(f"  {f}")
+
 sys.exit(1 if failed else 0)

--- a/tests/test_hdf_workers.py
+++ b/tests/test_hdf_workers.py
@@ -1,0 +1,416 @@
+"""Headless unit tests for the hdfmonkey transfer/delete worker bodies in
+zxnu_workers (_run_get_task / _run_put_task / _run_put_external_task /
+_run_delete_task, their scan helpers, is_directory and the small path/zip
+helpers). This is the SD-Card tab's operation layer — the code HdfTaskWorker
+runs on the thread pool — which until now was only exercised end-to-end by
+the offscreen UI suite, and only with a real hdfmonkey on a real image.
+
+Here hdfmonkey is replaced by an in-memory fake image (a nested dict behind
+an execute_hdf_monkey-compatible callable), so every branch — including the
+full-disk detection, the mkdir-already-exists ls fallback and the
+cancel/error paths a healthy image never hits — runs deterministically with
+no external tool, no HDF file and no display."""
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import threading
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from PySide6.QtCore import QCoreApplication, Qt
+from zxnu_config import UP_DIRECTORY
+from zxnu_workers import (HdfTaskSignals, _run_delete_task, _run_get_task,
+                          _run_put_external_task, _run_put_task,
+                          get_parent_root_directory_splited, is_directory,
+                          zip_unique_name)
+
+ok = True
+
+
+def check(label, cond, detail=""):
+    global ok
+    print(f"{'PASS' if cond else 'FAIL'} {label}"
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        ok = False
+
+
+class FakeResult:
+    def __init__(self, returncode, stdout=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+class FakeImage:
+    """In-memory stand-in for a FAT image driven through hdfmonkey. Dirs are
+    dicts, files are bytes. Mimics the behaviours the worker bodies rely on:
+    ls prints "[DIR]\\tname" / "<size>\\tname" lines, mkdir cannot create
+    intermediate directories, rm refuses a non-empty directory, and a full
+    disk answers "Access denied" to put/mkdir."""
+
+    def __init__(self, tree=None, full_disk=False):
+        self.tree = {} if tree is None else tree
+        self.full_disk = full_disk
+        self.calls = []           # (command, *extra_argv) in execution order
+        self.fail_paths = set()   # rm/put on these: rc=1 with a generic error
+        self.raise_paths = set()  # any command on these: raises
+
+    def node(self, path):
+        node = self.tree
+        for part in [p for p in path.split("/") if p]:
+            if not isinstance(node, dict) or part not in node:
+                return None
+            node = node[part]
+        return node
+
+    def parent(self, path):
+        parts = [p for p in path.split("/") if p]
+        if not parts:
+            return None, None
+        node = self.tree
+        for part in parts[:-1]:
+            if not isinstance(node, dict) or part not in node:
+                return None, None
+            node = node[part]
+        return (node, parts[-1]) if isinstance(node, dict) else (None, None)
+
+    # Signature-compatible with MainWindow's execute_hdf_monkey.
+    def execute(self, command, image_path, additional_args="", silent=False,
+                extra_argv=None, prompt_if_missing=True):
+        argv = list(extra_argv or [])
+        self.calls.append((command,) + tuple(argv))
+        path = argv[0] if argv else ""
+        if path in self.raise_paths:
+            raise RuntimeError(f"boom on {path}")
+        if command == "ls":
+            node = self.node(path)
+            if not isinstance(node, dict):
+                return FakeResult(1, b"Not a directory\n")
+            lines = [f"[DIR]\t{n}" if isinstance(c, dict) else f"{len(c)}\t{n}"
+                     for n, c in sorted(node.items())]
+            return FakeResult(0, ("\n".join(lines) + "\n").encode())
+        if command == "rm":
+            if path in self.fail_paths:
+                return FakeResult(1, b"Input/output error\n")
+            node = self.node(path)
+            if isinstance(node, dict) and node:
+                return FakeResult(1, b"Directory not empty\n")
+            parent, leaf = self.parent(path)
+            if parent is None or leaf not in parent:
+                return FakeResult(1, b"Not found\n")
+            del parent[leaf]
+            return FakeResult(0)
+        if command == "mkdir":
+            if self.full_disk:
+                return FakeResult(1, b"Access denied\n")
+            parent, leaf = self.parent(path)
+            if parent is None:
+                return FakeResult(1, b"Not found\n")   # no intermediate dirs
+            if leaf in parent:
+                return FakeResult(1, b"File exists\n")
+            parent[leaf] = {}
+            return FakeResult(0)
+        if command == "get":
+            src, dst = argv
+            node = self.node(src)
+            if not isinstance(node, bytes):
+                return FakeResult(1, b"Not found\n")
+            with open(dst, "wb") as f:
+                f.write(node)
+            return FakeResult(0)
+        if command == "put":
+            src, dst = argv
+            if self.full_disk:
+                return FakeResult(1, b"Access denied\n")
+            if dst in self.fail_paths:
+                return FakeResult(1, b"Input/output error\n")
+            parent, leaf = self.parent(dst)
+            if parent is None:
+                return FakeResult(1, b"Not found\n")
+            with open(src, "rb") as f:
+                parent[leaf] = f.read()
+            return FakeResult(0)
+        raise AssertionError(f"unexpected hdfmonkey command: {command}")
+
+
+def make_signals():
+    """An HdfTaskSignals plus a dict recording every emission (direct
+    connections: the worker bodies run synchronously right here)."""
+    sig = HdfTaskSignals()
+    rec = {"progress": [], "status": [], "error": []}
+    sig.progress.connect(rec["progress"].append, Qt.DirectConnection)
+    sig.status.connect(rec["status"].append, Qt.DirectConnection)
+    sig.error.connect(rec["error"].append, Qt.DirectConnection)
+    return sig, rec
+
+
+IS_WINDOWS = os.name == "nt"
+DIR_NAV = "\\" if IS_WINDOWS else "/"
+IMG = "fake.hdf"
+
+
+def test_path_helpers():
+    check("split nested", get_parent_root_directory_splited("/games/sub/f.txt")
+          == ("/games/sub", "f.txt"))
+    check("split root file", get_parent_root_directory_splited("/f.txt")
+          == ("", "f.txt"))
+    check("zip name free", zip_unique_name("demo", set()) == "demo.zip")
+    check("zip name taken", zip_unique_name("demo", {"demo.zip"}) == "demo (2).zip")
+    check("zip name taken twice",
+          zip_unique_name("demo", {"demo.zip", "demo (2).zip"}) == "demo (3).zip")
+
+
+def test_is_directory():
+    img = FakeImage({"games": {"lev": {"a.bin": b"AA"}}, "boot.bas": b"10 GO"})
+    check("dir at root", is_directory(img.execute, IMG, "/games") is True)
+    check("file at root", is_directory(img.execute, IMG, "/boot.bas") is False)
+    check("nested dir", is_directory(img.execute, IMG, "/games/lev") is True)
+    check("nested file", is_directory(img.execute, IMG, "/games/lev/a.bin") is False)
+    check("missing entry", is_directory(img.execute, IMG, "/nowhere") is False)
+
+
+def test_delete():
+    # Full recursive delete: files first, then dirs deepest-first, so every
+    # rm hits an already-empty directory. UP_DIRECTORY rows are filtered and
+    # doubled slashes collapsed.
+    img = FakeImage({"games": {"a.txt": b"A",
+                               "lev": {"b.txt": b"BB", "deep": {"c.txt": b"C"}}},
+                     "top.txt": b"T"})
+    sig, rec = make_signals()
+    _run_delete_task(sig, threading.Event(), img.execute, IMG,
+                     [UP_DIRECTORY, "/games", "//top.txt"])
+    check("delete empties tree", img.tree == {}, repr(img.tree))
+    rm_order = [c[1] for c in img.calls if c[0] == "rm"]
+    check("delete rm order (files, then dirs deepest-first)",
+          rm_order == ["/games/a.txt", "/games/lev/b.txt",
+                       "/games/lev/deep/c.txt", "/top.txt",
+                       "/games/lev/deep", "/games/lev", "/games"],
+          repr(rm_order))
+    check("delete no errors", rec["error"] == [])
+    check("delete progress marquee then 100",
+          rec["progress"][0] == -1 and rec["progress"][-1] == 100,
+          repr(rec["progress"]))
+
+    # An rm that RAISES must emit error and keep deleting the rest; the
+    # parents of the survivor then legitimately fail rm (not empty) — which
+    # the worker treats as silent best-effort, exactly like real hdfmonkey.
+    img = FakeImage({"games": {"a.txt": b"A", "lev": {"b.txt": b"BB"}}})
+    img.raise_paths.add("/games/lev/b.txt")
+    sig, rec = make_signals()
+    _run_delete_task(sig, threading.Event(), img.execute, IMG, ["/games"])
+    check("delete error emitted once",
+          len(rec["error"]) == 1 and "Failed deleting" in rec["error"][0],
+          repr(rec["error"]))
+    check("delete continues past error",
+          img.tree == {"games": {"lev": {"b.txt": b"BB"}}}, repr(img.tree))
+
+    # Cancel mid-phase-2: items 1 and 2 are deleted (cancel lands during
+    # item 2's status), the rest survive.
+    img = FakeImage({f"f{i}.txt": b"X" for i in range(4)})
+    sig, rec = make_signals()
+    cancel = threading.Event()
+    sig.status.connect(lambda s: cancel.set() if s.startswith("Deleting (2/") else None,
+                       Qt.DirectConnection)
+    _run_delete_task(sig, cancel, img.execute, IMG,
+                     ["/f0.txt", "/f1.txt", "/f2.txt", "/f3.txt"])
+    check("delete cancel stops early",
+          sorted(img.tree) == ["f2.txt", "f3.txt"], repr(sorted(img.tree)))
+
+
+def test_get():
+    img = FakeImage({"games": {"a.bin": b"AAA", "lev": {"b.bin": b"BB"}},
+                     "boot.bas": b"BOOT"})
+    dest = tempfile.mkdtemp(prefix="hdfw_get_")
+    try:
+        sig, rec = make_signals()
+        _run_get_task(sig, threading.Event(), img.execute, IMG,
+                      [("/boot.bas", "boot.bas"), ("/games", "games")],
+                      dest, DIR_NAV, IS_WINDOWS)
+
+        def rd(*parts):
+            p = os.path.join(dest, *parts)
+            return open(p, "rb").read() if os.path.isfile(p) else None
+        check("get root file", rd("boot.bas") == b"BOOT")
+        check("get dir file", rd("games", "a.bin") == b"AAA")
+        check("get nested file", rd("games", "lev", "b.bin") == b"BB")
+        check("get no errors", rec["error"] == [])
+        check("get progress marquee then 100",
+              rec["progress"][0] == -1 and rec["progress"][-1] == 100,
+              repr(rec["progress"]))
+        get_dsts = [c[2] for c in img.calls if c[0] == "get"]
+        check("get local paths forward-slashed",
+              get_dsts and all("\\" not in d for d in get_dsts), repr(get_dsts))
+    finally:
+        shutil.rmtree(dest, ignore_errors=True)
+
+    # A get that raises must emit error and keep downloading the rest.
+    img = FakeImage({"a.bin": b"A", "b.bin": b"B"})
+    img.raise_paths.add("/a.bin")
+    dest = tempfile.mkdtemp(prefix="hdfw_get2_")
+    try:
+        sig, rec = make_signals()
+        _run_get_task(sig, threading.Event(), img.execute, IMG,
+                      [("/a.bin", "a.bin"), ("/b.bin", "b.bin")],
+                      dest, DIR_NAV, IS_WINDOWS)
+        check("get error emitted once",
+              len(rec["error"]) == 1 and "Failed downloading" in rec["error"][0],
+              repr(rec["error"]))
+        check("get continues past error",
+              open(os.path.join(dest, "b.bin"), "rb").read() == b"B")
+    finally:
+        shutil.rmtree(dest, ignore_errors=True)
+
+
+def test_put_single():
+    local = tempfile.mkdtemp(prefix="hdfw_put_")
+    try:
+        src = os.path.join(local, "up.bin")
+        with open(src, "wb") as f:
+            f.write(b"PAYLOAD")
+
+        img = FakeImage()
+        sig, rec = make_signals()
+        _run_put_task(sig, threading.Event(), img.execute, lambda p: None,
+                      IMG, src, "/up.bin")
+        check("put single lands", img.tree == {"up.bin": b"PAYLOAD"},
+              repr(img.tree))
+        check("put single progress", rec["progress"] == [0, 100],
+              repr(rec["progress"]))
+        check("put single no errors", rec["error"] == [])
+
+        # Generic failure (no "Access denied"): plain error, no cancel.
+        img = FakeImage()
+        img.fail_paths.add("/up.bin")
+        sig, rec = make_signals()
+        cancel = threading.Event()
+        _run_put_task(sig, cancel, img.execute,
+                      lambda p: "SHOULD NOT BE CONSULTED", IMG, src, "/up.bin")
+        check("put generic failure error",
+              rec["error"] == ["Failed uploading: up.bin"], repr(rec["error"]))
+        check("put generic failure no cancel", not cancel.is_set())
+
+        # Access denied + the probe confirms a full disk: its message is THE
+        # error, and the whole task is cancelled.
+        img = FakeImage(full_disk=True)
+        sig, rec = make_signals()
+        cancel = threading.Event()
+        _run_put_task(sig, cancel, img.execute, lambda p: "SD image is full",
+                      IMG, src, "/up.bin")
+        check("put full-disk error", rec["error"] == ["SD image is full"],
+              repr(rec["error"]))
+        check("put full-disk cancels", cancel.is_set())
+
+        # Access denied but the probe is inconclusive (None): fall through to
+        # the generic error, no cancel.
+        img = FakeImage(full_disk=True)
+        sig, rec = make_signals()
+        cancel = threading.Event()
+        _run_put_task(sig, cancel, img.execute, lambda p: None,
+                      IMG, src, "/up.bin")
+        check("put denied-but-not-full error",
+              rec["error"] == ["Failed uploading: up.bin"], repr(rec["error"]))
+        check("put denied-but-not-full no cancel", not cancel.is_set())
+    finally:
+        shutil.rmtree(local, ignore_errors=True)
+
+
+def test_put_directory():
+    local = tempfile.mkdtemp(prefix="hdfw_putd_")
+    try:
+        os.makedirs(os.path.join(local, "updir", "sub", "deeper"))
+        for rel, data in (("one.txt", b"1"), (os.path.join("sub", "two.txt"), b"22"),
+                          (os.path.join("sub", "deeper", "three.txt"), b"333")):
+            with open(os.path.join(local, "updir", rel), "wb") as f:
+                f.write(data)
+
+        # /games already exists in the image: its mkdir fails "File exists"
+        # and must be rescued by the ls fallback, then the rest is created.
+        img = FakeImage({"games": {}})
+        sig, rec = make_signals()
+        _run_put_task(sig, threading.Event(), img.execute, lambda p: None,
+                      IMG, os.path.join(local, "updir"), "/games/updir")
+        check("put dir tree lands",
+              img.tree == {"games": {"updir": {
+                  "one.txt": b"1",
+                  "sub": {"two.txt": b"22",
+                          "deeper": {"three.txt": b"333"}}}}},
+              repr(img.tree))
+        check("put dir no errors", rec["error"] == [])
+        mkdirs = [c[1] for c in img.calls if c[0] == "mkdir"]
+        check("put dir mkdir each segment once (dedupe)",
+              sorted(mkdirs) == ["/games", "/games/updir", "/games/updir/sub",
+                                 "/games/updir/sub/deeper"]
+              and len(mkdirs) == len(set(mkdirs)), repr(mkdirs))
+        check("put dir ls fallback rescued existing /games",
+              ("ls", "/games") in img.calls)
+        put_dsts = [c[2] for c in img.calls if c[0] == "put"]
+        check("put dir image paths forward-slashed",
+              len(put_dsts) == 3 and all("\\" not in d for d in put_dsts),
+              repr(put_dsts))
+
+        # Full disk detected during the mkdir phase: cancel before any put.
+        img = FakeImage(full_disk=True)
+        sig, rec = make_signals()
+        cancel = threading.Event()
+        _run_put_task(sig, cancel, img.execute, lambda p: "SD image is full",
+                      IMG, os.path.join(local, "updir"), "/dst")
+        check("put dir full-disk error", rec["error"] == ["SD image is full"],
+              repr(rec["error"]))
+        check("put dir full-disk cancels before uploads",
+              cancel.is_set() and not [c for c in img.calls if c[0] == "put"])
+    finally:
+        shutil.rmtree(local, ignore_errors=True)
+
+
+def test_put_external():
+    local = tempfile.mkdtemp(prefix="hdfw_pute_")
+    try:
+        for n in ("a.bin", "b.bin"):
+            with open(os.path.join(local, n), "wb") as f:
+                f.write(n.encode())
+
+        img = FakeImage()
+        sig, rec = make_signals()
+        _run_put_external_task(sig, threading.Event(), img.execute,
+                               lambda p: None, IMG,
+                               [(os.path.join(local, "a.bin"), "/a.bin"),
+                                (os.path.join(local, "b.bin"), "/b.bin")])
+        check("put external both land",
+              img.tree == {"a.bin": b"a.bin", "b.bin": b"b.bin"},
+              repr(img.tree))
+
+        # Cancel during the first item's status: its upload is skipped and
+        # the second item never starts.
+        img = FakeImage()
+        sig, rec = make_signals()
+        cancel = threading.Event()
+        sig.status.connect(lambda s: cancel.set(), Qt.DirectConnection)
+        _run_put_external_task(sig, cancel, img.execute, lambda p: None, IMG,
+                               [(os.path.join(local, "a.bin"), "/a.bin"),
+                                (os.path.join(local, "b.bin"), "/b.bin")])
+        check("put external cancel skips everything",
+              img.tree == {} and not [c for c in img.calls if c[0] == "put"],
+              repr(img.calls))
+    finally:
+        shutil.rmtree(local, ignore_errors=True)
+
+
+def main():
+    QCoreApplication(sys.argv)   # signals only — no display, no event loop
+    # The failure-path tests make the workers call logging.error on purpose;
+    # keep the console output to the PASS/FAIL lines.
+    logging.disable(logging.CRITICAL)
+    test_path_helpers()
+    test_is_directory()
+    test_delete()
+    test_get()
+    test_put_single()
+    test_put_directory()
+    test_put_external()
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -1,0 +1,1059 @@
+"""Offscreen widget-layer tests for zxnu_remote_explorer.RemoteExplorerWidget
+(the NextSync tab's dual-pane local <-> Next file manager).
+
+The worker side of the Remote Explorer is covered by test_remote_listen.py;
+this file covers the WIDGET side, which previously only the app-wide offscreen
+smoke test touched. The widget's seam makes that cheap: every remote command
+leaves through one injected ``enqueue`` callable and every result arrives via
+plain ``on_*`` methods, so a real QWidget under QT_QPA_PLATFORM=offscreen can
+be driven end-to-end with a recorded queue and hand-fed worker replies — no
+socket, no worker thread, no display. QInputDialog/QMessageBox are replaced by
+scripted fakes inside the module's namespace, so nothing ever blocks.
+
+Covers: connection state + drive combo (getdrives/extra drives/free space),
+listing rendering + both panes' sort persistence, navigation (up/double-click/
+ls-failure fallback), the operation lifecycle (_run_op/step/cancel/disconnect/
+background rcpy overlay), transfers (get/put incl. recursive folder upload),
+copy/cut/paste in all four directions (with move markers deleting sources
+only after confirmation), the rcpy free-space precheck, sync-root handling,
+local file operations (new folder/rename/delete/copy-paste/zip round-trip)
+and drag & drop entry points."""
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from PySide6.QtCore import QItemSelectionModel, QMimeData, QPointF, Qt, QUrl
+from PySide6.QtGui import QColor, QDropEvent
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+import zxnu_remote_explorer as rex
+from zxnu_remote_explorer import (RemoteExplorerWidget, RE_PATH_ROLE,
+                                  _ext_type_text, _human_size, _norm_remote_dir,
+                                  _parse_re_sort, _posix_join, _re_drive_of,
+                                  _re_norm_dir, _re_sort_to_str)
+
+ok = True
+
+
+def check(label, cond, detail=""):
+    global ok
+    print(f"{'PASS' if cond else 'FAIL'} {label}"
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        ok = False
+
+
+# ---------------------------------------------------------------------------
+# scripted stand-ins for the module's modal dialogs
+# ---------------------------------------------------------------------------
+class FakeInput:
+    """Replaces zxnu_remote_explorer.QInputDialog: getText pops scripted
+    (text, ok) answers; an empty script answers a cancel."""
+    queue = []
+
+    @classmethod
+    def getText(cls, *a, **k):
+        return cls.queue.pop(0) if cls.queue else ("", False)
+
+
+class FakeMsg:
+    """Replaces zxnu_remote_explorer.QMessageBox: question/warning return the
+    scripted ``answer``; critical/information record their text."""
+    Yes = QMessageBox.Yes
+    No = QMessageBox.No
+    Cancel = QMessageBox.Cancel
+    StandardButton = QMessageBox.StandardButton
+    answer = QMessageBox.Yes
+    criticals = []
+    infos = []
+
+    @classmethod
+    def question(cls, *a, **k):
+        return cls.answer
+
+    @classmethod
+    def warning(cls, *a, **k):
+        return cls.answer
+
+    @classmethod
+    def critical(cls, parent, title, text, *a, **k):
+        cls.criticals.append(text)
+        return QMessageBox.StandardButton.Close
+
+    @classmethod
+    def information(cls, parent, title, text, *a, **k):
+        cls.infos.append(text)
+
+
+rex.QInputDialog = FakeInput
+rex.QMessageBox = FakeMsg
+
+
+# ---------------------------------------------------------------------------
+# harness helpers
+# ---------------------------------------------------------------------------
+def make_widget(**kw):
+    """A RemoteExplorerWidget wired to recorders for every host callback."""
+    calls = {"q": [], "log": [], "toasts": [], "sync_root": [],
+             "remote_cwd": [], "sorts": [], "extra_drives": []}
+    w = RemoteExplorerWidget(
+        enqueue=calls["q"].append,
+        local_start_dir=kw.get("local_start_dir"),
+        log=calls["log"].append,
+        drain=kw.get("drain"),
+        on_sync_root_changed=calls["sync_root"].append,
+        remote_start_dir=kw.get("remote_start_dir"),
+        on_remote_cwd_changed=calls["remote_cwd"].append,
+        local_sort=kw.get("local_sort"),
+        next_sort=kw.get("next_sort"),
+        on_sort_changed=lambda which, v: calls["sorts"].append((which, v)),
+        on_toast=lambda t, m, variant="red": calls["toasts"].append((t, m, variant)),
+        extra_drives=kw.get("extra_drives"),
+        on_extra_drives_changed=calls["extra_drives"].append)
+    return w, calls
+
+
+def connect_widget(w, calls, drives=("C", "M"), listing=()):
+    """Bring a widget to the usual ready state: connected on drive C, cwd /,
+    with ``listing`` shown. Clears the recorders afterwards."""
+    w.on_connected()
+    w.on_drives("C", list(drives))
+    w.on_listing("/", list(listing))
+    for rec in calls.values():
+        rec.clear()
+
+
+def drain(calls):
+    q = list(calls["q"])
+    calls["q"].clear()
+    return q
+
+
+def fwd(p):
+    """Forward-slashed form of a local path, as the widget emits them (the
+    sync root, QFileSystemModel.filePath and QUrl.toLocalFile all use "/";
+    recursive-upload walks use the native separator)."""
+    return p.replace("\\", "/")
+
+
+def normq(q):
+    """A queue with every string normalised to forward slashes, so command
+    comparisons are separator-agnostic."""
+    return [tuple(fwd(x) if isinstance(x, str) else x for x in c) for c in q]
+
+
+def logged(calls, needle):
+    return any(needle in s for s in calls["log"])
+
+
+def next_names(w):
+    return [w.next_model.item(r, 0).text()
+            for r in range(w.next_model.rowCount())]
+
+
+def select_next(w, *names):
+    sm = w.next_view.selectionModel()
+    sm.clearSelection()
+    for r in range(w.next_model.rowCount()):
+        if w.next_model.item(r, 0).text() in names:
+            sm.select(w.next_model.index(r, 0),
+                      QItemSelectionModel.Select | QItemSelectionModel.Rows)
+
+
+def select_local(w, *paths):
+    """Select real files/folders in the local pane, waiting out
+    QFileSystemModel's asynchronous directory population."""
+    sm = w.local_view.selectionModel()
+    sm.clearSelection()
+    for p in paths:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            six = w.local_model.index(p)
+            if six.isValid():
+                ix = w.local_proxy.mapFromSource(six)
+                if ix.isValid():
+                    sm.select(ix, QItemSelectionModel.Select
+                              | QItemSelectionModel.Rows)
+                    break
+            root = w.local_model.index(w._browse_dir())
+            if w.local_model.canFetchMore(root):
+                w.local_model.fetchMore(root)
+            QApplication.processEvents()
+            time.sleep(0.01)
+        else:
+            raise AssertionError(f"local row never appeared: {p}")
+
+
+def drop_event(mime, pos=(10, 9000)):
+    return QDropEvent(QPointF(*pos), Qt.CopyAction, mime,
+                      Qt.LeftButton, Qt.NoModifier)
+
+
+def url_mime(*paths):
+    m = QMimeData()
+    m.setUrls([QUrl.fromLocalFile(p) for p in paths])
+    return m
+
+
+TMP = tempfile.mkdtemp(prefix="rexw_")
+
+
+def tdir(name):
+    p = os.path.join(TMP, name)
+    os.makedirs(p, exist_ok=True)
+    return p
+
+
+def tfile(reldir, name, data=b"x"):
+    p = os.path.join(reldir, name)
+    with open(p, "wb") as f:
+        f.write(data)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+def test_pure_helpers():
+    check("human size", [_human_size(None), _human_size(512), _human_size(7000),
+                         _human_size(4 * 1024 * 1024)]
+          == ["", "512 B", "6.8 K", "4.0 M"])
+    check("ext type", [_ext_type_text("a.tap"), _ext_type_text("a.tap.zip"),
+                       _ext_type_text("noext")] == ["tap", "tap", ""])
+    check("posix join", _posix_join("/games/", "lev") == "/games/lev"
+          and _posix_join("", "x") == "/x")
+    check("drive of", [_re_drive_of("M:/x"), _re_drive_of("/x"),
+                       _re_drive_of("")] == ["M", "", ""])
+    check("norm dir", [_re_norm_dir("M:"), _re_norm_dir(""),
+                       _re_norm_dir("/games")] == ["M:/", "/", "/games"])
+    check("norm remote", [_norm_remote_dir(None), _norm_remote_dir("games"),
+                          _norm_remote_dir("m:games\\lev")]
+          == ["/", "/games", "M:/games/lev"])
+    check("sort parse fallback", _parse_re_sort("bogus") == ("name", Qt.AscendingOrder))
+    check("sort round-trip",
+          _parse_re_sort(_re_sort_to_str("size", Qt.DescendingOrder))
+          == ("size", Qt.DescendingOrder))
+    check("fmt free", [RemoteExplorerWidget._fmt_free(512),
+                       RemoteExplorerWidget._fmt_free(1572864)]
+          == ["512 bytes", "1.5 MB"])
+    colors = {RemoteExplorerWidget._free_color(n * 1024 * 1024)
+              for n in (50, 150, 250)}
+    check("free color traffic light", len(colors) == 3
+          and RemoteExplorerWidget._free_color(250 * 1024 * 1024) == "#2fb344")
+
+
+def test_initial_and_connection_state():
+    root = tdir("init_root")
+    w, calls = make_widget(local_start_dir=root)
+    check("starts disconnected", not w._connected
+          and not w.btn_to_next.isEnabled() and not w.next_view.isEnabled())
+    check("waiting label", "waiting for .sync5" in w.next_path_label.text())
+    check("start dir committed as sync root",
+          w.sync_root() == root.replace("\\", "/")
+          and calls["sync_root"] == [root.replace("\\", "/")])
+    check("path box shows sync root",
+          w.local_path_edit.text() == root.replace("\\", "/"))
+
+    w.on_connected()
+    check("connect enables the pane", w._connected and w.btn_to_next.isEnabled())
+    check("connect asks drives then lists /",
+          drain(calls) == [("drives",), ("ls", "/")])
+
+    w.on_drives("C", ["C", "M"])
+    combo = [w.next_drive_combo.itemText(i)
+             for i in range(w.next_drive_combo.count())]
+    check("drive combo filled", combo == ["C", "M"]
+          and w.next_drive_combo.isEnabled() and w.next_drive_add.isEnabled())
+    check("drives trigger a free-space query", drain(calls) == [("free", "C")])
+    check("drives logged", logged(calls, "Next drives: C M"))
+
+    w.on_free_space("C", 300 * 1024 * 1024)
+    check("free space in path label", "300.0 MB free" in w.next_path_label.text()
+          and "#2fb344" in w.next_path_label.text())
+    w.on_free_space("C", None)
+    check("failed free query clears the figure",
+          w.next_path_label.text() == "Next: /")
+
+    w.on_disconnected()
+    check("disconnect clears pane", not w._connected
+          and w.next_model.rowCount() == 0
+          and not w.next_drive_combo.isEnabled()
+          and w.next_drive_combo.count() == 0)
+
+    # Old dot: no getdrives reply -> lone implicit drive, switcher disabled.
+    w.on_connected()
+    w.on_drives("", [])
+    check("old dot: lone drive, disabled combo",
+          [w.next_drive_combo.itemText(i)
+           for i in range(w.next_drive_combo.count())] == ["C"]
+          and not w.next_drive_combo.isEnabled()
+          and not w.next_drive_add.isEnabled())
+    # Distrusted current letter (not in the reported list) falls back to C.
+    w.on_drives("X", ["C", "M"])
+    check("bogus current drive distrusted", w._default_drive == "C")
+
+
+def test_listing_and_rendering():
+    w, calls = make_widget(local_start_dir=tdir("lst_root"))
+    connect_widget(w, calls)
+    w.on_listing("/", [(True, 0, "GAMES"), (False, 1234, "boot.bas"),
+                       (False, 100, "."), (False, 100, "..")])
+    check("listing rows (no .. at root, dot rows dropped)",
+          next_names(w) == ["boot.bas", "GAMES"])
+    row = next_names(w).index("boot.bas")
+    check("file row type/size", w.next_model.item(row, 1).text() == "bas"
+          and w.next_model.item(row, 2).text() == "1.2 K")
+    grow = next_names(w).index("GAMES")
+    check("dir row type/size", w.next_model.item(grow, 1).text() == "DIR"
+          and w.next_model.item(grow, 2).text() == "")
+    check("cwd reported to host once", calls["remote_cwd"] == [])  # "/" is start
+
+    w.on_listing("/GAMES", [(False, 10, "a.tap")])
+    check("subdir listing pins ..", next_names(w) == ["..", "a.tap"])
+    check("subdir cwd persisted", calls["remote_cwd"] == ["/GAMES"])
+    check("path label follows", w.next_path_label.text() == "Next: /GAMES")
+
+    # Colours: push a custom file colour, the existing row re-tints in place.
+    w.set_item_colors({"file_name": QColor("#804020"), "bogus": QColor("red"),
+                       "dir_name": None})
+    arow = next_names(w).index("a.tap")
+    check("set_item_colors re-tints rows",
+          w.next_model.item(arow, 0).foreground().color().name() == "#804020")
+
+
+def test_navigation():
+    w, calls = make_widget(local_start_dir=tdir("nav_root"))
+    connect_widget(w, calls, listing=[(True, 0, "GAMES")])
+    ix = w.next_model.item(next_names(w).index("GAMES"), 0).index()
+    w._next_double_clicked(ix)
+    check("double-click dir navigates",
+          w._cwd == "/GAMES" and drain(calls) == [("ls", "/GAMES")])
+    w.on_listing("/GAMES", [(True, 0, "LEV")])
+    calls["q"].clear()
+    up_ix = w.next_model.item(0, 0).index()   # the ".." row
+    check("up row flagged", w.next_model.item(0, 0).data(RE_PATH_ROLE) == "..")
+    w._next_double_clicked(up_ix)
+    check("double-click .. goes up",
+          w._cwd == "/" and drain(calls) == [("ls", "/")])
+    w._next_up()
+    check("up at root is a no-op", drain(calls) == [])
+
+    w.on_listing("M:/games", [(True, 0, "sub")])
+    calls["q"].clear()
+    check("drive cwd not at root", not w._at_drive_root())
+    w._next_up()
+    check("up on a drive path stops at its root",
+          w._cwd == "M:/" and drain(calls) == [("ls", "M:/")]
+          and w._at_drive_root())
+
+    # _in_cwd drives the "refresh only the visible folder" logic.
+    check("_in_cwd drive root", w._in_cwd("M:/file.tap")
+          and not w._in_cwd("M:/sub/file.tap") and not w._in_cwd("/file.tap"))
+    w._cwd = "/games"
+    check("_in_cwd nested", w._in_cwd("/games/x.tap")
+          and not w._in_cwd("/games/sub/y.tap") and not w._in_cwd("/other"))
+
+
+def test_drive_switching():
+    w, calls = make_widget(local_start_dir=tdir("drv_root"),
+                           extra_drives="e")
+    connect_widget(w, calls)
+    combo = [w.next_drive_combo.itemText(i)
+             for i in range(w.next_drive_combo.count())]
+    check("saved extra drive merged into combo", combo == ["C", "E", "M"])
+
+    w.next_drive_combo.setCurrentText("M")
+    check("combo switch jumps to drive root", w._cwd == "M:/"
+          and drain(calls) == [("ls", "M:/"), ("free", "M")])
+    w.on_listing("M:/", [])
+    check("combo follows cwd", w.next_drive_combo.currentText() == "M")
+
+    # "+ Drive": invalid letter, then declined, then confirmed.
+    calls["q"].clear()
+    FakeInput.queue = [("q", True)]
+    w._add_drive_clicked()
+    check("+drive rejects invalid letter",
+          logged(calls, "single letter C..P") and drain(calls) == [])
+    FakeInput.queue = [("d", True)]
+    FakeMsg.answer = QMessageBox.No
+    w._add_drive_clicked()
+    check("+drive declined does nothing", drain(calls) == []
+          and calls["extra_drives"] == [])
+    FakeInput.queue = [("d", True)]
+    FakeMsg.answer = QMessageBox.Yes
+    w._add_drive_clicked()
+    check("+drive confirmed persists and switches",
+          calls["extra_drives"] == ["DE"] and w._cwd == "D:/"
+          and ("ls", "D:/") in drain(calls))
+    FakeInput.queue = [("m", True)]
+    calls["q"].clear()
+    w._add_drive_clicked()
+    check("+drive with a known letter just switches",
+          w._cwd == "M:/" and ("ls", "M:/") in drain(calls)
+          and calls["extra_drives"] == ["DE"])
+
+
+def test_ls_failed_fallback():
+    w, calls = make_widget(local_start_dir=tdir("lsf_root"))
+    connect_widget(w, calls)
+    w.on_listing("M:/games", [])
+    calls["toasts"].clear()
+    calls["q"].clear()
+    w.on_ls_failed("M:/games")
+    check("lost folder falls back to its drive root",
+          w._cwd == "M:/" and drain(calls) == [("ls", "M:/")]
+          and calls["toasts"] and calls["toasts"][0][2] == "yellow")
+    w.on_ls_failed("M:/")
+    check("lost drive root falls back to /",
+          w._cwd == "/" and drain(calls) == [("ls", "/")])
+    calls["toasts"].clear()
+    w.on_ls_failed("/")
+    check("lost / gives up quietly",
+          drain(calls) == [] and calls["toasts"] == [])
+
+
+def test_sorting():
+    entries = [(False, 2048, "b.tap"), (True, 0, "AAA"),
+               (False, 10, "a.zzz"), (True, 0, "zdir")]
+    w, calls = make_widget(local_start_dir=tdir("srt_root"))
+    connect_widget(w, calls)
+    w.on_listing("/", entries)
+    check("default sort name asc",
+          next_names(w) == ["a.zzz", "AAA", "b.tap", "zdir"])
+    w._on_next_header_clicked(0)
+    check("name header click flips to desc",
+          next_names(w) == ["zdir", "b.tap", "AAA", "a.zzz"]
+          and ("next", "name:desc") in calls["sorts"])
+    w._on_next_header_clicked(2)
+    check("size sort groups dirs first",
+          next_names(w) == ["AAA", "zdir", "a.zzz", "b.tap"]
+          and ("next", "size:asc") in calls["sorts"])
+    w._on_next_header_clicked(2)
+    check("size sort desc reverses",
+          next_names(w) == ["b.tap", "a.zzz", "zdir", "AAA"])
+
+    # Restored sorts: indicators applied, nothing re-saved.
+    w2, calls2 = make_widget(local_start_dir=tdir("srt2_root"),
+                             next_sort="size:desc", local_sort="type:desc")
+    h = w2.next_view.header()
+    check("restored next sort indicator", h.sortIndicatorSection() == 2
+          and h.sortIndicatorOrder() == Qt.DescendingOrder)
+    lh = w2.local_view.header()
+    check("restored local sort indicator", lh.sortIndicatorSection() == 2
+          and lh.sortIndicatorOrder() == Qt.DescendingOrder)
+    check("restoring saved nothing", calls2["sorts"] == [])
+    w2.local_view.sortByColumn(1, Qt.AscendingOrder)
+    check("local header click persists",
+          calls2["sorts"] == [("local", "size:asc")])
+
+
+def test_op_lifecycle_new_folder_rename_delete():
+    w, calls = make_widget(local_start_dir=tdir("op_root"))
+    connect_widget(w, calls,
+                   listing=[(True, 0, "GAMES"), (False, 1234, "boot.bas")])
+
+    # New Folder: happy path.
+    FakeInput.queue = [("Games2", True)]
+    w._new_folder()
+    check("new folder queues mkdir and blocks the UI",
+          drain(calls) == [("mkdir", "/Games2")] and w._op_active
+          and not w.isEnabled())
+    w.on_op_done(True, "mkdir", "/Games2")
+    check("op ends with one refresh + free re-read",
+          drain(calls) == [("ls", "/"), ("free", "C")] and not w._op_active
+          and w.isEnabled() and calls["toasts"] == [])
+
+    # New Folder: cancelled prompt starts nothing.
+    FakeInput.queue = [("", False)]
+    w._new_folder()
+    check("cancelled new folder is a no-op",
+          drain(calls) == [] and not w._op_active)
+
+    # New Folder: a deliberate mkdir failure IS toasted.
+    FakeInput.queue = [("bad", True)]
+    w._new_folder()
+    w.on_op_done(False, "mkdir", "/bad")
+    check("failed new folder toasts red",
+          calls["toasts"] and "mkdir failed: bad" in calls["toasts"][0][1]
+          and calls["toasts"][0][2] == "red")
+    calls["toasts"].clear()
+
+    # Rename: exactly one selection, name validation, then the command.
+    calls["q"].clear()
+    select_next(w, "boot.bas")
+    FakeInput.queue = [("a/b", True)]
+    w._rename_selected()
+    check("rename rejects a path", logged(calls, "name only")
+          and drain(calls) == [] and not w._op_active)
+    FakeInput.queue = [("boot2.bas", True)]
+    w._rename_selected()
+    check("rename queues the command",
+          drain(calls) == [("rename", "/boot.bas", "/boot2.bas")])
+    w.on_op_done(True, "rename", "/boot2.bas")
+    calls["q"].clear()
+    select_next(w, "boot.bas", "GAMES")
+    w._rename_selected()
+    check("rename needs exactly one item",
+          logged(calls, "exactly one") and drain(calls) == [])
+
+    # Delete: declined, then confirmed (dir -> rmtree, file -> rm).
+    FakeMsg.answer = QMessageBox.No
+    w._delete_selected()
+    check("declined delete is a no-op", drain(calls) == [] and not w._op_active)
+    FakeMsg.answer = QMessageBox.Yes
+    w._delete_selected()
+    q = drain(calls)
+    check("delete queues rm for files, rmtree for dirs",
+          sorted(q) == [("rm", "/boot.bas"), ("rmtree", "/GAMES")])
+    w.on_op_done(True, "rm", "/boot.bas")
+    check("op waits for every reply", w._op_active)
+    w.on_op_done(True, "delete", "/GAMES")
+    check("delete op ends after both replies", not w._op_active)
+
+
+def test_get_size_dialog():
+    w, calls = make_widget(local_start_dir=tdir("sz_root"))
+    connect_widget(w, calls, listing=[(True, 0, "GAMES")])
+    select_next(w, "GAMES")
+    w._get_size_selected()
+    check("get size queues fsize", drain(calls) == [("fsize", "/GAMES")])
+    FakeMsg.infos.clear()
+    w.on_op_done(True, "size", "/GAMES")
+    w.on_fsize("/GAMES", {"bytes": 2048, "files": 3, "dirs": 1})
+    check("fsize result pops the info dialog",
+          FakeMsg.infos and "2,048" in FakeMsg.infos[0] and not w._op_active)
+    FakeMsg.infos.clear()
+    w.on_fsize("/GAMES", None)
+    check("failed fsize shows no dialog", FakeMsg.infos == [])
+
+
+def test_transfers_get_put():
+    root = tdir("xfer_root")
+    w, calls = make_widget(local_start_dir=root)
+    connect_widget(w, calls,
+                   listing=[(True, 0, "GAMES"), (False, 9, "boot.bas")])
+
+    # Download: the folder's local dir is pre-created so empty dirs show.
+    select_next(w, "GAMES", "boot.bas")
+    w._get_selected()
+    q = drain(calls)
+    check("get queues one get per item",
+          sorted(normq(q)) == sorted([("get", "/GAMES", fwd(root)),
+                                      ("get", "/boot.bas", fwd(root))]))
+    check("get pre-creates the folder locally",
+          os.path.isdir(os.path.join(root, "GAMES")))
+    w.on_got("/boot.bas", os.path.join(root, "boot.bas"))
+    w.on_got("/GAMES", os.path.join(root, "GAMES"))
+    check("get op ends", not w._op_active)
+
+    # Upload: file + recursive folder (mkdir before the puts into it).
+    up = tdir("xfer_root/updir")
+    fa = tfile(root, "a.txt")
+    fx = tfile(up, "x.txt")
+    sub = os.path.join(up, "sub")
+    os.makedirs(sub, exist_ok=True)
+    fy = tfile(sub, "y.txt")
+    select_local(w, fa, up)
+    calls["q"].clear()
+    w._put_selected()
+    q = drain(calls)
+    nq = normq(q)
+    check("put queues files and the folder tree",
+          sorted(nq) == sorted([("put", fwd(fa), "/"), ("mkdir", "/updir"),
+                                ("put", fwd(fx), "/updir/"),
+                                ("mkdir", "/updir/sub"),
+                                ("put", fwd(fy), "/updir/sub/")]))
+    check("mkdir precedes its puts",
+          nq.index(("mkdir", "/updir")) < nq.index(("put", fwd(fx), "/updir/"))
+          and nq.index(("mkdir", "/updir/sub"))
+          < nq.index(("put", fwd(fy), "/updir/sub/")))
+    for cmd in q:
+        if cmd[0] == "put":
+            w.on_put_done(True, cmd[2] + os.path.basename(cmd[1]))
+        else:
+            w.on_op_done(True, "mkdir", cmd[1])
+    check("put op ends after all replies", not w._op_active)
+
+    # A failed put during the op becomes one red toast at the end.
+    calls["toasts"].clear()
+    select_local(w, fa)
+    w._put_selected()
+    calls["q"].clear()
+    w.on_put_done(False, "/a.txt")
+    check("failed upload toasts once at op end", not w._op_active
+          and calls["toasts"] and "Upload failed: a.txt" in calls["toasts"][0][1])
+
+    # Empty selection only logs.
+    w.local_view.selectionModel().clearSelection()
+    calls["q"].clear()
+    w._put_selected()
+    check("put with no selection logs", logged(calls, "Select local file")
+          and drain(calls) == [])
+
+
+def test_send_local_paths():
+    root = tdir("send_root")
+    fa = tfile(root, "send.txt")
+    w, calls = make_widget(local_start_dir=root)
+    check("send offline", w.send_local_paths([fa]) == "offline")
+    connect_widget(w, calls)
+    check("send with nothing that exists",
+          w.send_local_paths([os.path.join(root, "nope")]) == "empty")
+    outcome = []
+    check("send queues", w.send_local_paths(
+        [fa], on_done=lambda ok_, fails: outcome.append((ok_, fails))) == "queued")
+    check("send while busy", w.send_local_paths([fa]) == "busy")
+    w.on_put_done(True, "/send.txt")
+    check("send reports success", outcome == [(True, [])])
+
+
+def test_copy_cut_paste_next_to_local():
+    root = tdir("n2l_root")
+    w, calls = make_widget(local_start_dir=root)
+    connect_widget(w, calls,
+                   listing=[(True, 0, "GAMES"), (False, 9, "boot.bas")])
+
+    # Copy -> paste: a plain download.
+    select_next(w, "boot.bas")
+    w._copy_next("copy")
+    check("copy next fills the clip", w._clip == ("next", [("/boot.bas", False)],
+                                                  "copy"))
+    w._paste_into_local()
+    check("paste downloads",
+          normq(drain(calls)) == [("get", "/boot.bas", fwd(root))])
+    w.on_got("/boot.bas", os.path.join(root, "boot.bas"))
+    calls["q"].clear()               # drop the end-of-op ls + free re-read
+
+    # Cut -> paste: download + marker, source removed only after the marker.
+    select_next(w, "boot.bas")
+    w._copy_next("cut")
+    w._paste_into_local()
+    q = drain(calls)
+    check("move queues get then marker",
+          normq(q)[0] == ("get", "/boot.bas", fwd(root)) and q[1][0] == "mark"
+          and len(w._cut_jobs) == 1)
+    token = q[1][1]
+    w.on_got("/boot.bas", os.path.join(root, "boot.bas"))
+    w.on_marked(token)
+    check("confirmed move deletes the Next source",
+          drain(calls) == [("rm", "/boot.bas")] and w._cut_jobs == [])
+    w.on_op_done(True, "rm", "/boot.bas")
+    check("move op ends", not w._op_active)
+    calls["q"].clear()
+
+    # A transfer error before the marker keeps the source.
+    calls["toasts"].clear()
+    select_next(w, "boot.bas")
+    w._copy_next("cut")
+    w._paste_into_local()
+    q = drain(calls)
+    w.on_error("wire broke")
+    w.on_marked(q[1][1])             # op ends here -> a trailing ls + free
+    check("failed move keeps the Next source",
+          not any(c[0] in ("rm", "rmdir") for c in drain(calls))
+          and logged(calls, "kept /boot.bas") and not w._op_active
+          and w._cut_jobs == [])
+    check("failure toasted", calls["toasts"]
+          and "wire broke" in calls["toasts"][0][1])
+
+    # Cut folder: the downloaded copy's layout drives a bottom-up remote wipe.
+    select_next(w, "GAMES")
+    w._copy_next("cut")
+    w._paste_into_local()
+    q = drain(calls)
+    gcopy = os.path.join(root, "GAMES")
+    tfile(gcopy, "f1.txt")
+    inner = os.path.join(gcopy, "inner")
+    os.makedirs(inner, exist_ok=True)
+    tfile(inner, "f2.txt")
+    w.on_got("/GAMES", gcopy)
+    w.on_marked(q[1][1])
+    check("folder move mirrors the copy bottom-up",
+          drain(calls) == [("rm", "/GAMES/inner/f2.txt"),
+                           ("rmdir", "/GAMES/inner"),
+                           ("rm", "/GAMES/f1.txt"), ("rmdir", "/GAMES")])
+    for op, p in (("rm", "/GAMES/inner/f2.txt"), ("rmdir", "/GAMES/inner"),
+                  ("rm", "/GAMES/f1.txt"), ("rmdir", "/GAMES")):
+        w.on_op_done(True, op, p)
+    check("folder move op ends", not w._op_active)
+
+
+def test_copy_cut_paste_local_to_next():
+    root = tdir("l2n_root")
+    w, calls = make_widget(local_start_dir=root)
+    connect_widget(w, calls)
+    fa = tfile(root, "up.bin", b"DATA")
+    select_local(w, fa)
+    w._copy_local("copy")
+    check("copy local fills the clip",
+          w._clip == ("local", [fwd(fa)], "copy"))
+    calls["q"].clear()
+    w._paste_into_next()
+    check("paste uploads", normq(drain(calls)) == [("put", fwd(fa), "/")])
+    w.on_put_done(True, "/up.bin")
+
+    # Cut -> paste: upload + marker, local file deleted only after the marker.
+    fmv = tfile(root, "move.bin", b"MOVE")
+    select_local(w, fmv)
+    w._copy_local("cut")
+    calls["q"].clear()
+    w._paste_into_next()
+    q = drain(calls)
+    check("local move queues put then marker",
+          normq(q)[0] == ("put", fwd(fmv), "/") and q[1][0] == "mark"
+          and w._clip is None)
+    w.on_put_done(True, "/move.bin")
+    w.on_marked(q[1][1])
+    check("confirmed local move removes the file",
+          not os.path.exists(fmv) and logged(calls, "removed local")
+          and not w._op_active)
+
+    # Failed upload keeps the local source.
+    fkeep = tfile(root, "keep.bin")
+    select_local(w, fkeep)
+    w._copy_local("cut")
+    calls["q"].clear()
+    w._paste_into_next()
+    q = drain(calls)
+    w.on_put_done(False, "/keep.bin")
+    w.on_marked(q[1][1])
+    check("failed local move keeps the file",
+          os.path.exists(fkeep) and not w._op_active)
+
+    # Cut NEXT items cannot paste back into the Next.
+    w.on_listing("/", [(False, 9, "boot.bas")])
+    select_next(w, "boot.bas")
+    w._copy_next("cut")
+    calls["q"].clear()
+    w._paste_into_next()
+    check("cut next items refuse a next paste",
+          drain(calls) == [] and logged(calls, "paste into the local pane"))
+
+
+def test_rcpy_precheck_and_background():
+    root = tdir("rcpy_root")
+    w, calls = make_widget(local_start_dir=root)
+    connect_widget(w, calls, listing=[(True, 0, "GAMES")])
+
+    # Pasting into the source's own folder is refused outright.
+    select_next(w, "GAMES")
+    w._copy_next("copy")
+    calls["q"].clear()
+    w._paste_into_next()
+    check("self-paste skipped", drain(calls) == [] and w._precheck is None
+          and logged(calls, "destination equals or is inside the source"))
+
+    # Into another folder: rfsize precheck, then the rcpy with totals.
+    w.on_listing("/dst", [])
+    calls["q"].clear()
+    w._paste_into_next()
+    check("precheck measures the source and re-reads free space",
+          drain(calls) == [("fsize", "/GAMES"), ("free", "C")]
+          and w._precheck is not None)
+    w.on_fsize("/GAMES", {"bytes": 1000, "files": 3, "dirs": 1})
+    w.on_op_done(True, "size", "/GAMES")     # stage-1 op ends
+    calls["q"].clear()
+    w.on_free_space("C", 10_000_000)
+    q = drain(calls)
+    check("fitting copy launches rcpy",
+          ("rcpy", "/GAMES", "/dst/GAMES") in q and w._op_active)
+
+    # Background mode: the dialog button hands the op to the overlay.
+    w.on_op_progress("copy", "/dst/GAMES/f1.bin")
+    w._on_op_cancel_clicked()
+    check("backgrounded: local pane free, Next pane covered",
+          w.isEnabled() and w._op_background
+          and not w.next_container.isEnabled()
+          and w._next_overlay is not None
+          and "Remote copy in progress" in w._next_overlay.text())
+    calls["toasts"].clear()
+    w.on_op_done(True, "copy", "/dst/GAMES")
+    check("backgrounded op ends with a green toast",
+          not w._op_active and w._next_overlay is None
+          and w.next_container.isEnabled()
+          and any(t[2] == "green" and "Remote copy complete" in t[0]
+                  for t in calls["toasts"]))
+
+    # Not enough space: the copy is refused before any rcpy is queued.
+    w.on_listing("/dst2", [])
+    calls["q"].clear()
+    FakeMsg.criticals.clear()
+    w._paste_into_next()
+    w.on_fsize("/GAMES", {"bytes": 10_000_000, "files": 3, "dirs": 1})
+    w.on_op_done(True, "size", "/GAMES")
+    calls["q"].clear()
+    w.on_free_space("C", 1000)
+    check("too-big copy refused",
+          not any(c[0] == "rcpy" for c in drain(calls))
+          and FakeMsg.criticals and "not started" in FakeMsg.criticals[0]
+          and logged(calls, "rcpy refused"))
+
+
+def test_cancel_and_disconnect_mid_op():
+    root = tdir("cancel_root")
+    drained = {"n": 0}
+
+    def drain_hook():
+        drained["n"] += 1
+        return 1
+    w, calls = make_widget(local_start_dir=root, drain=drain_hook)
+    connect_widget(w, calls)
+    fa = tfile(root, "c1.bin")
+    fb = tfile(root, "c2.bin")
+    select_local(w, fa, fb)
+    w._put_selected()
+    check("two puts queued", len(drain(calls)) == 2 and w._op_total == 2)
+    w.on_put_done(False, "/c1.bin")          # one failure, then the user cancels
+    calls["toasts"].clear()
+    w._on_op_cancel()
+    check("cancel drains the queue and ends the op",
+          drained["n"] == 1 and not w._op_active and w.isEnabled()
+          and logged(calls, "Cancelling remote operation"))
+    check("a cancelled op never toasts failures", calls["toasts"] == [])
+
+    # Disconnect mid-op: op released, moves keep their sources.
+    select_local(w, fa)
+    w._copy_local("cut")
+    calls["q"].clear()
+    w._paste_into_next()
+    check("move op running", w._op_active and len(w._cut_jobs) == 1)
+    w.on_disconnected()
+    check("disconnect ends the op and abandons moves",
+          not w._op_active and w.isEnabled() and w._cut_jobs == []
+          and os.path.exists(fa)
+          and logged(calls, "unfinished moves kept their sources")
+          and logged(calls, "stopped the running operation"))
+
+
+def test_sync_root_and_local_pane():
+    root = tdir("sr_root")
+    sub = os.path.join(root, "deeper")
+    os.makedirs(sub, exist_ok=True)
+    w, calls = make_widget(local_start_dir=root)
+    check("syncroot button hidden at the root",
+          not w.local_set_syncroot_button.isVisible())
+    w._set_local_dir(sub, commit=False)
+    check("browsing elsewhere offers the button",
+          w.local_set_syncroot_button.isVisibleTo(w)
+          and w.sync_root() == root.replace("\\", "/"))
+    FakeMsg.answer = QMessageBox.Yes
+    calls["sync_root"].clear()
+    w._on_set_syncroot_clicked()
+    check("button commits the browsed folder",
+          w.sync_root() == sub.replace("\\", "/")
+          and calls["sync_root"] == [sub.replace("\\", "/")]
+          and not w.local_set_syncroot_button.isVisibleTo(w))
+
+    w.local_path_edit.setText(os.path.join(TMP, "no-such-dir"))
+    w._on_path_edit()
+    check("typing a bogus path restores the box",
+          w.local_path_edit.text() == sub.replace("\\", "/"))
+    w.local_path_edit.setText(root)
+    w._on_path_edit()
+    check("typing a real path commits it",
+          w.sync_root() == root.replace("\\", "/"))
+
+    w.set_local_dir(sub)
+    check("public set_local_dir browses without committing",
+          w._browse_dir() == sub.replace("\\", "/")
+          and w.sync_root() == root.replace("\\", "/"))
+    w.set_local_dir(os.path.join(TMP, "no-such-dir"))
+    check("set_local_dir ignores a missing folder",
+          w._browse_dir() == sub.replace("\\", "/"))
+    w._local_up()
+    check("local Up browses to the parent",
+          w._browse_dir() == root.replace("\\", "/"))
+    w._local_refresh()
+    check("local refresh keeps the folder",
+          w._browse_dir() == root.replace("\\", "/"))
+
+
+def test_local_file_operations():
+    root = tdir("lop_root")
+    w, calls = make_widget(local_start_dir=root)
+
+    FakeInput.queue = [("made", True)]
+    w._local_new_folder()
+    check("local new folder created", os.path.isdir(os.path.join(root, "made")))
+    FakeInput.queue = [("made", True)]
+    w._local_new_folder()
+    check("duplicate name refused", logged(calls, "already exists"))
+    FakeInput.queue = [("a/b", True)]
+    w._local_new_folder()
+    check("path as name refused", logged(calls, "name only"))
+
+    fr = tfile(root, "old.txt")
+    select_local(w, fr)
+    FakeInput.queue = [("new.txt", True)]
+    w._local_rename_selected()
+    check("local rename", not os.path.exists(fr)
+          and os.path.isfile(os.path.join(root, "new.txt")))
+
+    fd = tfile(root, "doomed.txt")
+    select_local(w, fd)
+    FakeMsg.answer = QMessageBox.No
+    w._local_delete_selected()
+    check("declined local delete keeps the file", os.path.exists(fd))
+    FakeMsg.answer = QMessageBox.Yes
+    w._local_delete_selected()
+    check("confirmed local delete removes it", not os.path.exists(fd))
+
+    # Copy/move engine incl. the Explorer-style " - Copy" names.
+    src = tfile(root, "copyme.txt", b"C")
+    other = tdir("lop_other")
+    w._copy_paths_into_local([src], other)
+    check("copy into another folder",
+          os.path.isfile(os.path.join(other, "copyme.txt")))
+    w._copy_paths_into_local([src], root, dup_in_place=True)
+    check("same-folder paste duplicates",
+          os.path.isfile(os.path.join(root, "copyme - Copy.txt")))
+    w._copy_paths_into_local([src], root, dup_in_place=True)
+    check("second duplicate numbered",
+          os.path.isfile(os.path.join(root, "copyme - Copy (2).txt")))
+    w._copy_paths_into_local([src], root, move=True)
+    check("same-folder move is a no-op", os.path.isfile(src))
+    calls["toasts"].clear()
+    w._copy_paths_into_local([src], other, move=True)
+    check("colliding move refused with a toast", os.path.isfile(src)
+          and calls["toasts"] and "already exists" in calls["toasts"][0][1])
+    calls["toasts"].clear()
+    folder = tdir("lop_root/selfcopy")
+    w._copy_paths_into_local([folder], folder)
+    check("folder into itself refused", calls["toasts"]
+          and "into itself" in calls["toasts"][0][1])
+
+    mv = tfile(root, "moveme.txt")
+    w._copy_paths_into_local([mv], other, move=True)
+    check("move relocates the file", not os.path.exists(mv)
+          and os.path.isfile(os.path.join(other, "moveme.txt")))
+
+    # Zip round-trip through the local pane actions.
+    zroot = tdir("lop_zip")
+    za = tfile(zroot, "art.scr", b"S" * 100)
+    zdir = os.path.join(zroot, "bundle")
+    os.makedirs(zdir, exist_ok=True)
+    tfile(zdir, "inner.txt", b"I")
+    calls["toasts"].clear()
+    w._local_zip([za, zdir])
+    zip_path = os.path.join(zroot, "art.scr.zip")   # first item's name + .zip
+    check("local zip created", os.path.isfile(zip_path)
+          and any("Zip complete" in t[0] for t in calls["toasts"]))
+    os.remove(za)
+    shutil.rmtree(zdir)
+    calls["toasts"].clear()
+    w._local_unzip(zip_path)
+    check("local unzip restores the tree",
+          os.path.isfile(za) and os.path.isfile(os.path.join(zdir, "inner.txt"))
+          and any("Unzip complete" in t[0] for t in calls["toasts"]))
+
+
+def test_drag_and_drop():
+    root = tdir("dnd_root")
+    w, calls = make_widget(local_start_dir=root)
+    connect_widget(w, calls)
+
+    # NB: keep every QMimeData in a local — QDropEvent does not own it, and a
+    # garbage-collected mime turns event.mimeData() into a dangling object.
+    fa = tfile(root, "drag.bin", b"D")
+    mime_fa = url_mime(fa)
+    ev = drop_event(mime_fa)
+    w._next_drop(ev)
+    check("OS drop on the Next pane uploads",
+          ev.isAccepted() and normq(drain(calls)) == [("put", fwd(fa), "/")])
+    w.on_put_done(True, "/drag.bin")
+    calls["q"].clear()
+
+    mime_empty = QMimeData()
+    ev = drop_event(mime_empty)
+    w._next_drop(ev)
+    check("empty drop ignored", not ev.isAccepted() and drain(calls) == [])
+
+    # Dragging Next entries into the local pane downloads them.
+    mime = QMimeData()
+    mime.setData("application/x-zxnu-next-entries", b"F\t/boot.bas\nD\t/GAMES")
+    ev = drop_event(mime)
+    w._local_drop(ev)
+    check("next-entry drop downloads incl. empty folders",
+          normq(drain(calls)) == [("get", "/boot.bas", fwd(root)),
+                                  ("get", "/GAMES", fwd(root))]
+          and os.path.isdir(os.path.join(root, "GAMES")))
+    w.on_got("/boot.bas", os.path.join(root, "boot.bas"))
+    w.on_got("/GAMES", os.path.join(root, "GAMES"))
+
+    # An OS file drop on the local pane copies into the browsed folder.
+    other = tdir("dnd_other")
+    fb = tfile(other, "dropped.txt", b"T")
+    mime_fb = url_mime(fb)
+    ev = drop_event(mime_fb)
+    w._local_drop(ev)
+    check("OS drop on the local pane copies",
+          os.path.isfile(os.path.join(root, "dropped.txt")))
+
+
+def test_arrow_pulse_and_overlay_resize():
+    w, calls = make_widget(local_start_dir=tdir("pulse_root"))
+    w.resize(800, 500)
+    w.show()
+    check("show starts the arrow pulse", w._arrow_pulse_timer is not None
+          and w._arrow_pulse_timer.isActive())
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and not w.btn_to_next.styleSheet():
+        QApplication.processEvents()
+        time.sleep(0.01)
+    check("pulse paints the buttons", "rgba(46,204,113" in w.btn_to_next.styleSheet())
+    w.hide()
+    check("hide stops the pulse", w._arrow_pulse_timer is None
+          and w.btn_to_next.styleSheet() == "")
+
+    # The overlay follows the Next pane through resizes (eventFilter path).
+    connect_widget(w, calls)
+    w._set_next_overlay("busy")
+    w.show()
+    w.next_container.resize(300, 200)
+    QApplication.processEvents()
+    check("overlay tracks the pane size",
+          w._next_overlay is not None
+          and w._next_overlay.size() == w.next_container.size())
+    w._set_next_overlay(None)
+    check("overlay removable", w._next_overlay is None
+          and w.next_container.isEnabled())
+    w.hide()
+
+
+def main():
+    logging.disable(logging.CRITICAL)
+    app = QApplication(sys.argv)  # noqa: F841 — QWidget construction needs it
+    try:
+        test_pure_helpers()
+        test_initial_and_connection_state()
+        test_listing_and_rendering()
+        test_navigation()
+        test_drive_switching()
+        test_ls_failed_fallback()
+        test_sorting()
+        test_op_lifecycle_new_folder_rename_delete()
+        test_get_size_dialog()
+        test_transfers_get_put()
+        test_send_local_paths()
+        test_copy_cut_paste_next_to_local()
+        test_copy_cut_paste_local_to_next()
+        test_rcpy_precheck_and_background()
+        test_cancel_and_disconnect_mid_op()
+        test_sync_root_and_local_pane()
+        test_local_file_operations()
+        test_drag_and_drop()
+        test_arrow_pulse_and_overlay_resize()
+    finally:
+        shutil.rmtree(TMP, ignore_errors=True)
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/zx-next-unite.py
+++ b/zx-next-unite.py
@@ -5701,7 +5701,7 @@ class MainWindow(QMainWindow):
 
                 # ---- Phase 3: remove the original
                 _run_delete_task(_StepProxy("Deleting (Step 3/3)…"), cancel_event,
-                                 image_path, [src_path])
+                                 execute_hdf_monkey, image_path, [src_path])
             finally:
                 shutil.rmtree(tmp_root, ignore_errors=True)
 

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -18,7 +18,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.1.4"
+ZX_NEXT_UNITE_VERSION = "9.1.5"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
## Summary
- `python tests/run_all.py --coverage`: opt-in coverage.py measurement of the app modules across every suite **including child processes** (subprocess hook via `tests/covhook/sitecustomize.py` + `COVERAGE_PROCESS_START`; `tests/.coveragerc` folds the offscreen UI suite's scratch app copy back onto the repo file). Worst-first per-file table + `tests/htmlcov/` HTML report; reporting only, never changes the exit code.
- New `tests/test_hdf_workers.py`: headless unit tests for the SD-Card operation layer in `zxnu_workers` (get/put/delete worker bodies) against an in-memory fake hdfmonkey image - full-disk detection, mkdir-exists ls fallback, delete ordering, cancel and error-continuation paths. `zxnu_workers.py`: 76->80.6%.
- New `tests/test_remote_explorer_widget.py`: offscreen widget-layer tests for `RemoteExplorerWidget` driven through its `enqueue`/`on_*` seam with scripted dialogs - connection/drive state, listing + sort persistence, navigation, operation lifecycle (cancel/disconnect/background rcpy overlay), transfers, copy/cut/paste with move markers, rcpy free-space precheck, sync root, local file ops, drag & drop. `zxnu_remote_explorer.py`: **10.2% -> 77.3%**; suite total 33.1% -> 37.1%.
- **Bug fix**: in-image rename crashed in its delete phase since v9.0.8 - the `_run_delete_task` call inside `_run_rename_task` predates strangler extraction #3 and was never given the new `execute` argument, so every rename did get+put then TypeError'd, leaving BOTH the old and new entries. Found while writing the worker-body tests; one-line fix.

## Test plan
- `python tests/run_all.py --coverage`: all 10 suites PASS (incl. the 7 offscreen UI phases with hdfmonkey), coverage table produced, exit 0.
- `ruff check .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)