### PR TITLE
Bump version to 9.1.9

### DIFF
--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -20,7 +20,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.1.8"
+ZX_NEXT_UNITE_VERSION = "9.1.9"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Version bump for the first CI-built release. After merging, tag the merge commit as v9.1.9 and push the tag — the release workflow builds the three platform packages and opens a draft release for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)