### PR TITLE
CI: run the test suite under Xvfb (fixes the 3.10 matrix leg)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,16 +51,22 @@ jobs:
             echo "::error::Tag ${GITHUB_REF_NAME} does not match ZX_NEXT_UNITE_VERSION=${ver} in zxnu_config.py — the self-updater compares these."
             exit 1
           fi
-      - name: Install Qt runtime libraries (offscreen tests)
+      - name: Install Qt runtime libraries and Xvfb (headless test display)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libegl1 libgl1 libxkbcommon0 fontconfig
+          sudo apt-get install -y --no-install-recommends \
+            libegl1 libgl1 libxkbcommon0 fontconfig xvfb \
+            libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+            libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 \
+            libxkbcommon-x11-0 libxcb-cursor0
       - name: Install dependencies
         run: python -m pip install -r REQUIREMENTS.txt
       - name: Run the test suite
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: python tests/run_all.py
+        # Under Xvfb, NOT QT_QPA_PLATFORM=offscreen: the suite manages Qt
+        # platforms itself (test_ui_offscreen.py opts into offscreen), and
+        # test_retro_log_widget.py NEEDS the real platform — pygame crashes
+        # natively under a forced offscreen (segfaulted the 3.10 leg on CI).
+        run: xvfb-run -a python tests/run_all.py
 
   build:
     needs: test


### PR DESCRIPTION
The workflow-level QT_QPA_PLATFORM=offscreen export silently segfaulted test_retro_log_widget.py on the Python 3.10 leg — that test's docstring warns the pygame-backed widget crashes natively under forced offscreen and must run on the real Qt platform (the 3.13 pygame build happened to tolerate it). The test step now runs under xvfb-run with the Qt xcb libraries installed and no forced platform, letting each test pick its own (test_ui_offscreen.py already opts into offscreen itself).

Verified by dispatching this branch's workflow: run 30363541589 — test (3.10) ✅, test (3.13) ✅, all three platform builds ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)