### PR TITLE
Bump version to 9.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.1.9"
+version = "9.2.0"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -20,7 +20,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.1.9"
+ZX_NEXT_UNITE_VERSION = "9.2.0"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Version bump for the next release (both gated spots: ZX_NEXT_UNITE_VERSION + pyproject.toml).

**Merge order: merge #203 (data root) first, then this.** Then tag the merge commit as v9.2.0 and push the tag — the release workflow builds the packages into a draft release, and publishing that release pushes 9.2.0 to PyPI automatically.

Since 9.1.9: PyPI/pipx install (zx-next-unite + nextsync5 entry points), one per-user data root with automatic migration of pipx-era state, Python 3.10+ floor verified by the CI test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)