### PR TITLE
Bump version to 9.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.2.0"
+version = "9.2.1"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.2.0"
+ZX_NEXT_UNITE_VERSION = "9.2.1"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Version bump for the 9.2.1 patch release (both gated spots: ZX_NEXT_UNITE_VERSION + pyproject.toml).

Since 9.2.0: every toast translated into FR/ES/PT/PL/RU/CS with a tripwire test, and pipx-aware install hints on the greyed-out optional-package toggles.

After merging: tag the merge commit as v9.2.1 and push the tag (say the word and Claude can do it) — the workflow builds the draft release, and publishing it pushes 9.2.1 to PyPI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)