### PR TITLE
Fix classic-sync Bye/Later shutdown race; bump to 9.2.2

### DIFF
--- a/nextsync5.py
+++ b/nextsync5.py
@@ -1417,6 +1417,23 @@ def main():
                     elif data == b"Bye":
                         sendpacket(conn, str.encode("Later"), 0)
                         print(f"{timestamp()} | Closing connection")
+                        # Drain until the Next closes its side before we do:
+                        # the hard (SO_LINGER-0) close below sends an RST
+                        # that can otherwise clobber the just-queued "Later",
+                        # making the dot retry its bye against a dead socket.
+                        # The peer's EOF proves "Later" was consumed; the
+                        # grace period bounds a client that never hangs up.
+                        try:
+                            conn.settimeout(2.0)
+                            while conn.recv(1024):
+                                pass
+                        except (socket.timeout, OSError):
+                            pass
+                        finally:
+                            try:
+                                conn.settimeout(None)
+                            except OSError:
+                                pass
                         talking = False
                         _in_transfer = False
                     elif data == b"Sync2" or data == b"Sync1" or data == b"Sync":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.2.1"
+version = "9.2.2"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.2.1"
+ZX_NEXT_UNITE_VERSION = "9.2.2"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -2234,6 +2234,28 @@ def run_classic_sync_server(sync_root, log, *, progress_callback=None,
                         elif data == b"Bye":
                             sendpacket(conn, str.encode("Later"), 0, log=_vlog)
                             log(f"{timestamp()} | Closing connection")
+                            # Drain until the Next closes its side before we
+                            # do: the hard (SO_LINGER-0) close below sends an
+                            # RST that can otherwise clobber the just-queued
+                            # "Later" (on Windows a reset also flushes data
+                            # already in the peer's receive buffer), making
+                            # the dot retry its bye against a dead socket —
+                            # and tests/test_classic_sync.py flake with
+                            # WinError 10054. The peer's EOF proves "Later"
+                            # was consumed; the grace period bounds a client
+                            # that never hangs up. Mirrors the post-B linger
+                            # in the Send path above.
+                            try:
+                                conn.settimeout(2.0)
+                                while conn.recv(1024):
+                                    pass
+                            except (socket.timeout, OSError):
+                                pass
+                            finally:
+                                try:
+                                    conn.settimeout(None)
+                                except OSError:
+                                    pass
                             talking = False
                         elif data == b"Sync2" or data == b"Sync1" or data == b"Sync":
                             packet = str.encode("Nextsync 0.8 or later needed")


### PR DESCRIPTION
## Summary

* **Fix the `tests/test_classic_sync.py` flake (~1-in-3 under back-to-back runs, `WinError 10054`)** — a real shutdown-ordering bug, not a test artifact: the classic Sync3/Sync4 server sets `SO_LINGER(1,0)` on the accepted connection (so *nixes never leave it in TIME_WAIT between syncs), which makes `close()` send a hard RST. The `Bye` handler queued its `"Later"` reply and closed immediately, so the RST raced the reply — on Windows a reset also flushes data already sitting in the peer''s receive buffer. Against a real Next the clobbered reply forces the dot to retry its bye against a dead socket, burning UART timeouts — the intermittent stall before "All done".

  Fix: after answering `Later`, drain the connection until the peer''s EOF (2 s grace bound) before closing — the peer''s FIN proves the reply was consumed, and only then may the linger-0 RST fire. Mirrors the post-`B` linger the Send path already uses. Applied to both classic loops: `zxnu_workers.run_classic_sync_server` (the app) and `nextsync5.py` (the standalone CLI server). The `-listen` loops close gracefully (no `SO_LINGER`) and are unaffected.

* **Bump version to 9.2.2** (`ZX_NEXT_UNITE_VERSION` + `pyproject.toml` in lockstep).

## Test plan

- [x] 20 consecutive `python tests/test_classic_sync.py` runs green (previously ~1-in-3 failures; odds of 20 clean runs under the old fault rate ≈ 0.03%)
- [x] `python tests/run_all.py` green twice back-to-back (the suite''s alternating classic-sync failure is gone)
- [x] `ruff check .` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)