### PR TITLE
Wizard polish: paginated bubble, rights reminder, live language switch, language-first tour

### DIFF
--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -486,11 +486,11 @@ def inspect_phase1():
         i = lay.indexOf(w)
         return None if i < 0 else lay.getItemPosition(i)[:2]
     check("general-text swatch at settings (23,1)",
-          spos(win.settings_btn_color_general_text) == (23, 1), str(spos(win.settings_btn_color_general_text)))
-    check("retro-log swatch right under it (24,1)",
-          spos(win.settings_btn_color_retro_log) == (24, 1), str(spos(win.settings_btn_color_retro_log)))
-    check("retro font combo pushed to (25,1)",
-          spos(win.settings_retro_log_font_combo) == (25, 1), str(spos(win.settings_retro_log_font_combo)))
+          spos(win.settings_btn_color_general_text) == (24, 1), str(spos(win.settings_btn_color_general_text)))
+    check("retro-log swatch right under it (25,1)",
+          spos(win.settings_btn_color_retro_log) == (25, 1), str(spos(win.settings_btn_color_retro_log)))
+    check("retro font combo pushed to (26,1)",
+          spos(win.settings_retro_log_font_combo) == (26, 1), str(spos(win.settings_retro_log_font_combo)))
     check("default retro color is phosphor green",
           win.img_color_retro_log.name().lower() == "#78ff8c", win.img_color_retro_log.name())
     check("default swatch shows phosphor green",
@@ -763,8 +763,11 @@ def inspect_phase6():
     check("UI language row right under it (1,1)",
           spos(win.settings_ui_language_combo) == (1, 1),
           str(spos(win.settings_ui_language_combo)))
-    check("desktop theme pushed to row 2",
-          spos(win.settings_desktop_theme_combo) == (2, 1),
+    check("wizard toggle right under the language row (2,0)",
+          spos(win.settings_wizard_checkbox) == (2, 0),
+          str(spos(win.settings_wizard_checkbox)))
+    check("desktop theme pushed to row 3",
+          spos(win.settings_desktop_theme_combo) == (3, 1),
           str(spos(win.settings_desktop_theme_combo)))
     check("cfg 'false' restored as unchecked", not cb.isChecked())
     cb.setChecked(True)
@@ -774,9 +777,9 @@ def inspect_phase6():
 
     # Recycle Bin deletes toggle: sits right under the no-prompt checkbox.
     rb = win.settings_delete_to_recycle_bin_checkbox
-    check("recycle toggle at settings (5,0)", spos(rb) == (5, 0), str(spos(rb)))
-    check("no-prompt checkbox above it (4,0)",
-          spos(win.settings_no_prompt_on_deletion_checkbox) == (4, 0),
+    check("recycle toggle at settings (6,0)", spos(rb) == (6, 0), str(spos(rb)))
+    check("no-prompt checkbox above it (5,0)",
+          spos(win.settings_no_prompt_on_deletion_checkbox) == (5, 0),
           str(spos(win.settings_no_prompt_on_deletion_checkbox)))
     if rb.isEnabled():
         check("cfg 'false' restored as unchecked (recycle)", not rb.isChecked())

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -116,10 +116,13 @@ wiz.bubble._flip(-1)
 check("page flip goes back", wiz.bubble._page == 0)
 
 wiz.start_tour()
-check("tour switched to the first tab", tabs.currentIndex() == 0)
-first_text = wiz.bubble.label.text()
-check("tour speaks the SD-card step",
-      first_text == wc.wizard_tr("tour.sdcard", "en"))
+check("tour opens on Settings with the language step",
+      tabs.tabText(tabs.currentIndex()).startswith("Settings")
+      and wiz.bubble.label.text() == wc.wizard_tr("tour.language", "en"))
+wiz.next_tour_step()
+check("then the SD-card tab and step",
+      tabs.currentIndex() == 0
+      and wiz.bubble.label.text() == wc.wizard_tr("tour.sdcard", "en"))
 wiz.next_tour_step()
 check("tour advanced to NextSync", tabs.currentIndex() == 1)
 wiz.next_tour_step()
@@ -160,12 +163,13 @@ wiz.on_language_changed()
 check("open menu re-speaks in the new language",
       wiz.bubble.label.text() == wc.wizard_tr("menu.title", "fr"))
 zxnu_i18n.set_current_ui_language("en")
-wiz.start_tour()
+wiz.start_tour()          # opens on the Settings/language step
+_lang_tab = tabs.currentIndex()
 zxnu_i18n.set_current_ui_language("pl")
 wiz.on_language_changed()
 check("open tour step re-speaks in the new language",
-      wiz.bubble.label.text() == wc.wizard_tr("tour.sdcard", "pl"))
-check("re-speak stays on the same tab", tabs.currentIndex() == 0)
+      wiz.bubble.label.text() == wc.wizard_tr("tour.language", "pl"))
+check("re-speak stays on the same tab", tabs.currentIndex() == _lang_tab)
 zxnu_i18n.set_current_ui_language("en")
 wiz.tell_joke()
 _joke_idx = wc.JOKES["en"].index(wiz.bubble.label.text())

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -153,7 +153,28 @@ zxnu_i18n.set_current_ui_language("es")
 wiz.show_menu()
 check("menu speaks the active language",
       wiz.bubble.label.text() == wc.wizard_tr("menu.title", "es"))
+
+# A live language switch re-composes whatever is currently on screen.
+zxnu_i18n.set_current_ui_language("fr")
+wiz.on_language_changed()
+check("open menu re-speaks in the new language",
+      wiz.bubble.label.text() == wc.wizard_tr("menu.title", "fr"))
 zxnu_i18n.set_current_ui_language("en")
+wiz.start_tour()
+zxnu_i18n.set_current_ui_language("pl")
+wiz.on_language_changed()
+check("open tour step re-speaks in the new language",
+      wiz.bubble.label.text() == wc.wizard_tr("tour.sdcard", "pl"))
+check("re-speak stays on the same tab", tabs.currentIndex() == 0)
+zxnu_i18n.set_current_ui_language("en")
+wiz.tell_joke()
+_joke_idx = wc.JOKES["en"].index(wiz.bubble.label.text())
+zxnu_i18n.set_current_ui_language("cs")
+wiz.on_language_changed()
+check("the SAME joke re-tells in the new language",
+      wiz.bubble.label.text() == wc.JOKES["cs"][_joke_idx])
+zxnu_i18n.set_current_ui_language("en")
+wiz._dismiss()
 
 # Turn-off persists and hides (the farewell hides after a delay; force it).
 wiz.set_enabled(False)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -106,7 +106,14 @@ wiz.startup()
 check("first-run marks the intro as shown",
       cfg.get(SETTING_WIZARD_INTRO_SHOWN) == "true")
 check("intro bubble is visible", wiz.bubble.isVisible())
-check("intro offers tour/later/off buttons", len(wiz.bubble._buttons) == 3)
+check("intro offers tour/later/off actions", len(wiz.bubble._actions) == 3)
+check("intro paginates with nav buttons",
+      len(wiz.bubble._pages) > 1
+      and any(b.text() == "▶" for b in wiz.bubble._buttons))
+wiz.bubble._flip(+1)
+check("page flip advances", wiz.bubble._page == 1)
+wiz.bubble._flip(-1)
+check("page flip goes back", wiz.bubble._page == 0)
 
 wiz.start_tour()
 check("tour switched to the first tab", tabs.currentIndex() == 0)
@@ -117,6 +124,11 @@ wiz.next_tour_step()
 check("tour advanced to NextSync", tabs.currentIndex() == 1)
 wiz.next_tour_step()
 check("tour advanced to GetIt", tabs.currentIndex() == 2)
+check("catalogue step softly recalls the rights reminder",
+      wc.wizard_tr("tour.disclaimer", "en")[:40]
+      in " ".join(wiz.bubble._pages))
+check("no page ever ends in a stranded ellipsis",
+      all(not p.endswith("…") for p in wiz.bubble._pages))
 # zxArt/ZXDB/Favorites/Unite/itch.io are absent from the stub -> the tour
 # must skip them gracefully: the next steps land on Settings then Help.
 wiz.next_tour_step()

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -3475,6 +3475,10 @@ class MainWindow(QMainWindow):
         # every catalogued text in place (English restores the originals).
         def _i18n_apply(code):
             translate_widget_tree(self, normalize_ui_language(code))
+            # A speaking wizard switches language mid-speech (zxnu_wizard.py).
+            _wiz = getattr(self, "_wizard", None)
+            if _wiz is not None:
+                _wiz.on_language_changed()
         self._i18n_apply = _i18n_apply
 
         build_settings_pane(

--- a/zxnu_settings_pane.py
+++ b/zxnu_settings_pane.py
@@ -198,7 +198,7 @@ def build_settings_pane(
         "  • Custom: keep your hand-picked colours. Changing any colour\n"
         "    below switches to Custom automatically."
     )
-    grid_tab_Settings.addWidget(desktop_theme_lbl, 2, 0)
+    grid_tab_Settings.addWidget(desktop_theme_lbl, 3, 0)
 
     host.settings_desktop_theme_combo = QComboBox()
     host.settings_desktop_theme_combo.addItem("Automatic (default)",   DESKTOP_THEME_AUTOMATIC)
@@ -211,7 +211,7 @@ def build_settings_pane(
     host.settings_desktop_theme_combo.currentIndexChanged.connect(
         lambda _i: _settings_desktop_theme_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_desktop_theme_combo, 2, 1)
+    grid_tab_Settings.addWidget(host.settings_desktop_theme_combo, 3, 1)
 
     # ── Application UI language (its own row, right under the self-update
     # toggle — columns 2+ sit outside the visible pane width, so the picker
@@ -261,7 +261,7 @@ def build_settings_pane(
         "Uncheck this option to suppress that warning."
     )
     host.settings_warn_image_nearly_full_checkbox.stateChanged.connect(settings_warn_image_nearly_full_statechanged)
-    grid_tab_Settings.addWidget(host.settings_warn_image_nearly_full_checkbox, 3, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_warn_image_nearly_full_checkbox, 4, 0, 1, 2)
 
     def settings_no_prompt_on_deletion_statechanged():
         configuration_dictionary[SETTING_NO_PROMPT_ON_DELETION] = "true" if host.settings_no_prompt_on_deletion_checkbox.isChecked() else "false"
@@ -275,7 +275,7 @@ def build_settings_pane(
         "Leave unchecked to keep the confirmation prompt (recommended)."
     )
     host.settings_no_prompt_on_deletion_checkbox.stateChanged.connect(settings_no_prompt_on_deletion_statechanged)
-    grid_tab_Settings.addWidget(host.settings_no_prompt_on_deletion_checkbox, 4, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_no_prompt_on_deletion_checkbox, 5, 0, 1, 2)
 
     # ── Recycle Bin deletes (Send2Trash, optional) ─────────────────────
     # When on (the default), files/folders deleted in the LOCAL file
@@ -310,7 +310,7 @@ def build_settings_pane(
             + "\nUntil it is installed, local deletes stay permanent.")
     host.settings_delete_to_recycle_bin_checkbox.stateChanged.connect(
         lambda _s: settings_delete_to_recycle_bin_statechanged())
-    grid_tab_Settings.addWidget(host.settings_delete_to_recycle_bin_checkbox, 5, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_delete_to_recycle_bin_checkbox, 6, 0, 1, 2)
 
     def settings_avail_check_statechanged():
         configuration_dictionary[SETTING_AVAIL_CHECK] = "true" if host.settings_avail_check_checkbox.isChecked() else "false"
@@ -327,7 +327,7 @@ def build_settings_pane(
     host.settings_avail_check_checkbox.stateChanged.connect(settings_avail_check_statechanged)
     _avail_check_visible = ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS or ZX_NEXT_UNITE_ZXART_ENABLE_DOWNLOAD_BUTTONS
     host.settings_avail_check_checkbox.setVisible(_avail_check_visible)
-    grid_tab_Settings.addWidget(host.settings_avail_check_checkbox, 7, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_avail_check_checkbox, 8, 0, 1, 2)
 
     def settings_multi_search_statechanged():
         configuration_dictionary[SETTING_MULTI_SEARCH] = "true" if host.settings_multi_search_checkbox.isChecked() else "false"
@@ -341,7 +341,7 @@ def build_settings_pane(
         "with the number of results found, e.g. ZXDB (5)."
     )
     host.settings_multi_search_checkbox.stateChanged.connect(settings_multi_search_statechanged)
-    grid_tab_Settings.addWidget(host.settings_multi_search_checkbox, 8, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_multi_search_checkbox, 9, 0, 1, 2)
 
     def settings_search_autocomplete_statechanged():
         enabled = host.settings_search_autocomplete_checkbox.isChecked()
@@ -357,7 +357,7 @@ def build_settings_pane(
         "Uncheck to disable autocomplete suggestions on all search inputs."
     )
     host.settings_search_autocomplete_checkbox.stateChanged.connect(settings_search_autocomplete_statechanged)
-    grid_tab_Settings.addWidget(host.settings_search_autocomplete_checkbox, 9, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_search_autocomplete_checkbox, 10, 0, 1, 2)
 
     # ---- Gallery (picture view) settings ----
     def _settings_gallery_anim_changed():
@@ -374,7 +374,7 @@ def build_settings_pane(
         "  • Timed: cycles continuously while the gallery is visible.\n"
         "  • None: never cycles between images (animated GIFs still play)."
     )
-    grid_tab_Settings.addWidget(gallery_anim_lbl, 10, 0)
+    grid_tab_Settings.addWidget(gallery_anim_lbl, 11, 0)
 
     host.settings_gallery_anim_combo = QComboBox()
     host.settings_gallery_anim_combo.addItem("On hover (default)", "hover")
@@ -384,7 +384,7 @@ def build_settings_pane(
     host.settings_gallery_anim_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_anim_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_anim_combo, 10, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_anim_combo, 11, 1)
 
     def _settings_gallery_rows_changed(val: int):
         val = max(GALLERY_MIN_ROWS, min(GALLERY_MAX_ROWS, int(val)))
@@ -397,14 +397,14 @@ def build_settings_pane(
         "Number of thumbnail rows shown per gallery page.\n"
         f"Range {GALLERY_MIN_ROWS}–{GALLERY_MAX_ROWS}. Default {DEFAULT_GALLERY_ROWS_PER_PAGE}."
     )
-    grid_tab_Settings.addWidget(gallery_rows_lbl, 11, 0)
+    grid_tab_Settings.addWidget(gallery_rows_lbl, 12, 0)
 
     host.settings_gallery_rows_spin = QSpinBox()
     host.settings_gallery_rows_spin.setRange(GALLERY_MIN_ROWS, GALLERY_MAX_ROWS)
     host.settings_gallery_rows_spin.setValue(DEFAULT_GALLERY_ROWS_PER_PAGE)
     host.settings_gallery_rows_spin.setToolTip(gallery_rows_lbl.toolTip())
     host.settings_gallery_rows_spin.valueChanged.connect(_settings_gallery_rows_changed)
-    grid_tab_Settings.addWidget(host.settings_gallery_rows_spin, 11, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_rows_spin, 12, 1)
 
     def _make_color_button(setting_key, color_attr, label_text, tooltip_text, grid_row,
                            switch_theme=True, on_change=None):
@@ -478,7 +478,7 @@ def build_settings_pane(
         "Number of thumbnail columns shown in the gallery grid.\n"
         "Default is 4. Choose 2 for larger tiles or 8 for more items per row."
     )
-    grid_tab_Settings.addWidget(gallery_cols_lbl, 12, 0)
+    grid_tab_Settings.addWidget(gallery_cols_lbl, 13, 0)
 
     host.settings_gallery_cols_combo = QComboBox()
     host.settings_gallery_cols_combo.addItem("2", 2)
@@ -489,7 +489,7 @@ def build_settings_pane(
     host.settings_gallery_cols_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_cols_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_cols_combo, 12, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_cols_combo, 13, 1)
 
     def _settings_gallery_img_size_changed():
         val = host.settings_gallery_img_size_combo.currentData() or DEFAULT_GALLERY_IMG_SIZE
@@ -504,7 +504,7 @@ def build_settings_pane(
         "  • Medium (default): standard size\n"
         "  • Large: double the medium height"
     )
-    grid_tab_Settings.addWidget(gallery_img_size_lbl, 13, 0)
+    grid_tab_Settings.addWidget(gallery_img_size_lbl, 14, 0)
 
     host.settings_gallery_img_size_combo = QComboBox()
     host.settings_gallery_img_size_combo.addItem("Small",          "small")
@@ -515,7 +515,7 @@ def build_settings_pane(
     host.settings_gallery_img_size_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_img_size_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_img_size_combo, 13, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_img_size_combo, 14, 1)
 
     def _settings_gallery_slideshow_changed():
         val = host.settings_gallery_slideshow_combo.currentData()
@@ -539,7 +539,7 @@ def build_settings_pane(
         "How long each screenshot is shown before the auto-advancing gallery\n"
         "slideshow moves to the next image. Default is 5 seconds."
     )
-    grid_tab_Settings.addWidget(gallery_slideshow_lbl, 14, 0)
+    grid_tab_Settings.addWidget(gallery_slideshow_lbl, 15, 0)
 
     host.settings_gallery_slideshow_combo = QComboBox()
     for _secs in GALLERY_SLIDESHOW_SECS_CHOICES:
@@ -550,45 +550,45 @@ def build_settings_pane(
     host.settings_gallery_slideshow_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_slideshow_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_slideshow_combo, 14, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_slideshow_combo, 15, 1)
 
     settings_section_lbl = QLabel("Local file explorers & App Text Colors:")
     settings_section_lbl.setToolTip(
         "Customize the foreground color of each item type shown in the SD card\n"
         "image explorer, plus the general app text color (labels, checkboxes,\n"
         "section headers) used across the app in Classic (non-pygame) mode.")
-    grid_tab_Settings.addWidget(settings_section_lbl, 16, 0, 1, 2)
+    grid_tab_Settings.addWidget(settings_section_lbl, 17, 0, 1, 2)
 
     host.settings_btn_color_up_directory = _make_color_button(
         SETTING_COLOR_UP_DIRECTORY, "img_color_up_directory",
         "  Up Directory item",
         "Color used for the '[Up Directory..]' navigation row in the image explorer.",
-        17)
+        18)
     host.settings_btn_color_dir_name = _make_color_button(
         SETTING_COLOR_DIR_NAME, "img_color_dir_name",
         "  Directory name",
         "Color used for directory name entries in the image explorer.",
-        18)
+        19)
     host.settings_btn_color_dir_type = _make_color_button(
         SETTING_COLOR_DIR_TYPE, "img_color_dir_type",
         "  Directory type label",
         "Color used for the 'DIR' type label column of directory entries.",
-        19)
+        20)
     host.settings_btn_color_file_name = _make_color_button(
         SETTING_COLOR_FILE_NAME, "img_color_file_name",
         "  File name",
         "Color used for file name entries in the image explorer.",
-        20)
+        21)
     host.settings_btn_color_file_ext = _make_color_button(
         SETTING_COLOR_FILE_EXT, "img_color_file_ext",
         "  File extension",
         "Color used for the file extension column in the image explorer.",
-        21)
+        22)
     host.settings_btn_color_file_size = _make_color_button(
         SETTING_COLOR_FILE_SIZE, "img_color_file_size",
         "  File size",
         "Color used for the file size column in the image explorer.",
-        22)
+        23)
     host.settings_btn_color_general_text = _make_color_button(
         SETTING_COLOR_GENERAL_TEXT, "img_color_general_text",
         "  General UI text",
@@ -597,7 +597,7 @@ def build_settings_pane(
         "light desktop/White theme would otherwise make this text black and\n"
         "unreadable. The White/Dark/Automatic/High-contrast themes set this\n"
         "automatically; picking a color here switches to the Custom theme.",
-        23)
+        24)
 
     # ---- Retro log console text color (pygame log windows) ----
     def _apply_retro_log_color(color=None):
@@ -622,7 +622,7 @@ def build_settings_pane(
         "Font color for the retro 8-bit (pygame) log consoles on the\n"
         "SD Card, NextSync and Help tabs. Applies immediately. Default is\n"
         "the classic phosphor green. Independent of the Desktop Theme.",
-        24, switch_theme=False, on_change=_apply_retro_log_color)
+        25, switch_theme=False, on_change=_apply_retro_log_color)
 
     # ---- Retro log font size (SD Card + NextSync pygame log windows) ----
     def _apply_retro_log_font_size(px):
@@ -651,7 +651,7 @@ def build_settings_pane(
         "Consolas text size for the retro 8-bit (pygame) log windows on the\n"
         "SD Card and NextSync tabs. Applies immediately. Default is 13."
     )
-    grid_tab_Settings.addWidget(retro_log_font_lbl, 25, 0)
+    grid_tab_Settings.addWidget(retro_log_font_lbl, 26, 0)
 
     host.settings_retro_log_font_combo = QComboBox()
     for _px in RETRO_LOG_FONT_SIZE_CHOICES:
@@ -665,7 +665,7 @@ def build_settings_pane(
     host.settings_retro_log_font_combo.currentIndexChanged.connect(
         lambda _i: _settings_retro_log_font_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_retro_log_font_combo, 25, 1)
+    grid_tab_Settings.addWidget(host.settings_retro_log_font_combo, 26, 1)
 
     # ---- Background image opacity ----
     bg_opacity_lbl = QLabel("Background image opacity (%):")
@@ -673,7 +673,7 @@ def build_settings_pane(
         "Controls how visible the background image is behind the UI.\n"
         "0 = fully hidden, 100 = fully visible. Default is 5%."
     )
-    grid_tab_Settings.addWidget(bg_opacity_lbl, 26, 0)
+    grid_tab_Settings.addWidget(bg_opacity_lbl, 27, 0)
 
     bg_opacity_row = QWidget()
     bg_opacity_row_layout = QHBoxLayout(bg_opacity_row)
@@ -816,7 +816,7 @@ def build_settings_pane(
 
     bg_opacity_row_layout.addWidget(host.settings_bg_opacity_slider, 1)
     bg_opacity_row_layout.addWidget(host.settings_bg_opacity_spinbox, 0)
-    grid_tab_Settings.addWidget(bg_opacity_row, 26, 1)
+    grid_tab_Settings.addWidget(bg_opacity_row, 27, 1)
 
     # ---- Background image selector ----
     bg_image_lbl = QLabel("Background image:")
@@ -824,7 +824,7 @@ def build_settings_pane(
         "Choose a specific background image or 'Random' to cycle through\n"
         "all images in the script folder every 5 seconds."
     )
-    grid_tab_Settings.addWidget(bg_image_lbl, 27, 0)
+    grid_tab_Settings.addWidget(bg_image_lbl, 28, 0)
 
     bg_image_row = QWidget()
     bg_image_row_layout = QHBoxLayout(bg_image_row)
@@ -867,7 +867,7 @@ def build_settings_pane(
     host.settings_bg_image_preview.setToolTip("Preview of the selected background image.")
     bg_image_row_layout.addWidget(host.settings_bg_image_preview, 0)
 
-    grid_tab_Settings.addWidget(bg_image_row, 27, 1)
+    grid_tab_Settings.addWidget(bg_image_row, 28, 1)
 
     def _update_bg_image_preview(path: str):
         """Refresh the thumbnail label for the given absolute image path."""
@@ -931,7 +931,7 @@ def build_settings_pane(
     )
     host.settings_crash_log_enabled_checkbox.stateChanged.connect(
         settings_crash_log_enabled_statechanged)
-    grid_tab_Settings.addWidget(host.settings_crash_log_enabled_checkbox, 28, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_crash_log_enabled_checkbox, 29, 0, 1, 2)
 
     def settings_disable_no_emulator_toast_statechanged():
         configuration_dictionary[SETTING_DISABLE_NO_EMULATOR_TOAST] = "true" if host.settings_disable_no_emulator_toast_checkbox.isChecked() else "false"
@@ -945,7 +945,7 @@ def build_settings_pane(
         "Check this if you do not use any emulator and do not want the reminder."
     )
     host.settings_disable_no_emulator_toast_checkbox.stateChanged.connect(settings_disable_no_emulator_toast_statechanged)
-    grid_tab_Settings.addWidget(host.settings_disable_no_emulator_toast_checkbox, 29, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_disable_no_emulator_toast_checkbox, 30, 0, 1, 2)
 
     # ── NextSync HTTP bridge toggle + port ──────────────────────────
     def _http_port_widgets_set_enabled(on):
@@ -1159,7 +1159,7 @@ def build_settings_pane(
     _http_bridge_vbox = QVBoxLayout()
     _http_bridge_vbox.addLayout(_http_bridge_row)
     _http_bridge_vbox.addLayout(_http_token_row)
-    grid_tab_Settings.addLayout(_http_bridge_vbox, 40, 0, 1, 2)
+    grid_tab_Settings.addLayout(_http_bridge_vbox, 41, 0, 1, 2)
     host._http_port_widgets_set_enabled = _http_port_widgets_set_enabled
 
     # ── MAME options (shown when MAME is launchable: a detected binary, or
@@ -1175,7 +1175,7 @@ def build_settings_pane(
             "This is inserted right after the MAME executable and is no longer part\n"
             "of the command-line parameters below."
         )
-        grid_tab_Settings.addWidget(mame_rom_lbl, 30, 0)
+        grid_tab_Settings.addWidget(mame_rom_lbl, 31, 0)
 
         host.settings_mame_rom_combo = QComboBox()
         for _rom_name in MAME_ROM_CHOICE:
@@ -1183,7 +1183,7 @@ def build_settings_pane(
         host.settings_mame_rom_combo.setToolTip(mame_rom_lbl.toolTip())
         host.settings_mame_rom_combo.currentIndexChanged.connect(
             lambda _i: settings_mame_rom_changed())
-        grid_tab_Settings.addWidget(host.settings_mame_rom_combo, 30, 1)
+        grid_tab_Settings.addWidget(host.settings_mame_rom_combo, 31, 1)
 
         def settings_mame_params_changed():
             configuration_dictionary[SETTING_MAME_COMMAND_LINE_PARAMETERS] = host.settings_mame_params_edit.text()
@@ -1200,7 +1200,7 @@ def build_settings_pane(
             "-mouse/-mouse_device or -joystick/-joystickprovider options typed here\n"
             "are ignored (the combos take precedence)."
         )
-        grid_tab_Settings.addWidget(mame_params_lbl, 31, 0)
+        grid_tab_Settings.addWidget(mame_params_lbl, 32, 0)
 
         host.settings_mame_params_edit = QLineEdit()
         host.settings_mame_params_edit.setText(
@@ -1208,7 +1208,7 @@ def build_settings_pane(
                 SETTING_MAME_COMMAND_LINE_PARAMETERS, MAME_DEFAULT_COMMAND_LINE))
         host.settings_mame_params_edit.setToolTip(mame_params_lbl.toolTip())
         host.settings_mame_params_edit.editingFinished.connect(settings_mame_params_changed)
-        grid_tab_Settings.addWidget(host.settings_mame_params_edit, 31, 1)
+        grid_tab_Settings.addWidget(host.settings_mame_params_edit, 32, 1)
 
         # The startup update check only exists where the app can actually
         # fetch a build (64-bit Windows / x86_64 Linux). On macOS MAME is
@@ -1235,7 +1235,7 @@ def build_settings_pane(
             )
             host.settings_mame_update_check_checkbox.stateChanged.connect(
                 lambda _s: settings_mame_update_check_changed())
-            grid_tab_Settings.addWidget(host.settings_mame_update_check_checkbox, 32, 0, 1, 2)
+            grid_tab_Settings.addWidget(host.settings_mame_update_check_checkbox, 33, 0, 1, 2)
 
     # ── Launch MAME with Flatpak (Linux) ──────────────────────────────
     # Shown on Linux regardless of whether a MAME binary was detected, so a
@@ -1303,7 +1303,7 @@ def build_settings_pane(
         host.settings_mame_flatpak_rompath_row.setVisible(_flatpak_on)
         _flatpak_layout.addWidget(host.settings_mame_flatpak_rompath_row)
 
-        grid_tab_Settings.addWidget(_flatpak_box, 32, 0, 1, 2)
+        grid_tab_Settings.addWidget(_flatpak_box, 33, 0, 1, 2)
 
     # ── CSpect default launch parameters ───────────────────────────────
     # Shown unconditionally (unlike the MAME block above, which is gated on
@@ -1325,14 +1325,14 @@ def build_settings_pane(
         "launch. Leave empty to restore the built-in default. Saved to the\n"
         "configuration file."
     )
-    grid_tab_Settings.addWidget(cspect_params_lbl, 33, 0)
+    grid_tab_Settings.addWidget(cspect_params_lbl, 34, 0)
 
     host.settings_cspect_params_edit = QLineEdit()
     host.settings_cspect_params_edit.setText(
         configuration_dictionary.get(SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS))
     host.settings_cspect_params_edit.setToolTip(cspect_params_lbl.toolTip())
     host.settings_cspect_params_edit.editingFinished.connect(settings_cspect_params_changed)
-    grid_tab_Settings.addWidget(host.settings_cspect_params_edit, 33, 1)
+    grid_tab_Settings.addWidget(host.settings_cspect_params_edit, 34, 1)
 
     # ── Unite! pygame background animation toggle ──────────────────────
     def _settings_pygame_anim_changed():
@@ -1361,7 +1361,7 @@ def build_settings_pane(
     )
     host.settings_pygame_anim_checkbox.stateChanged.connect(
         lambda _s: _settings_pygame_anim_changed())
-    grid_tab_Settings.addWidget(host.settings_pygame_anim_checkbox, 35, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_pygame_anim_checkbox, 36, 0, 1, 2)
 
     # ── NextSync retro-log starfield animation toggle ──────────────────
     def _settings_nextsync_anim_changed():
@@ -1393,7 +1393,7 @@ def build_settings_pane(
     )
     host.settings_nextsync_pygame_anim_checkbox.stateChanged.connect(
         lambda _s: _settings_nextsync_anim_changed())
-    grid_tab_Settings.addWidget(host.settings_nextsync_pygame_anim_checkbox, 38, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_nextsync_pygame_anim_checkbox, 39, 0, 1, 2)
 
     # ── Alien Floyd's: optional pygame-ce animated background everywhere ──
     # A Pink Floyd homage. When on, a pygame-ce "Alien Floyd's" animation
@@ -1448,7 +1448,7 @@ def build_settings_pane(
         "file. Requires the optional 'pygame-ce' package.")
     host.settings_alien_floyd_bg_checkbox.stateChanged.connect(
         lambda _s: _settings_alien_bg_changed())
-    grid_tab_Settings.addWidget(host.settings_alien_floyd_bg_checkbox, 36, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_alien_floyd_bg_checkbox, 37, 0, 1, 2)
 
     # ── Alien Floyd's: optional dedicated full-window tab ────────────────
     host._alien_floyd_tab_widget = None
@@ -1520,7 +1520,7 @@ def build_settings_pane(
         "configuration file. Requires the optional 'pygame-ce' package.")
     host.settings_alien_floyd_tab_checkbox.stateChanged.connect(
         lambda _s: _settings_alien_tab_changed())
-    grid_tab_Settings.addWidget(host.settings_alien_floyd_tab_checkbox, 37, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_alien_floyd_tab_checkbox, 38, 0, 1, 2)
 
     # ── itch.io: optional online tab (driven by the 'itch-dl' package) ───
     def _itchio_tab_set_visible(on):
@@ -1563,7 +1563,7 @@ def build_settings_pane(
             "configuration file. Requires the optional 'itch-dl' package.")
     host.settings_show_itchio_tab_checkbox.stateChanged.connect(
         lambda _s: _settings_itchio_tab_changed())
-    grid_tab_Settings.addWidget(host.settings_show_itchio_tab_checkbox, 39, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_show_itchio_tab_checkbox, 40, 0, 1, 2)
 
     # ── Onboarding Wizard (Wizzy, zxnu_wizard.py) ────────────────────────
     def _settings_wizard_changed():
@@ -1590,7 +1590,8 @@ def build_settings_pane(
         "configuration file.")
     host.settings_wizard_checkbox.stateChanged.connect(
         lambda _s: _settings_wizard_changed())
-    grid_tab_Settings.addWidget(host.settings_wizard_checkbox, 40, 0, 1, 2)
+    # Right under the Application-language row (all rows below shifted +1).
+    grid_tab_Settings.addWidget(host.settings_wizard_checkbox, 2, 0, 1, 2)
 
     # ── CSpect: check itch.io for a newer version at startup (default on) ──
     def settings_cspect_update_check_changed():
@@ -1613,7 +1614,7 @@ def build_settings_pane(
     host.settings_cspect_update_check_checkbox.stateChanged.connect(
         lambda _s: settings_cspect_update_check_changed())
     grid_tab_Settings.addWidget(
-        host.settings_cspect_update_check_checkbox, 34, 0, 1, 2)
+        host.settings_cspect_update_check_checkbox, 35, 0, 1, 2)
 
     # ── NextSync: what to do when a received file/dir already exists locally ──
     def _settings_nextsync_send_conflict_changed():
@@ -1630,7 +1631,7 @@ def build_settings_pane(
         "  • Overwrite: always replace the local file.\n"
         "  • Ignore: never touch existing local files."
     )
-    grid_tab_Settings.addWidget(nextsync_send_conflict_lbl, 6, 0)
+    grid_tab_Settings.addWidget(nextsync_send_conflict_lbl, 7, 0)
 
     host.settings_nextsync_send_conflict_combo = QComboBox()
     host.settings_nextsync_send_conflict_combo.addItem("Prompt (default)", "prompt")
@@ -1639,7 +1640,7 @@ def build_settings_pane(
     host.settings_nextsync_send_conflict_combo.setToolTip(nextsync_send_conflict_lbl.toolTip())
     host.settings_nextsync_send_conflict_combo.currentIndexChanged.connect(
         lambda _i: _settings_nextsync_send_conflict_changed())
-    grid_tab_Settings.addWidget(host.settings_nextsync_send_conflict_combo, 6, 1)
+    grid_tab_Settings.addWidget(host.settings_nextsync_send_conflict_combo, 7, 1)
 
     # ── Unite! search result sort / render preference ──────────────────
     def _settings_search_sort_changed():
@@ -1669,7 +1670,7 @@ def build_settings_pane(
         "  • Classic: ZXDB and zxArt items are preferred to the top, with\n"
         "    GetIt content placed at the end."
     )
-    grid_tab_Settings.addWidget(search_sort_lbl, 15, 0)
+    grid_tab_Settings.addWidget(search_sort_lbl, 16, 0)
 
     host.settings_search_sort_combo = QComboBox()
     host.settings_search_sort_combo.addItem("GetIt first class (default)", SEARCH_SORT_GETIT_FIRST)
@@ -1678,7 +1679,7 @@ def build_settings_pane(
     host.settings_search_sort_combo.setToolTip(search_sort_lbl.toolTip())
     host.settings_search_sort_combo.currentIndexChanged.connect(
         lambda _i: _settings_search_sort_changed())
-    grid_tab_Settings.addWidget(host.settings_search_sort_combo, 15, 1)
+    grid_tab_Settings.addWidget(host.settings_search_sort_combo, 16, 1)
 
     # "Open config file" — moved here from the SD-card tab. Opens hdfg.cfg in
     # the system text editor so advanced users can hand-edit settings. Placed
@@ -1686,7 +1687,7 @@ def build_settings_pane(
     # width rather than stretching across both columns.
     host.button_open_config_file = QPushButton("Open config file", host)
     host.button_open_config_file.clicked.connect(open_cspect_configuration_file)
-    grid_tab_Settings.addWidget(host.button_open_config_file, 41, 0, 1, 2, Qt.AlignLeft)
+    grid_tab_Settings.addWidget(host.button_open_config_file, 42, 0, 1, 2, Qt.AlignLeft)
 
     grid_tab_Settings.setColumnStretch(2, 1)
     zxnextunite_Settings_tab.setLayout(grid_tab_Settings)

--- a/zxnu_wizard.py
+++ b/zxnu_wizard.py
@@ -465,6 +465,9 @@ class WizardManager(QObject):
         self.bubble.on_resize = self._reposition
         self._tour_index = -1
         self._tour_active_page = None
+        # How to re-compose whatever the bubble currently shows — called on
+        # a live language switch so the wizard changes language mid-speech.
+        self._respeak = None
         self._teaser_cache = {}
         self._fetch_signals = _WikiFetchSignals()
         self._fetch_signals.done.connect(self._on_teaser)
@@ -589,7 +592,14 @@ class WizardManager(QObject):
         self.bubble.hide()
         self._tour_index = -1
         self._tour_active_page = None
+        self._respeak = None
         self.sprite.set_gesture("idle")
+
+    def on_language_changed(self):
+        """Live language switch (Settings combo): re-compose the current
+        speech in the new language while it is on screen."""
+        if self.bubble.isVisible() and self._respeak is not None:
+            self._respeak()
 
     # ── startup / first run ──────────────────────────────────────────────
     def startup(self):
@@ -613,6 +623,7 @@ class WizardManager(QObject):
             self.sprite.set_gesture("wave", cycles=2)
 
     def intro(self):
+        self._respeak = self.intro
         self._say(self._tr("intro.hello") + "\n\n" + self._tr("intro.offer"),
                   [(self._tr("btn.tour"), self.start_tour),
                    (self._tr("btn.later"), self._dismiss),
@@ -620,6 +631,7 @@ class WizardManager(QObject):
                   gesture="wave", cycles=4)
 
     def turn_off(self):
+        self._respeak = None
         self._say(self._tr("wizard.off"), [], gesture="cast", cycles=2)
         QTimer.singleShot(2600, lambda: self.set_enabled(False))
 
@@ -641,18 +653,23 @@ class WizardManager(QObject):
         self.next_tour_step()
 
     def next_tour_step(self):
-        tabw = getattr(self._host, "_tab_widget", None)
         while True:
             self._tour_index += 1
             if self._tour_index >= len(TOUR_STEPS):
                 self.finish_tour()
                 return
-            resolved = self._resolve_step(TOUR_STEPS[self._tour_index])
-            if resolved is not None:
+            if self._resolve_step(TOUR_STEPS[self._tour_index]) is not None:
                 break
+        self._show_tour_step()
+
+    def _show_tour_step(self):
+        """Display (or, on a language switch, re-display) the current step."""
+        resolved = self._resolve_step(TOUR_STEPS[self._tour_index])
+        if resolved is None:
+            return
         tab_index, text_key, page = resolved
         try:
-            tabw.setCurrentIndex(tab_index)
+            self._host._tab_widget.setCurrentIndex(tab_index)
         except Exception:
             pass
         self._tour_active_page = page
@@ -661,6 +678,7 @@ class WizardManager(QObject):
             # Browsing third-party catalogues: softly recall that the app
             # distributes nothing itself and rights are the user's to check.
             text += "\n\n" + self._tr("tour.disclaimer")
+        self._respeak = self._show_tour_step
         self._say(text,
                   [(self._tr("btn.next"), self.next_tour_step),
                    (self._tr("btn.more"), lambda _=False, p=page:
@@ -671,6 +689,7 @@ class WizardManager(QObject):
 
     def finish_tour(self):
         self._tour_active_page = None
+        self._respeak = self.finish_tour
         self._say(self._tr("tour.done"),
                   [(self._tr("btn.close"), self._dismiss)],
                   gesture="cast", cycles=3)
@@ -714,26 +733,35 @@ class WizardManager(QObject):
             self._reposition()
 
     # ── fun ──────────────────────────────────────────────────────────────
-    def _draw_from(self, table, bag):
-        lines = wizard_lines(table, self._lang())
+    # Bags hold INDICES into the canonical lists (same length in every
+    # language, tripwired), so a live language switch re-tells the SAME
+    # joke/story in the new language.
+    def _draw_index(self, table, bag):
         if not bag:
-            bag[:] = random.sample(lines, len(lines))
+            n = len(wizard_lines(table, "en"))
+            bag[:] = random.sample(range(n), n)
         return bag.pop()
 
-    def tell_joke(self):
-        self._say(self._draw_from(JOKES, self._joke_bag),
-                  [(self._tr("btn.another"), self.tell_joke),
+    def _show_fun(self, table, idx, again_cb, gesture, cycles):
+        lines = wizard_lines(table, self._lang())
+        self._respeak = lambda: self._show_fun(table, idx, again_cb,
+                                               gesture, cycles)
+        self._say(lines[idx % len(lines)],
+                  [(self._tr("btn.another"), again_cb),
                    (self._tr("btn.close"), self._dismiss)],
-                  gesture="cast", cycles=4)
+                  gesture=gesture, cycles=cycles)
+
+    def tell_joke(self):
+        self._show_fun(JOKES, self._draw_index(JOKES, self._joke_bag),
+                       self.tell_joke, "cast", 4)
 
     def tell_story(self):
-        self._say(self._draw_from(STORIES, self._story_bag),
-                  [(self._tr("btn.another"), self.tell_story),
-                   (self._tr("btn.close"), self._dismiss)],
-                  gesture="talk", cycles=14)
+        self._show_fun(STORIES, self._draw_index(STORIES, self._story_bag),
+                       self.tell_story, "talk", 14)
 
     # ── the click menu ───────────────────────────────────────────────────
     def show_menu(self):
+        self._respeak = self.show_menu
         self._say(self._tr("menu.title"),
                   [(self._tr("btn.tour"), self.start_tour),
                    (self._tr("btn.joke"), self.tell_joke),

--- a/zxnu_wizard.py
+++ b/zxnu_wizard.py
@@ -32,18 +32,19 @@ import threading
 import urllib.request
 import webbrowser
 
-from PySide6.QtCore import (Qt, QObject, QTimer, Signal)
+from PySide6.QtCore import (Qt, QObject, QRect, QTimer, Signal)
 from PySide6.QtGui import (QColor, QImage, QPainter, QPixmap)
-from PySide6.QtWidgets import (QHBoxLayout, QLabel, QPushButton,
+from PySide6.QtWidgets import (QHBoxLayout, QLabel, QLayout, QPushButton,
     QVBoxLayout, QWidget)
 
 import zxnu_config
 from zxnu_config import (SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN,
                          ZXART_USER_AGENT)
 from zxnu_i18n import current_ui_language
-from zxnu_wizard_content import (JOKES, STORIES, TEXTS, TOUR_STEPS,
-                                 USER_MANUAL_PAGE, WIKI_PAGE_BASE,
-                                 WIKI_RAW_BASE, wizard_lines, wizard_tr)
+from zxnu_wizard_content import (DISCLAIMER_STEPS, JOKES, STORIES, TEXTS,
+                                 TOUR_STEPS, USER_MANUAL_PAGE,
+                                 WIKI_PAGE_BASE, WIKI_RAW_BASE,
+                                 wizard_lines, wizard_tr)
 
 # ── Sprite artwork ────────────────────────────────────────────────────────
 # 26×28 cells, '.' transparent. The suit is deep blue with the Spectrum
@@ -301,36 +302,125 @@ class WizardBubble(QWidget):
         v = QVBoxLayout(self)
         v.setContentsMargins(10, 8, 10, 8)
         v.setSpacing(6)
+        # The layout owns the bubble's size: it can never shrink below its
+        # content (deferred button deletions used to trigger a relayout
+        # that squashed the bubble under its own text).
+        v.setSizeConstraint(QLayout.SetMinimumSize)
         self.label = QLabel("")
         self.label.setWordWrap(True)
-        self.label.setMaximumWidth(self.MAX_TEXT_W)
+        # Fixed width: a wrapped QLabel's sizeHint under a plain adjustSize
+        # miscomputes its height (the classic word-wrap trap — text got
+        # visibly clipped); pinning the width makes heightForWidth exact.
+        self.label.setFixedWidth(self.MAX_TEXT_W)
         self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         v.addWidget(self.label)
         self.button_row = QHBoxLayout()
         self.button_row.setSpacing(6)
         v.addLayout(self.button_row)
         self._buttons = []
+        self._pages = [""]
+        self._page = 0
+        self._actions = []
+        # Set by the manager: called after every re-render so the bubble is
+        # re-anchored (page flips change its height; growing from a fixed
+        # top-left corner used to push it past the window's bottom edge).
+        self.on_resize = None
+
+    # Long speeches are split into pages the reader flips with ◀ / ▶ —
+    # nothing ever ends in an unreadable "…" again.
+    PAGE_CHARS = 250
+
+    @staticmethod
+    def _paginate(text, limit=PAGE_CHARS):
+        pages = []
+        for block in text.split("\n\n"):
+            block = block.strip()
+            while len(block) > limit:
+                cut = block.rfind(" ", 0, limit)
+                if cut <= 0:
+                    cut = limit
+                pages.append(block[:cut].rstrip())
+                block = block[cut:].strip()
+            if block:
+                pages.append(block)
+        return pages or [""]
 
     def show_message(self, text, buttons):
-        """Set *text* and rebuild the button row from (label, cb) pairs."""
-        for b in self._buttons:
-            self.button_row.removeWidget(b)
-            b.deleteLater()
+        """Paginate *text* and rebuild the button row from (label, cb)."""
+        self._pages = self._paginate(text)
+        self._page = 0
+        self._actions = list(buttons)
+        self._render()
+
+    def append_text(self, extra):
+        """Add late-arriving text (the wiki teaser) as extra pages."""
+        self._pages += self._paginate(extra)
+        self._render()
+
+    def _flip(self, delta):
+        self._page = max(0, min(len(self._pages) - 1, self._page + delta))
+        self._render()
+
+    def _render(self):
+        # Empty the whole button row (widgets AND the stretch item — the
+        # stretch used to accumulate once per render).
+        while self.button_row.count():
+            item = self.button_row.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.setParent(None)   # off-screen NOW (deleteLater ghosts)
+                w.deleteLater()
         self._buttons = []
+        many = len(self._pages) > 1
+        last = self._page >= len(self._pages) - 1
+        text = self._pages[self._page] + ("  …" if not last else "")
         self.label.setText(text)
-        for (label, cb) in buttons:
+        # Word-wrapped QLabels under-report their wrapped height to layouts
+        # (the text was visibly clipped); measure it ourselves — with the
+        # POLISHED (stylesheet) font — and pin both dimensions so the
+        # layout maths below is exact.
+        self.label.ensurePolished()
+        fm = self.label.fontMetrics()
+        rect = fm.boundingRect(QRect(0, 0, self.MAX_TEXT_W, 2000),
+                               Qt.TextWordWrap, text)
+        self.label.setFixedSize(self.MAX_TEXT_W,
+                                rect.height() + fm.lineSpacing())
+        nav = []
+        if many:
+            nav = [("◀", lambda: self._flip(-1)),
+                   (f"{self._page + 1}/{len(self._pages)}", None),
+                   ("▶", lambda: self._flip(+1))]
+        for (label, cb) in nav + self._actions:
             btn = QPushButton(label)
-            btn.clicked.connect(cb)
+            if cb is None:
+                btn.setEnabled(False)              # the page counter
+            elif label == "◀":
+                btn.clicked.connect(cb)
+                btn.setEnabled(self._page > 0)
+            elif label == "▶":
+                btn.clicked.connect(cb)
+                btn.setEnabled(not last)
+            else:
+                btn.clicked.connect(cb)
+            if label in ("◀", "▶"):
+                btn.setFixedWidth(30)
+            elif cb is None:
+                btn.setFixedWidth(48)
             self.button_row.addWidget(btn)
             self._buttons.append(btn)
         self.button_row.addStretch(1)
-        self.adjustSize()
+        self.layout().activate()
+        self.resize(self.layout().sizeHint())
         self.show()
         self.raise_()
 
-    def append_text(self, extra):
-        self.label.setText(self.label.text() + "\n\n" + extra)
-        self.adjustSize()
+    def resizeEvent(self, event):
+        # The SetMinimumSize layout constraint can grow the bubble a beat
+        # after _render (posted LayoutRequest); re-anchoring on the REAL
+        # resize keeps the bubble inside the window whatever the timing.
+        super().resizeEvent(event)
+        if self.on_resize is not None:
+            self.on_resize()
 
 
 class _WikiFetchSignals(QObject):
@@ -372,6 +462,7 @@ class WizardManager(QObject):
         self.sprite.hide()
         self.bubble.hide()
         self.sprite.clicked.connect(self.show_menu)
+        self.bubble.on_resize = self._reposition
         self._tour_index = -1
         self._tour_active_page = None
         self._teaser_cache = {}
@@ -565,7 +656,12 @@ class WizardManager(QObject):
         except Exception:
             pass
         self._tour_active_page = page
-        self._say(self._tr(text_key),
+        text = self._tr(text_key)
+        if text_key in DISCLAIMER_STEPS:
+            # Browsing third-party catalogues: softly recall that the app
+            # distributes nothing itself and rights are the user's to check.
+            text += "\n\n" + self._tr("tour.disclaimer")
+        self._say(text,
                   [(self._tr("btn.next"), self.next_tour_step),
                    (self._tr("btn.more"), lambda _=False, p=page:
                        self.open_manual(p)),

--- a/zxnu_wizard_content.py
+++ b/zxnu_wizard_content.py
@@ -256,6 +256,38 @@ TEXTS = {
         "fr": "Extrait du manuel :",
     },
     # ── The tab tour ──────────────────────────────────────────────────────
+    # Step 0 — the tour opens on the Settings tab so the user can pick
+    # their language before anything else (the wizard re-speaks instantly).
+    "tour.language": {
+        "en": "First things first: I speak seven languages! Right here in "
+              "Settings, find 'Application language:' and pick yours — I "
+              "will switch the very moment you do. All set? Then let's "
+              "go exploring!",
+        "es": "Lo primero es lo primero: ¡hablo siete idiomas! Aquí mismo "
+              "en Ajustes, busca «Application language:» y elige el tuyo "
+              "— cambiaré en el mismo instante. ¿Todo listo? ¡Pues vamos "
+              "a explorar!",
+        "pt": "Primeiro o mais importante: falo sete línguas! Aqui mesmo "
+              "nas Definições, procura «Application language:» e escolhe "
+              "a tua — mudo no preciso instante. Tudo pronto? Então vamos "
+              "explorar!",
+        "pl": "Najpierw najważniejsze: mówię w siedmiu językach! Tutaj, w "
+              "Ustawieniach, znajdź „Application language:” i wybierz "
+              "swój — przełączę się w tej samej chwili. Gotowe? To "
+              "ruszamy na zwiedzanie!",
+        "ru": "Первым делом: я говорю на семи языках! Прямо здесь, в "
+              "Настройках, найдите «Application language:» и выберите "
+              "свой — я переключусь в то же мгновение. Готовы? Тогда "
+              "отправляемся исследовать!",
+        "cs": "Nejdřív to hlavní: mluvím sedmi jazyky! Přímo tady v "
+              "Nastavení najdi „Application language:“ a vyber si svůj — "
+              "přepnu se v tu samou chvíli. Připraveno? Tak vyrážíme na "
+              "průzkum!",
+        "fr": "Commençons par l'essentiel : je parle sept langues ! Ici "
+              "même, dans les Réglages, trouvez « Application language: » "
+              "et choisissez la vôtre — je changerai à l'instant même. "
+              "Tout est prêt ? Alors partons explorer !",
+    },
     "tour.sdcard": {
         "en": "The SD Card Utility! Mount a Next .hdf/.img image, browse "
               "it side by side with your PC files, drag things across — "
@@ -684,6 +716,9 @@ STORIES = {
 # flags, itch.io without itch-dl). The Settings/Help steps match the
 # literal titles the monolith uses for those two addTab calls.
 TOUR_STEPS = (
+    # The tour OPENS on Settings so the user can pick their language first
+    # (the wizard re-speaks the step live when they do).
+    ("Settings 🔩",                        "tour.language",  "Settings-tab"),
     ("ZX_NEXT_UNITE_TAB_TITLE_GOOEY",     "tour.sdcard",    "SD-Card-Utility-tab"),
     ("ZX_NEXT_UNITE_TAB_TITLE_NEXTSYNC",  "tour.nextsync",  "NextSync-tab"),
     ("ZX_NEXT_UNITE_TAB_TITLE_GETIT",     "tour.getit",     "GetIt-tab"),

--- a/zxnu_wizard_content.py
+++ b/zxnu_wizard_content.py
@@ -213,6 +213,39 @@ TEXTS = {
         "fr": "Et voilà la visite ! Cliquez sur moi quand vous voulez — "
               "une blague, une histoire ou un autre tour. Bon Speccy !",
     },
+    # Gentle rights reminder appended to the online-catalogue tour steps
+    # (GetIt / ZXDB / zxArt / Unite!) — see DISCLAIMER_STEPS below.
+    "tour.disclaimer": {
+        "en": "A friendly reminder: this application distributes no "
+              "software or ROMs itself — it only presents content from "
+              "third-party services, and it is up to you to check that "
+              "you have the right to download what you grab.",
+        "es": "Un recordatorio amistoso: esta aplicación no distribuye "
+              "software ni ROMs por sí misma — solo presenta contenido de "
+              "servicios de terceros, y te corresponde a ti comprobar que "
+              "tienes derecho a descargar lo que te lleves.",
+        "pt": "Um lembrete amigável: esta aplicação não distribui "
+              "software nem ROMs — apenas apresenta conteúdo de serviços "
+              "de terceiros, e cabe-te a ti verificar se tens o direito "
+              "de descarregar o que levares.",
+        "pl": "Przyjazne przypomnienie: ta aplikacja sama nie "
+              "rozpowszechnia żadnego oprogramowania ani ROM-ów — jedynie "
+              "prezentuje treści z serwisów zewnętrznych, a sprawdzenie, "
+              "czy masz prawo je pobrać, należy do ciebie.",
+        "ru": "Дружеское напоминание: это приложение само не "
+              "распространяет программы или ROM-файлы — оно лишь "
+              "показывает контент сторонних сервисов, и проверять, есть "
+              "ли у вас право его скачивать, должны вы сами.",
+        "cs": "Přátelské připomenutí: tato aplikace sama žádný software "
+              "ani ROMy nešíří — pouze zobrazuje obsah služeb třetích "
+              "stran a je na tobě ověřit, že máš právo si stáhnout, co "
+              "si bereš.",
+        "fr": "Petit rappel amical : cette application ne distribue "
+              "elle-même aucun logiciel ni ROM — elle ne fait que "
+              "présenter du contenu de services tiers, et il vous "
+              "appartient de vérifier que vous avez le droit de "
+              "télécharger ce que vous prenez.",
+    },
     "manual.teaser": {
         "en": "From the manual:",
         "es": "Del manual:",
@@ -662,6 +695,10 @@ TOUR_STEPS = (
     ("Settings 🔩",                        "tour.settings",  "Settings-tab"),
     ("?",                                  "tour.help",      "Help-tab"),
 )
+
+# Tour steps that browse third-party online catalogues: the wizard softly
+# appends the "tour.disclaimer" rights reminder to these.
+DISCLAIMER_STEPS = {"tour.getit", "tour.zxdb", "tour.zxart", "tour.unite"}
 
 # The manual's landing page (the wizard's "Read the manual" outside a tour).
 USER_MANUAL_PAGE = "User-Manual"


### PR DESCRIPTION
## Summary

Four refinements to Wizzy from first field use:

* **Paginated speech bubble** — long speeches used to truncate into an unreadable "…": the word-wrapped QLabel under-reported its height and the bubble clipped its own text. Speeches now split into pages flipped with pressable **◀ ▶** buttons + a page counter (ellipsis remains only as a continuation cue). Geometry made deterministic (polished-font metrics + `SetMinimumSize` constraint + re-anchor in `resizeEvent`); also fixed an accumulating stretch item and `deleteLater` button ghosting.
* **Soft rights reminder** — the GetIt / ZXDB / zxArt / Unite! tour steps now gently recall that the app distributes no software or ROMs itself, only presents third-party services, and download rights are the user''s to check. All seven languages.
* **Settings placement** — the "Show Wizzy" toggle moved to sit directly under "Application language:" (rows below shifted). This surfaced and fixed a real overlap: the toggle had shared grid row 40 with the NextSync HTTP-bridge block, and the first renumbering pass also had to bump the `_make_color_button` helper rows (17–24) it initially missed. Cell uniqueness now verified across `addWidget`/`addLayout`/helper rows.
* **Live language switch + language-first tour** — changing the application language while the wizard is speaking re-composes the current speech instantly (every display path records a re-speak callable; jokes/stories re-tell the SAME item by index). And the tour now OPENS on the Settings tab with a new step inviting the user to pick their language — the wizard re-speaks that very step the moment they do.

## Test plan

- [x] `tests/test_wizard.py` extended: pagination + flips, no stranded ellipsis, rights reminder on catalogue steps, live re-speak (menu / tour step / same-joke-by-index), new tour sequence
- [x] `tests/test_ui_offscreen.py` grid assertions updated + new check pinning the wizard toggle at (2,0)
- [x] `python tests/run_all.py` fully green; `ruff check .` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)