### PR TITLE
9.3.0: Wizzy ships — community kudos finale + version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.2.2"
+version = "9.3.0"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -140,8 +140,15 @@ check("hidden tabs are skipped (Settings next)",
 wiz.next_tour_step()
 check("last step is the Help tab", tabs.tabText(tabs.currentIndex()) == "?")
 wiz.next_tour_step()
+_finale = " ".join(wiz.bubble._pages)
+check("tour finale sends the kudos",
+      "em00k" in _finale and "the Gary(s)" in _finale
+      and "Tim" in _finale)
 check("tour finishes with the outro",
-      wiz.bubble.label.text() == wc.wizard_tr("tour.done", "en"))
+      wc.wizard_tr("tour.done", "en") in _finale)
+check("kudos template carries {names} in every language",
+      all("{names}" in wc.TEXTS["tour.kudos"][lang]
+          for lang in wc.WIZARD_LANGS))
 
 # Jokes rotate through the whole bag without repeats.
 seen = set()

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.2.2"
+ZX_NEXT_UNITE_VERSION = "9.3.0"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_wizard.py
+++ b/zxnu_wizard.py
@@ -41,10 +41,10 @@ import zxnu_config
 from zxnu_config import (SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN,
                          ZXART_USER_AGENT)
 from zxnu_i18n import current_ui_language
-from zxnu_wizard_content import (DISCLAIMER_STEPS, JOKES, STORIES, TEXTS,
-                                 TOUR_STEPS, USER_MANUAL_PAGE,
-                                 WIKI_PAGE_BASE, WIKI_RAW_BASE,
-                                 wizard_lines, wizard_tr)
+from zxnu_wizard_content import (DISCLAIMER_STEPS, JOKES, KUDOS_NAMES,
+                                 STORIES, TEXTS, TOUR_STEPS,
+                                 USER_MANUAL_PAGE, WIKI_PAGE_BASE,
+                                 WIKI_RAW_BASE, wizard_lines, wizard_tr)
 
 # ── Sprite artwork ────────────────────────────────────────────────────────
 # 26×28 cells, '.' transparent. The suit is deep blue with the Spectrum
@@ -690,9 +690,12 @@ class WizardManager(QObject):
     def finish_tour(self):
         self._tour_active_page = None
         self._respeak = self.finish_tour
-        self._say(self._tr("tour.done"),
+        # The finale: kudos to the people who make the Next awesome, then
+        # the goodbye — the bubble paginates the long thank-you list.
+        self._say(self._tr("tour.kudos").format(names=KUDOS_NAMES)
+                  + "\n\n" + self._tr("tour.done"),
                   [(self._tr("btn.close"), self._dismiss)],
-                  gesture="cast", cycles=3)
+                  gesture="cast", cycles=6)
 
     # ── wiki content ─────────────────────────────────────────────────────
     def open_manual(self, page=None):

--- a/zxnu_wizard_content.py
+++ b/zxnu_wizard_content.py
@@ -197,6 +197,34 @@ TEXTS = {
         "fr": "Comme vous voudrez ! *pouf* — vous pourrez me rappeler à "
               "tout moment depuis l'onglet Réglages. Adieu, aventurier !",
     },
+    # Tour finale: KUDOS! The {names} placeholder is filled from
+    # KUDOS_NAMES below (proper names — never translated), so adding a
+    # name is a one-line edit that reaches every language.
+    "tour.kudos": {
+        "en": "One last magic word before you go: KUDOS to {names} — and "
+              "the entire community — for their support and incredible "
+              "work to make the Next an awesome platform!",
+        "es": "Una última palabra mágica antes de irte: ¡KUDOS a {names} "
+              "— y a toda la comunidad — por su apoyo y su increíble "
+              "trabajo para hacer del Next una plataforma increíble!",
+        "pt": "Uma última palavra mágica antes de ires: KUDOS a {names} — "
+              "e a toda a comunidade — pelo apoio e pelo trabalho "
+              "incrível que fazem do Next uma plataforma fantástica!",
+        "pl": "Ostatnie magiczne słowo na drogę: KUDOS dla {names} — i "
+              "całej społeczności — za wsparcie i niesamowitą pracę, "
+              "dzięki której Next jest tak wspaniałą platformą!",
+        "ru": "Последнее волшебное слово на прощание: KUDOS {names} — и "
+              "всему сообществу — за поддержку и невероятную работу, "
+              "благодаря которой Next стал такой замечательной "
+              "платформой!",
+        "cs": "Ještě jedno kouzelné slovo na cestu: KUDOS pro {names} — a "
+              "celou komunitu — za podporu a neuvěřitelnou práci, díky "
+              "níž je Next tak skvělá platforma!",
+        "fr": "Un dernier mot magique avant de partir : KUDOS à {names} — "
+              "et à toute la communauté — pour leur soutien et leur "
+              "travail incroyable qui font du Next une plateforme "
+              "formidable !",
+    },
     "tour.done": {
         "en": "And that's the tour! Click me any time for a joke, a story "
               "or another walk-around. Happy Speccy-ing!",
@@ -734,6 +762,13 @@ TOUR_STEPS = (
 # Tour steps that browse third-party online catalogues: the wizard softly
 # appends the "tour.disclaimer" rights reminder to these.
 DISCLAIMER_STEPS = {"tour.getit", "tour.zxdb", "tour.zxart", "tour.unite"}
+
+# The heroes the wizard thanks at the end of the tour (fills the {names}
+# placeholder of "tour.kudos"; proper names, shared by every language).
+KUDOS_NAMES = ("em00k, Jari, Leonis, Remy, Phoebus, Adrian, Mike, Thomas, "
+               "Robin, Flash, the Chris(s) 🙂, Holub, the Richard(s) 🙂, "
+               "the Gary(s) 🙂, Henrique, Victor, Nicolas & Anthony, "
+               "Simon, Jamie, Tim")
 
 # The manual's landing page (the wizard's "Read the manual" outside a tour).
 USER_MANUAL_PAGE = "User-Manual"


### PR DESCRIPTION
## Summary

* **Tour finale: community kudos** — at the end of the tour, before the goodbye, Wizzy thanks em00k, Jari, Leonis, Remy, Phoebus, Adrian, Mike, Thomas, Robin, Flash, the Chris(s) 🙂, Holub, the Richard(s) 🙂, the Gary(s) 🙂, Henrique, Victor, Nicolas & Anthony, Simon, Jamie, Tim — and the entire community — for their support and incredible work making the Next an awesome platform. The sentence is translated into all seven UI languages (`tour.kudos`); the names live in one untranslated `KUDOS_NAMES` constant so future additions are a one-line edit, and a tripwire verifies the `{names}` placeholder survives in every translation.
* **Version bump to 9.3.0** — minor bump for the Wizzy onboarding wizard feature (PRs #213/#214); `ZX_NEXT_UNITE_VERSION` and `pyproject.toml` in lockstep.

## Test plan

- [x] `tests/test_wizard.py`: finale carries the kudos (names + outro) and the `{names}` placeholder exists in every language
- [x] `python tests/run_all.py` fully green; `ruff check .` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)