### PR TITLE
Flatpak: fix MAME launch, bundle the optional extras, forgiving hdfmonkey installs

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -25,10 +25,18 @@ and painless updates.
   come from the Flatpak remote.
 - hdfmonkey: the "Download and install HDF Monkey" button works as usual;
   the jjjs `linux-musl` build is static and runs inside the sandbox.
-- Limitations: launching host-installed emulators (CSpect via mono, MAME)
-  from inside the sandbox is not supported; the optional extras (pygame
-  retro modes, Flask HTTP bridge, Send2Trash, itch-dl) are not bundled in
-  the first iteration — their Settings toggles simply stay greyed out.
+- The four optional extras (pygame-ce retro modes + Alien Floyd's, itch-dl
+  / the itch.io tab, the Flask HTTP bridge, Send2Trash) are bundled as
+  pinned wheels (the `python3-extras` module), so their Settings toggles
+  work out of the box.
+- "Launch MAME via Flatpak" works from inside the sandbox: the launch is
+  delegated to the host via `flatpak-spawn --host flatpak run
+  org.mamedev.MAME` (hence the `--talk-name=org.freedesktop.Flatpak`
+  finish-arg; see `mame_flatpak_command` in `zxnu_config.py`). Launching a
+  host-installed CSpect (via mono) is still not wired up.
+- Manual hdfmonkey drops are found in the stray
+  `~/.var/app/<id>/downloads/` location as well as the real data root
+  (`flatpak_stray_download_root` in `zxnu_config.py`).
 
 ## Building locally (on Linux)
 

--- a/flatpak/io.github.jclauzel.ZXNextUnite.yml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.yml
@@ -34,6 +34,10 @@ finish-args:
   # Route hdfg.cfg + downloads/ to the XDG data dir instead of the
   # (read-only) install dir — same switch the PyPI entry point flips.
   - --env=ZX_NEXT_UNITE_MODE=installed
+  # Lets the app launch the user's chosen emulator on the host through
+  # `flatpak-spawn --host` — the "Launch MAME via Flatpak" setting runs
+  # `flatpak run org.mamedev.MAME`, which cannot exist inside the sandbox.
+  - --talk-name=org.freedesktop.Flatpak
 
 cleanup-commands:
   # The PySide BaseApp ships a trim script; tolerate its absence so a
@@ -41,6 +45,100 @@ cleanup-commands:
   - sh -c '[ -x /app/cleanup-BaseApp.sh ] && /app/cleanup-BaseApp.sh || true'
 
 modules:
+  # The four optional extras the app detects at runtime (their Settings
+  # toggles stay greyed out when missing): pygame-ce (retro modes + the
+  # Alien Floyd's tab), itch-dl (the itch.io tab, incl. its CSpect+hdfmonkey
+  # install), Flask (the NextSync HTTP bridge) and Send2Trash (recycle-bin
+  # deletes). Vendored as pinned wheels because Flathub builds are offline;
+  # regenerate the list with pip's --report resolver against the runtime's
+  # Python (currently 3.12) when bumping versions.
+  - name: python3-extras
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+        pygame-ce itch-dl flask send2trash
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
+        sha256: d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9
+      - type: file
+        url: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
+        sha256: ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc
+      - type: file
+        url: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+        sha256: 62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+      - type: file
+        url: https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+        sha256: 5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
+        sha256: e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl
+        sha256: f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+        sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+      - type: file
+        url: https://files.pythonhosted.org/packages/15/c7/d585e783e7428db6916e3ffb3f2ae78a73ebf7e63ba600cfe1a2f7fb4814/itch_dl-0.7.2-py3-none-any.whl
+        sha256: fae05bd05cd103fcc3f7df9e593bc1e4f3c7389a36c1d7629ff2e906907e7c47
+      - type: file
+        url: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+        sha256: c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef
+      - type: file
+        url: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+        sha256: 85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+      - type: file
+        url: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+        sha256: ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+        sha256: d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/db/17/70ada4cef84eca48a995cc9e0f2f087e6190b3e4111e9c8ec3c7a8f689bd/pygame_ce-2.5.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 0d8fa8822c0f4b5ae6b44ada7be9f2193fd512da1381c37fa3c5bda8971d64cb
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/e5/94/7f6304a31ccc7d11d4443e590cbfa6fce2bd34077575a7790d4f0a14f440/pygame_ce-2.5.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: 4dc989462faf2c5947881f708fa406d7ac13c1bc987c1588d630ca62ad369989
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+      - type: file
+        url: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
+        sha256: 0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c
+      - type: file
+        url: https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl
+        sha256: 4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c
+      - type: file
+        url: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+        sha256: 7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
+      - type: file
+        url: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+        sha256: 481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+      - type: file
+        url: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
+        sha256: 63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50
+
   - name: zx-next-unite
     buildsystem: simple
     build-commands:

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -32,6 +32,7 @@ SUITES = [
     # (file, timeout seconds, required import or None)
     ("test_api_parsers.py",     120, None),
     ("test_data_root.py",       240, None),
+    ("test_hdfmonkey_discovery.py", 120, None),
     ("test_pane_imports.py",    120, None),
     ("test_hdf_workers.py",     120, None),
     ("test_classic_sync.py",    180, None),

--- a/tests/test_hdfmonkey_discovery.py
+++ b/tests/test_hdfmonkey_discovery.py
@@ -1,0 +1,144 @@
+"""hdfmonkey downloads-folder discovery tests (zxnu_config).
+
+Covers the lenient scan added for the Flatpak/manual-install cases:
+  - the canonical downloads/hdfmonkey/<platform>/<exe> layout,
+  - a bare binary dropped straight into downloads/hdfmonkey/,
+  - a hand-extracted archive whose per-platform folder sits deeper down,
+  - NOT matching a loose binary under another platform's folder name,
+  - the exec bit being restored on POSIX,
+  - the Flatpak stray root ~/.var/app/<id>/downloads (binary and jjjs zip),
+    which is only consulted when FLATPAK_ID is set.
+
+Run with: python tests/test_hdfmonkey_discovery.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, REPO)
+
+from zxnu_config import (  # noqa: E402
+    DOWNLOADS_HDFMONKEY_DIRNAME,
+    find_hdfmonkey_in_downloads,
+    find_hdfmonkey_jjjs_zip_in_downloads,
+    flatpak_stray_download_root,
+    hdfmonkey_platform_dirs,
+)
+
+FAIL = []
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+PLAT_DIR, EXE = hdfmonkey_platform_dirs()[0]
+# A per-platform folder name that is never valid for the CURRENT platform.
+FOREIGN_DIR = "linux-musl" if PLAT_DIR != "linux-musl" else "macos-intel"
+
+BASE = tempfile.mkdtemp(prefix="zxnu-hdfm-test-")
+
+def make_base(name, rel_binary_path):
+    """Create <BASE>/<name>/downloads/hdfmonkey/<rel_binary_path> and return
+    the base dir (what find_hdfmonkey_in_downloads takes)."""
+    base = os.path.join(BASE, name)
+    path = os.path.join(base, DOWNLOADS_HDFMONKEY_DIRNAME, rel_binary_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(b"#!fake hdfmonkey\n")
+    return base
+
+# 1. Canonical layout (what the auto-download produces).
+b = make_base("canonical", os.path.join(PLAT_DIR, EXE))
+found = find_hdfmonkey_in_downloads(b)
+check("canonical <plat>/<exe> layout is found",
+      found is not None and found.endswith(os.path.join(PLAT_DIR, EXE)),
+      repr(found))
+
+# 2. Bare binary dropped straight into downloads/hdfmonkey/.
+b = make_base("flat", EXE)
+found = find_hdfmonkey_in_downloads(b)
+check("bare binary in downloads/hdfmonkey/ is found",
+      found is not None and os.path.basename(found) == EXE, repr(found))
+
+# 3. Hand-extracted archive: platform folder at a deeper level.
+b = make_base("nested", os.path.join("hdfmonkey-2jjjs", PLAT_DIR, EXE))
+found = find_hdfmonkey_in_downloads(b)
+check("hand-extracted nested <plat>/<exe> is found",
+      found is not None and found.endswith(os.path.join(PLAT_DIR, EXE)),
+      repr(found))
+
+# 4. A binary under ANOTHER platform's folder must not be trusted (the bare
+#    file name is shared across the Linux and macOS builds).
+b = make_base("foreign", os.path.join("hdfmonkey-2jjjs", FOREIGN_DIR, EXE))
+found = find_hdfmonkey_in_downloads(b)
+check("foreign platform folder is not matched", found is None, repr(found))
+
+# 5. POSIX: the exec bit lost by zip extraction is restored on adoption.
+if sys.platform != "win32":
+    b = make_base("execbit", os.path.join(PLAT_DIR, EXE))
+    path = os.path.join(b, DOWNLOADS_HDFMONKEY_DIRNAME, PLAT_DIR, EXE)
+    os.chmod(path, 0o644)
+    found = find_hdfmonkey_in_downloads(b)
+    check("exec bit is restored on POSIX",
+          found is not None and os.access(found, os.X_OK), repr(found))
+
+# 6. Flatpak stray root: with FLATPAK_ID set, ~/.var/app/<id>/downloads is
+#    scanned too (both the binary and the jjjs-zip scans); without it, not.
+fake_home = os.path.join(BASE, "home")
+app_id = "io.test.ZXNU"
+stray_base = os.path.join(fake_home, ".var", "app", app_id)
+stray_bin = os.path.join(stray_base, DOWNLOADS_HDFMONKEY_DIRNAME, PLAT_DIR, EXE)
+os.makedirs(os.path.dirname(stray_bin), exist_ok=True)
+with open(stray_bin, "wb") as fh:
+    fh.write(b"#!fake hdfmonkey\n")
+
+# A minimal outer jjjs zip: nested inner zip + password.txt.
+stray_downloads = os.path.join(stray_base, "downloads")
+inner = os.path.join(BASE, "inner.zip")
+with zipfile.ZipFile(inner, "w") as zf:
+    zf.writestr("dummy.txt", "x")
+with zipfile.ZipFile(os.path.join(stray_downloads, "hdfmonkey-2jjjs.zip"), "w") as zf:
+    zf.write(inner, "hdfmonkey-2jjjs.zip")
+    zf.writestr("password.txt", "jjjs")
+
+empty_base = os.path.join(BASE, "empty"); os.makedirs(empty_base)
+_saved = {k: os.environ.get(k) for k in ("FLATPAK_ID", "HOME", "USERPROFILE")}
+try:
+    os.environ["FLATPAK_ID"] = app_id
+    os.environ["HOME"] = fake_home            # POSIX expanduser
+    os.environ["USERPROFILE"] = fake_home     # Windows expanduser
+    check("flatpak_stray_download_root points into ~/.var/app/<id>",
+          flatpak_stray_download_root() == stray_base,
+          repr(flatpak_stray_download_root()))
+    found = find_hdfmonkey_in_downloads(empty_base)
+    check("stray ~/.var/app/<id>/downloads binary is found when sandboxed",
+          found is not None and os.path.normcase(found) == os.path.normcase(stray_bin),
+          repr(found))
+    found_zip = find_hdfmonkey_jjjs_zip_in_downloads(empty_base)
+    check("stray ~/.var/app/<id>/downloads jjjs zip is found when sandboxed",
+          found_zip is not None
+          and os.path.normcase(os.path.dirname(found_zip)) == os.path.normcase(stray_downloads),
+          repr(found_zip))
+finally:
+    for k, v in _saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+check("stray root is ignored when FLATPAK_ID is unset",
+      flatpak_stray_download_root() is None
+      and find_hdfmonkey_in_downloads(empty_base) is None)
+
+shutil.rmtree(BASE, ignore_errors=True)
+
+print()
+if FAIL:
+    print(f"{len(FAIL)} FAILED: {FAIL}")
+    sys.exit(1)
+print("all hdfmonkey discovery tests passed")

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -1167,6 +1167,20 @@ MAME_FLATPAK_APP_ID = "org.mamedev.MAME"
 MAME_FLATPAK_COMMAND = ("flatpak", "run", MAME_FLATPAK_APP_ID)
 
 
+def mame_flatpak_command():
+    """The argv prefix that launches Flatpak MAME, sandbox-aware.
+
+    When ZX Next Unite itself runs inside a Flatpak sandbox (FLATPAK_ID set),
+    there is no `flatpak` binary on the sandbox PATH — the launch must be
+    delegated to the host through `flatpak-spawn --host` (present in every
+    Flatpak runtime; needs the org.freedesktop.Flatpak talk-name granted in
+    the manifest). Unsandboxed installs keep calling `flatpak` directly.
+    """
+    if os.environ.get("FLATPAK_ID"):
+        return ("flatpak-spawn", "--host") + MAME_FLATPAK_COMMAND
+    return MAME_FLATPAK_COMMAND
+
+
 def mame_flatpak_supported():
     """True where the "Launch Mame with Flatpak" option is offered — Linux only,
     since Flatpak is a Linux packaging system."""
@@ -1853,6 +1867,46 @@ def find_hdfmonkey_near_cspect(cspect_path):
     return None
 
 
+def flatpak_stray_download_root():
+    """Extra base directory to scan for hand-dropped hdfmonkey copies when the
+    app runs inside a Flatpak sandbox: ``~/.var/app/<app-id>``.
+
+    The real data root there is ``~/.var/app/<app-id>/data/zx-next-unite``
+    (the XDG data dir), but every Flatpak how-to presents ``~/.var/app/<id>``
+    itself as "the app's folder", so manual copies routinely land in
+    ``~/.var/app/<id>/downloads/`` — one level too shallow to ever be found.
+    Scanning that stray location too turns the mistake into a working install.
+    Returns ``None`` when not sandboxed.
+    """
+    app_id = os.environ.get("FLATPAK_ID")
+    if not app_id:
+        return None
+    return os.path.join(os.path.expanduser("~"), ".var", "app", app_id)
+
+
+def _hdfmonkey_scan_bases(base_dir):
+    """The candidate base directories for the downloads-folder scans: the
+    caller's data root plus, inside a Flatpak, the stray ``~/.var/app/<id>``
+    location (see :func:`flatpak_stray_download_root`)."""
+    bases = [base_dir] if base_dir else []
+    stray = flatpak_stray_download_root()
+    if stray and stray not in bases:
+        bases.append(stray)
+    return bases
+
+
+def _hdfmonkey_adopt_binary(path):
+    """Return ``path`` after making sure it is runnable: zip extractors (and
+    manual copies) routinely lose the executable bit the POSIX platforms need."""
+    if platform.system() != "Windows" and not os.access(path, os.X_OK):
+        try:
+            os.chmod(path, os.stat(path).st_mode
+                     | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        except OSError:
+            logging.exception(f"hdfmonkey: could not set the exec bit on {path}")
+    return path
+
+
 def find_hdfmonkey_in_downloads(base_dir):
     """Locate an hdfmonkey executable installed by the standalone auto-download
     (HDF_MONKEY_JJJS_URL) under ``<base_dir>/downloads/hdfmonkey/<platform>/``.
@@ -1862,16 +1916,41 @@ def find_hdfmonkey_in_downloads(base_dir):
     ``extract_hdfmonkey_from_jjjs_zip``), so a later launch re-discovers it the
     same cheap way ``find_hdfmonkey_near_cspect`` picks up a CSpect-bundled copy.
 
+    Hand-extracted copies are accepted too: the per-platform folder may sit at
+    any depth below ``downloads/hdfmonkey`` (unzipping the jjjs archive adds
+    nesting levels), and a bare binary dropped straight into
+    ``downloads/hdfmonkey/`` counts as well. The bare file name is shared
+    across the Linux and macOS builds, so only the current platform's folder
+    name is trusted at depth — never a loose file under some other platform's
+    folder. Inside a Flatpak the stray ``~/.var/app/<id>/downloads`` location
+    is scanned in addition to the real data root.
+
     Returns the full path to the first matching build for this platform, or
     ``None`` when none is present.
     """
-    if not base_dir:
-        return None
-    root = os.path.join(base_dir, DOWNLOADS_HDFMONKEY_DIRNAME)
-    for plat_dir, exe in hdfmonkey_platform_dirs():
-        candidate = os.path.join(root, plat_dir, exe)
-        if os.path.isfile(candidate):
-            return candidate
+    plat_pairs = hdfmonkey_platform_dirs()
+    for scan_base in _hdfmonkey_scan_bases(base_dir):
+        root = os.path.join(scan_base, DOWNLOADS_HDFMONKEY_DIRNAME)
+        # The canonical layout the auto-download produces.
+        for plat_dir, exe in plat_pairs:
+            candidate = os.path.join(root, plat_dir, exe)
+            if os.path.isfile(candidate):
+                return _hdfmonkey_adopt_binary(candidate)
+        if not os.path.isdir(root):
+            continue
+        # A bare binary dropped straight into downloads/hdfmonkey/.
+        for _plat_dir, exe in plat_pairs:
+            candidate = os.path.join(root, exe)
+            if os.path.isfile(candidate):
+                return _hdfmonkey_adopt_binary(candidate)
+        # This platform's folder at any depth (hand-extracted archive).
+        for plat_dir, exe in plat_pairs:
+            for walk_root, dirs, _files in os.walk(root):
+                dirs.sort()
+                if os.path.basename(walk_root) == plat_dir:
+                    candidate = os.path.join(walk_root, exe)
+                    if os.path.isfile(candidate):
+                        return _hdfmonkey_adopt_binary(candidate)
     return None
 
 
@@ -1907,12 +1986,10 @@ def find_hdfmonkey_jjjs_zip_in_downloads(base_dir):
     Returns the full path to the first matching archive, or ``None`` when none is
     found.
     """
-    if not base_dir:
-        return None
-    search_dirs = [
-        os.path.join(base_dir, DOWNLOADS_ROOT_DIRNAME),
-        os.path.join(base_dir, DOWNLOADS_HDFMONKEY_DIRNAME),
-    ]
+    search_dirs = []
+    for scan_base in _hdfmonkey_scan_bases(base_dir):
+        search_dirs.append(os.path.join(scan_base, DOWNLOADS_ROOT_DIRNAME))
+        search_dirs.append(os.path.join(scan_base, DOWNLOADS_HDFMONKEY_DIRNAME))
     seen = set()
     for d in search_dirs:
         if not os.path.isdir(d):

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -262,7 +262,7 @@ def build_emulator_ops(
         # below, so they must not be duplicated or conflict. The launcher
         # prefix is either the detected binary or the Flatpak run command.
         _param_tokens = strip_mame_combo_options(shlex.split(mame_parameters))
-        _launch_prefix = (list(MAME_FLATPAK_COMMAND) if _flatpak
+        _launch_prefix = (list(mame_flatpak_command()) if _flatpak
                           else [mame_path])
         mame_argv = _launch_prefix + [mame_rom] + _param_tokens
 
@@ -296,7 +296,7 @@ def build_emulator_ops(
 
         # Executable that will actually be invoked: the detected MAME binary,
         # or the Flatpak run command when Flatpak mode is enabled.
-        _mame_executable = " ".join(MAME_FLATPAK_COMMAND) if _flatpak else mame_path
+        _mame_executable = " ".join(mame_flatpak_command()) if _flatpak else mame_path
         logging.info(f"MAME executable: {_mame_executable}")
         add_main_log_window(f"MAME executable: {_mame_executable}")
         logging.info(f"MAME start with arguments: {mame_argv}")
@@ -1821,7 +1821,9 @@ def build_hdfmonkey_install_ops(
             f"1. Click 'Open download page' below (or browse to\n"
             f"    {HDF_MONKEY_JJJS_URL} ).\n"
             "2. Download the hdfmonkey .zip file.\n"
-            f"3. Drop the downloaded .zip into this folder:\n"
+            f"3. Drop the downloaded .zip into this EXACT folder — the app "
+            f"has already created it, and the 'Open downloads folder' button "
+            f"below opens it so nothing needs to be typed:\n"
             f"    {downloads_root}\n"
             "4. Click \"I've dropped the zip - try again\".")
         open_page_btn = box.addButton("Open download page", QMessageBox.ActionRole)


### PR DESCRIPTION
Fixes from the first real Flatpak run (sandboxed app on CommodoreOS Linux):

## MAME launch inside the sandbox
"Launch MAME via Flatpak" failed with `[Errno 2] No such file or directory: 'flatpak'` — there is no flatpak CLI inside the sandbox. New `mame_flatpak_command()` in `zxnu_config.py` prefixes the launch with `flatpak-spawn --host` when `FLATPAK_ID` is set; the manifest grants `--talk-name=org.freedesktop.Flatpak` for it. Unsandboxed launches are unchanged.

## Optional extras bundled in the Flatpak
New `python3-extras` manifest module vendors the four runtime-detected extras as pinned wheels (x86_64 + aarch64): **pygame-ce** (retro modes + Alien Floyd's tab), **itch-dl** (the itch.io tab), **Flask** (NextSync HTTP bridge) and **Send2Trash**. Their Settings toggles were permanently greyed out in the sandbox before.

## Forgiving hdfmonkey manual installs
- Discovery accepts a hand-extracted binary: the per-platform folder at any depth under `downloads/hdfmonkey/`, or a bare binary dropped right there (only the current platform's folder name is trusted — the Linux/macOS builds share a file name).
- A lost POSIX exec bit (typical after zip extraction) is restored on adoption.
- Inside a Flatpak, the stray `~/.var/app/<id>/downloads/` location every Flatpak how-to points users at is scanned too (the real data root is `~/.var/app/<id>/data/zx-next-unite/`).
- The manual-download dialog now spells out that the shown folder is the exact drop target.

## Tests
New `tests/test_hdfmonkey_discovery.py` (8 checks) covers all of the above; registered in `run_all.py`. Full suite + ruff green; the flatpak CI workflow built the bundle with the new manifest on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)