### PR TITLE
Bump version to 9.4.4

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -68,7 +68,7 @@ zip) stays untouched and a Flatpak failure can never block a release.
    sources:
      - type: git
        url: https://github.com/jclauzel/ZX-Next-Unite.git
-       tag: v9.4.3
+       tag: v9.4.4
        commit: <full commit sha of the tag>
    ```
 

--- a/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
@@ -50,6 +50,7 @@
     <color type="primary" scheme_preference="dark">#1c1c60</color>
   </branding>
   <releases>
+    <release version="9.4.4" date="2026-07-30"/>
     <release version="9.4.3" date="2026-07-29"/>
     <release version="9.4.2" date="2026-07-29"/>
   </releases>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.4.3"
+version = "9.4.4"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.4.3"
+ZX_NEXT_UNITE_VERSION = "9.4.4"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Version bump for the Flatpak-fixes release (PR #221): `ZX_NEXT_UNITE_VERSION`, `pyproject.toml`, a 9.4.4 entry in the AppStream metainfo `<releases>`, and the flatpak README's pin example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)