### PR TITLE
Flatpak: launch CSpect via the host's mono (flatpak-spawn) + bump to 9.4.5

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -29,11 +29,12 @@ and painless updates.
   / the itch.io tab, the Flask HTTP bridge, Send2Trash) are bundled as
   pinned wheels (the `python3-extras` module), so their Settings toggles
   work out of the box.
-- "Launch MAME via Flatpak" works from inside the sandbox: the launch is
-  delegated to the host via `flatpak-spawn --host flatpak run
-  org.mamedev.MAME` (hence the `--talk-name=org.freedesktop.Flatpak`
-  finish-arg; see `mame_flatpak_command` in `zxnu_config.py`). Launching a
-  host-installed CSpect (via mono) is still not wired up.
+- Emulator launches are delegated to the host via `flatpak-spawn --host`
+  when sandboxed (hence the `--talk-name=org.freedesktop.Flatpak`
+  finish-arg): "Launch MAME via Flatpak" runs `flatpak run org.mamedev.MAME`
+  on the host (`mame_flatpak_command` in `zxnu_config.py`), and CSpect runs
+  under the HOST's mono (which must be installed there) — all involved
+  paths live under the user's real home, so they resolve unchanged.
 - Manual hdfmonkey drops are found in the stray
   `~/.var/app/<id>/downloads/` location as well as the real data root
   (`flatpak_stray_download_root` in `zxnu_config.py`).
@@ -68,7 +69,7 @@ zip) stays untouched and a Flatpak failure can never block a release.
    sources:
      - type: git
        url: https://github.com/jclauzel/ZX-Next-Unite.git
-       tag: v9.4.4
+       tag: v9.4.5
        commit: <full commit sha of the tag>
    ```
 

--- a/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
@@ -50,6 +50,7 @@
     <color type="primary" scheme_preference="dark">#1c1c60</color>
   </branding>
   <releases>
+    <release version="9.4.5" date="2026-07-30"/>
     <release version="9.4.4" date="2026-07-30"/>
     <release version="9.4.3" date="2026-07-29"/>
     <release version="9.4.2" date="2026-07-29"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.4.4"
+version = "9.4.5"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.4.4"
+ZX_NEXT_UNITE_VERSION = "9.4.5"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -184,6 +184,13 @@ def build_emulator_ops(
                 cspect_executable = f'"{cspect_exe}"' if use_bundled else "CSpect.exe"
             else:
                 cspect_executable = f'mono "{cspect_exe}"' if use_bundled else "mono CSpect.exe"
+                # Inside the Flatpak sandbox there is no mono — delegate the
+                # launch to the host through the Flatpak portal, exactly like
+                # the MAME launch (mame_flatpak_command): every involved path
+                # (CSpect under ~/.var/app, the cwd, the -mmc image) is a real
+                # host path, so the host-side mono resolves them unchanged.
+                if os.environ.get("FLATPAK_ID"):
+                    cspect_executable = "flatpak-spawn --host " + cspect_executable
 
             logging.info(f"CSpect executable: {cspect_executable}")
             add_main_log_window(f"CSpect executable: {cspect_executable}")
@@ -203,6 +210,11 @@ def build_emulator_ops(
                 if platform.system() != "Windows":
                     logging.error("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
                     add_main_log_window("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
+                    if os.environ.get("FLATPAK_ID"):
+                        add_main_log_window(
+                            "Running as a Flatpak: mono must be installed on "
+                            "the HOST system — the launch is delegated there "
+                            "via flatpak-spawn.")
 
             set_all_buttons_enabled()
 


### PR DESCRIPTION
Follow-up to #221 from sandbox testing: launching CSpect inside the Flatpak failed with exit 127 — mono is on the host, not in the KDE runtime. The shell launch is now prefixed with `flatpak-spawn --host` when `FLATPAK_ID` is set, using the same portal (and the same `org.freedesktop.Flatpak` talk-name, granted since 9.4.4) as the MAME launch. All involved paths (the itch.io CSpect under `~/.var/app`, its working directory, the `-mmc` image) are real host paths, so the host-side mono resolves them unchanged. The mono advisory now tells Flatpak users mono must be installed on the HOST, and the flatpak README's limitation note is updated.

Also bumps the version to 9.4.5 (config, pyproject, metainfo `<releases>`, README pin example).

Full test suite + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)