### PR TITLE
Flatpak CI: attach the bundle to the draft release on v* tags

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -2,13 +2,23 @@ name: flatpak
 
 # Builds the Linux Flatpak bundle from flatpak/io.github.jclauzel.ZXNextUnite.yml
 # and uploads it as a workflow artifact. Runs on demand (workflow_dispatch,
-# available once the workflow is on the default branch) and on any push that
+# available once the workflow is on the default branch), on any push that
 # touches the packaging files — so a manifest change is CI-validated before
-# it merges. Deliberately separate from release.yml: the release asset
-# contract with the in-app self-updater (exe / tar.gz / zip) stays
-# untouched, and a Flatpak build failure can never block a release.
+# it merges — and on v* tag creation, where the bundle (built from the exact
+# tag commit) is additionally attached to the draft GitHub release that
+# release.yml creates for the same tag, named
+# zx-next-unite-<tag>-linux-x86_64.flatpak.
+#
+# Deliberately separate from release.yml: the release asset contract with
+# the in-app self-updater (exe / tar.gz / zip) stays untouched — a .flatpak
+# asset can never match select_zxnu_release_asset — and a Flatpak build
+# failure can never block a release. The attach step is non-blocking too:
+# it retries while release.yml is still creating the draft, then degrades
+# to a warning (worst case the bundle is attached manually from the
+# workflow artifact).
 on:
   workflow_dispatch:
+  create:
   push:
     branches:
       - "**"
@@ -19,7 +29,12 @@ on:
 jobs:
   flatpak:
     name: Build Flatpak bundle
+    # Every new branch fires `create` too — those builds are already covered
+    # by the push-paths trigger, so for create events only v* tags proceed.
+    if: github.event_name != 'create' || (github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.8
       options: --privileged
@@ -32,3 +47,53 @@ jobs:
           manifest-path: flatpak/io.github.jclauzel.ZXNextUnite.yml
           cache-key: flatpak-builder-${{ hashFiles('flatpak/io.github.jclauzel.ZXNextUnite.yml') }}
           upload-artifact: true
+      # stdlib-only python (the container has no gh CLI): find the release
+      # for this tag (drafts included — the tags API endpoint skips drafts),
+      # replace any same-named asset, upload the bundle.
+      - name: Attach bundle to the release (v* tags)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, sys, time, urllib.request
+
+          tag = os.environ["GITHUB_REF"].split("/", 2)[2]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          asset = f"zx-next-unite-{tag}-linux-x86_64.flatpak"
+          api = "https://api.github.com"
+
+          def req(url, data=None, method=None, ctype="application/json"):
+              r = urllib.request.Request(url, data=data, method=method)
+              r.add_header("Authorization", f"Bearer {token}")
+              r.add_header("Accept", "application/vnd.github+json")
+              if data is not None:
+                  r.add_header("Content-Type", ctype)
+              return urllib.request.urlopen(r, timeout=300)
+
+          release = None
+          for attempt in range(10):  # release.yml may still be creating the draft
+              with req(f"{api}/repos/{repo}/releases?per_page=30") as resp:
+                  releases = json.load(resp)
+              release = next((r for r in releases if r.get("tag_name") == tag), None)
+              if release:
+                  break
+              print(f"release {tag} not there yet (attempt {attempt + 1}/10) - waiting 60s")
+              time.sleep(60)
+          if not release:
+              print(f"::warning::no release found for {tag} - attach {asset} "
+                    "manually from the workflow artifact")
+              sys.exit(0)
+
+          for a in release.get("assets", []):  # --clobber semantics on re-runs
+              if a["name"] == asset:
+                  req(f"{api}/repos/{repo}/releases/assets/{a['id']}",
+                      method="DELETE").close()
+
+          upload = release["upload_url"].split("{")[0] + f"?name={asset}"
+          with open("zx-next-unite.flatpak", "rb") as fh:
+              data = fh.read()
+          with req(upload, data=data, ctype="application/octet-stream") as resp:
+              print(f"attached {asset} to release {tag} (HTTP {resp.status})")
+          PYEOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,12 @@ Flatpak (Linux): everything lives under `flatpak/` (manifest on the KDE 6.8
 runtime + PySide BaseApp, desktop entry, AppStream metainfo, pixel-art icons
 — dots, not the Sinclair rainbow) with the build/Flathub-submission steps in
 `flatpak/README.md`. `.github/workflows/flatpak.yml` builds the
-`zx-next-unite.flatpak` bundle as a workflow artifact (workflow_dispatch +
-`v*` tags) — deliberately separate from `release.yml` so the self-updater's
+`zx-next-unite.flatpak` bundle as a workflow artifact (workflow_dispatch,
+pushes touching `flatpak/**`, and `v*` tag creation — tag runs also attach
+the bundle to the tag's draft release as
+`zx-next-unite-<tag>-linux-x86_64.flatpak`, retrying while `release.yml`
+creates the draft and degrading to a warning, never a failure) —
+deliberately separate from `release.yml` so the self-updater's
 asset contract stays untouched (a `.flatpak` asset can never match
 `select_zxnu_release_asset`, which requires `.tar.gz`+`linux`). Inside the
 sandbox `ZX_NEXT_UNITE_MODE=installed` is set via finish-args and the

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -54,9 +54,13 @@ flatpak install --user zx-next-unite.flatpak
 `.github/workflows/flatpak.yml` builds the bundle in the
 `flathub-infra/flatpak-github-actions` KDE 6.8 container and uploads
 `zx-next-unite.flatpak` as a workflow artifact. Triggers: manual
-(workflow_dispatch, once the workflow is on the default branch) and any
+(workflow_dispatch, once the workflow is on the default branch), any
 push touching `flatpak/**` or the workflow itself — so manifest changes are
-CI-validated before they merge. It is deliberately separate from
+CI-validated before they merge — and `v*` tag creation, where the bundle
+(built from the exact tag commit) is additionally attached to the tag's
+draft release as `zx-next-unite-<tag>-linux-x86_64.flatpak` (stdlib-only
+uploader, drafts included; it retries while `release.yml` creates the
+draft, then degrades to a warning). It is deliberately separate from
 `release.yml` so the self-updater's release-asset contract (exe / tar.gz /
 zip) stays untouched and a Flatpak failure can never block a release.
 


### PR DESCRIPTION
The flatpak workflow now also runs on `v*` tag creation and attaches the bundle — built from the exact tag commit — to the draft release `release.yml` creates for the same tag, as `zx-next-unite-<tag>-linux-x86_64.flatpak` (continuing what was done manually for v9.4.5).

Design notes:
- Tag trigger via the `create` event (sidesteps the paths-filter-vs-tags trap); branch creations are filtered out at the job level — already verified on this very branch: its `create` run was skipped in 1s.
- The uploader is stdlib-only python (the flathub container ships no `gh`) and finds the release via the list API, drafts included (the by-tag endpoint skips drafts). Retries up to 10 minutes while the draft appears, then degrades to a warning.
- The isolation guarantees hold: a Flatpak failure still can never block a release, and a `.flatpak` asset can never match the self-updater's `select_zxnu_release_asset` contract (`.tar.gz`+`linux`).
- CLAUDE.md and flatpak/README.md updated to describe the new trigger and attach behavior.

First real exercise of the tag path will be the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)