### PR TITLE
Remote Explorer idle panel polish (.sync5 example + retro styling) + bump to 9.4.6

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -73,7 +73,7 @@ zip) stays untouched and a Flatpak failure can never block a release.
    sources:
      - type: git
        url: https://github.com/jclauzel/ZX-Next-Unite.git
-       tag: v9.4.5
+       tag: v9.4.6
        commit: <full commit sha of the tag>
    ```
 

--- a/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
@@ -50,6 +50,7 @@
     <color type="primary" scheme_preference="dark">#1c1c60</color>
   </branding>
   <releases>
+    <release version="9.4.6" date="2026-07-30"/>
     <release version="9.4.5" date="2026-07-30"/>
     <release version="9.4.4" date="2026-07-30"/>
     <release version="9.4.3" date="2026-07-29"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.4.5"
+version = "9.4.6"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.4.5"
+ZX_NEXT_UNITE_VERSION = "9.4.6"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -600,6 +600,16 @@ def build_nextsync_pane(
                 "file_size":    host.img_color_file_size,
                 "general_text": host.img_color_general_text,
             })
+            # The idle host/IP panel follows the retro (Consolas) log colour
+            # and font-size settings — floored at 12pt for readability.
+            col = (configuration_dictionary.get(SETTING_COLOR_RETRO_LOG)
+                   or "").strip() or "#33ff33"
+            try:
+                pt = int(configuration_dictionary.get(SETTING_RETRO_LOG_FONT_SIZE)
+                         or DEFAULT_RETRO_LOG_FONT_SIZE)
+            except (TypeError, ValueError):
+                pt = DEFAULT_RETRO_LOG_FONT_SIZE
+            widget.set_idle_details_style(col, max(12, pt))
         except Exception:
             pass
     host._re_apply_item_colors = _re_apply_item_colors
@@ -685,6 +695,15 @@ def build_nextsync_pane(
                           "to — give it the",
                           "Primary IP (or whichever address is on the same "
                           "network as the Next)."]
+                addr = primary or next(
+                    (x for x in ips if not x.startswith("127")), None)
+                if addr:
+                    lines += ["",
+                              "Example — on the Next, type this once to save "
+                              "the address:",
+                              f"    .sync5 {addr}",
+                              "then start the remote session any time with:",
+                              "    .sync5 -listen"]
             _re_ip_info_cache["text"] = "\n".join(lines)
             _re_ip_info_cache["t"] = now
         return _re_ip_info_cache["text"]

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -533,6 +533,11 @@ class RemoteExplorerWidget(QWidget):
         # '.sync5' is the one thing they need while setting the link up.
         self._idle_details_provider = None
         self._idle_info_overlay = None
+        # Style for the idle-details overlay; the host pushes the user's
+        # retro-log (Consolas) colour + font-size settings through
+        # set_idle_details_style so the panel follows them live.
+        self._idle_info_color = "#a6f0a6"
+        self._idle_info_pt = 12
         self.next_path_label = QLabel("Next: (not connected)", self)
         next_up = QPushButton("Up", self)
         next_up.setMaximumWidth(48)
@@ -1012,15 +1017,28 @@ class RemoteExplorerWidget(QWidget):
             lbl.setAlignment(Qt.AlignCenter)
             # Purely informational: never intercept the pane's mouse events.
             lbl.setAttribute(Qt.WA_TransparentForMouseEvents, True)
-            lbl.setStyleSheet(
-                "QLabel { background: transparent; color: #7fae7f;"
-                " font-family: Consolas, 'Courier New', monospace;"
-                " font-size: 10pt; }")
+            lbl.setStyleSheet(self._idle_info_stylesheet())
             lbl.setGeometry(self.next_container.rect())
             lbl.show()
             lbl.raise_()
             self._idle_info_overlay = lbl
         self._idle_info_overlay.setText(text)
+
+    def _idle_info_stylesheet(self):
+        return ("QLabel { background: transparent;"
+                f" color: {self._idle_info_color};"
+                " font-family: Consolas, 'Courier New', monospace;"
+                f" font-size: {self._idle_info_pt}pt; }}")
+
+    def set_idle_details_style(self, color=None, point_size=None):
+        """Restyle the idle-details overlay (the host pushes the retro-log
+        Consolas colour and font-size settings here, live)."""
+        if color:
+            self._idle_info_color = color
+        if point_size:
+            self._idle_info_pt = int(point_size)
+        if self._idle_info_overlay is not None:
+            self._idle_info_overlay.setStyleSheet(self._idle_info_stylesheet())
 
     def refresh_idle_status(self):
         """Re-evaluate the idle status (host state changed: sync root set,


### PR DESCRIPTION
Follow-ups to #225 on the Remote Explorer's new idle host/IP panel:

- The block now ends with a worked example using the machine's detected primary IP — `.sync5 <primary IP>` once to save the address, then `.sync5 -listen` — so first-time setup is copy-along.
- The panel follows the user's retro-log (Consolas) colour and font-size settings live (new `set_idle_details_style`, pushed through `_re_apply_item_colors`), floored at 12pt, instead of a hardcoded dim green.

Also bumps the version to 9.4.6 (config, pyproject, metainfo `<releases>`, README pin example) — this release carries #225 (dotN 5.5 with the `-L` alias + the idle panel) and this polish.

Full test suite + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)