### PR TITLE
HTTP_BRIDGE.md: note the -l / -L listen aliases

### DIFF
--- a/nextsync/sync/server/HTTP_BRIDGE.md
+++ b/nextsync/sync/server/HTTP_BRIDGE.md
@@ -2,8 +2,8 @@
 
 The HTTP bridge is a small self-hosted web server — built on
 [Flask](https://flask.palletsprojects.com/) by the Pallets team
-(BSD-3-Clause) — that republishes a NextSync **`.sync5 -listen`** session as
-plain HTTP routes:
+(BSD-3-Clause) — that republishes a NextSync **`.sync5 -listen`** session
+(short aliases: `.sync5 -l` or `-L`) as plain HTTP routes:
 
 ```
 caller (.http on a Next / curl / browser)


### PR DESCRIPTION
Completes the -L alias documentation sweep: the bridge doc's first `.sync5 -listen` mention now notes the short aliases. (README and the wiki's Home / Installation / NextSync-tab pages were updated in #228 and the wiki push; the User-Manual overview has no -listen mention.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)