### PR TITLE
i18n: localise the SD Card console's startup banner, detection and update checks

### DIFF
--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -505,6 +505,63 @@ def test_gallery_item_viewer():
               not missing, str(missing))
 
 
+def test_sdcard_console():
+    """The SD Card console's startup banner, detection block and update checks.
+
+    These are emitted through add_main_log_window, so nothing but ui_tr_now can
+    reach them. The banner and credits come from INIT_LOG, a module constant
+    built at IMPORT time — before any language is known — so they have to be
+    translated as they are emitted, not where they are defined."""
+    print("\n== SD Card console ==")
+    from zxnu_config import INIT_LOG, ZX_NEXT_UNITE_VERSION
+
+    banner = "Welcome to ZX Next Unite {version}"
+    lines = [banner] + list(INIT_LOG[1:])
+    detection = [
+        "Loaded configuration file.",
+        "Using MAME under: {path}",
+        "MAME version: {version}",
+        "Using CSpect under downloads/cspect: {path}",
+        "Using hdfmonkey bundled with CSpect: {path}",
+        "Checking for a newer MAME release…",
+        "Checking itch.io for a newer CSpect release…",
+        "Checking for a newer ZX Next Unite release on GitHub…",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).",
+        "MAME is up-to-date with a patched version "
+        "(installed 0.{installed}, latest 0.{latest}).",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).",
+        "CSpect is up to date (installed {installed}, latest {latest}).",
+    ]
+    for code, _n in UI_LANGUAGES:
+        if code == DEFAULT_UI_LANGUAGE:
+            continue
+        missing = [s for s in lines + detection if s not in CATALOGS[code]]
+        check(f"the SD Card console is translated in '{code}'",
+              not missing, f"{len(missing)}: {[m[:34] for m in missing[:3]]}")
+
+    # INIT_LOG[0] is the banner WITH the version already interpolated, so it
+    # can never match a catalog key — the emitter must use the template.
+    check("the banner constant is not itself a catalog key (template is used)",
+          INIT_LOG[0] not in CATALOGS["fr"]
+          and INIT_LOG[0] == f"Welcome to ZX Next Unite {ZX_NEXT_UNITE_VERSION}",
+          INIT_LOG[0])
+
+    set_current_ui_language("fr")
+    rendered = ui_tr_now(banner).format(version=ZX_NEXT_UNITE_VERSION)
+    check("the banner renders translated with the version intact",
+          rendered.startswith("Bienvenue") and ZX_NEXT_UNITE_VERSION in rendered,
+          rendered)
+    # Names and URLs inside the credit lines must survive translation.
+    for src, keep in ((INIT_LOG[1], "Jari Komppa"),
+                      (INIT_LOG[2], "https://wiki.specnext.dev/MAME:Installing"),
+                      (INIT_LOG[4], "http://cspect.org")):
+        for code, _n in UI_LANGUAGES:
+            set_current_ui_language(code)
+            check(f"credit line keeps {keep[:26]!r} in '{code}'",
+                  keep in ui_tr_now(src), ui_tr_now(src)[:60])
+    set_current_ui_language(DEFAULT_UI_LANGUAGE)
+
+
 def test_runtime_text_sweep():
     """No widget text written AFTER startup may be a bare English literal.
 
@@ -596,6 +653,7 @@ def main():
     test_emulator_option_combos()
     test_log_line_placeholders()
     test_gallery_item_viewer()
+    test_sdcard_console()
     test_runtime_text_sweep()
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
     sys.exit(0 if ok else 1)

--- a/zxnu_config_io.py
+++ b/zxnu_config_io.py
@@ -29,6 +29,7 @@ from PySide6.QtCore import (Qt, QTimer)
 from PySide6.QtGui import (QPixmap)
 
 from zxnu_config import *
+from zxnu_i18n import ui_tr_now
 from zxnu_gallery import *
 from zxnu_http_bridge import flask_available
 
@@ -907,7 +908,7 @@ def build_config_io(
                 pass
 
             config_loaded_with_success = True
-            add_main_log_window("Loaded configuration file.")
+            add_main_log_window(ui_tr_now("Loaded configuration file."))
             logging.info("Configuration file loaded successfully.")
 
         except ValueError as e:

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -1122,14 +1122,15 @@ def build_emulator_ops(
                     return
                 if latest_num <= installed_num:
                     if info.get("patched"):
-                        add_main_log_window(
+                        add_main_log_window(ui_tr_now(
                             "MAME is up-to-date with a patched version "
-                            f"(installed 0.{installed_num}, "
-                            f"latest 0.{latest_num}).")
+                            "(installed 0.{installed}, latest 0.{latest})."
+                        ).format(installed=installed_num, latest=latest_num))
                     else:
-                        add_main_log_window(
-                            f"MAME is up-to-date (installed 0.{installed_num}, "
-                            f"latest 0.{latest_num}).")
+                        add_main_log_window(ui_tr_now(
+                            "MAME is up-to-date (installed 0.{installed}, "
+                            "latest 0.{latest})."
+                        ).format(installed=installed_num, latest=latest_num))
                     return
                 _prompt_mame_update(info, installed_num)
             except Exception as exc:
@@ -1142,7 +1143,7 @@ def build_emulator_ops(
                 "MAME update check: could not reach the release site; "
                 "skipping.")
 
-        add_main_log_window("Checking for a newer MAME release…")
+        add_main_log_window(ui_tr_now("Checking for a newer MAME release…"))
         getit_run_in_thread(_job, _on_result, _on_error)
 
     # Expose so the startup sequence can kick the check once the config
@@ -1444,9 +1445,10 @@ def build_emulator_ops(
                         f"versions (latest tag {tag!r}); skipping.")
                     return
                 if remote <= local:
-                    add_main_log_window(
-                        f"ZX Next Unite is up to date "
-                        f"(installed {ZX_NEXT_UNITE_VERSION}, latest {tag}).")
+                    add_main_log_window(ui_tr_now(
+                        "ZX Next Unite is up to date (installed {installed}, "
+                        "latest {latest})."
+                    ).format(installed=ZX_NEXT_UNITE_VERSION, latest=tag))
                     return
                 add_main_log_window(
                     f"ZX Next Unite update available: {tag} "
@@ -1462,7 +1464,8 @@ def build_emulator_ops(
                 "ZX Next Unite update check: could not reach GitHub "
                 "(offline, or no release published yet); skipping.")
 
-        add_main_log_window("Checking for a newer ZX Next Unite release on GitHub…")
+        add_main_log_window(ui_tr_now(
+            "Checking for a newer ZX Next Unite release on GitHub…"))
         getit_run_in_thread(_job, _on_result, _on_error)
 
     host._check_zxnu_update_async = _check_zxnu_update_async
@@ -1707,9 +1710,10 @@ def build_emulator_ops(
                 installed_name = info.get("installed_name")
                 latest_name = info.get("version_name")
                 if not info.get("newer"):
-                    add_main_log_window(
-                        f"CSpect is up to date (installed {installed_name}, "
-                        f"latest {latest_name}).")
+                    add_main_log_window(ui_tr_now(
+                        "CSpect is up to date (installed {installed}, "
+                        "latest {latest})."
+                    ).format(installed=installed_name, latest=latest_name))
                     return
                 add_main_log_window(
                     f"CSpect update ▸ newer build available: installed "
@@ -1735,7 +1739,8 @@ def build_emulator_ops(
             add_main_log_window(f"CSpect update check skipped: {detail}")
             logging.info(f"CSpect update check skipped: {detail}")
 
-        add_main_log_window("Checking itch.io for a newer CSpect release…")
+        add_main_log_window(ui_tr_now(
+            "Checking itch.io for a newer CSpect release…"))
         getit_run_in_thread(_job, _on_result, _on_error)
 
     # Expose so the startup sequence (and the itch.io post-login callback)

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,45 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        # ---- SD Card console: banner, detection, update checks ----
+        "CSpect - by Mike Dailly http://cspect.org":
+            "CSpect - por Mike Dailly http://cspect.org",
+        "CSpect is up to date (installed {installed}, latest {latest}).":
+            "CSpect está actualizado (instalada {installed}, última {latest}).",
+        "Checking for a newer MAME release…":
+            "Buscando una versión más reciente de MAME…",
+        "Checking for a newer ZX Next Unite release on GitHub…":
+            "Buscando en GitHub una versión más reciente de ZX Next Unite…",
+        "Checking itch.io for a newer CSpect release…":
+            "Buscando en itch.io una versión más reciente de CSpect…",
+        "HDF Monkey - by Matt Westcott":
+            "HDF Monkey - por Matt Westcott",
+        "Inspired by HDFM-GOOEY - by em00k":
+            "Inspirado en HDFM-GOOEY - por em00k",
+        "Loaded configuration file.":
+            "Archivo de configuración cargado.",
+        "MAME - ZX Spectrum Next support by Holub https://wiki.specnext.dev/MAME:Installing":
+            "MAME - compatibilidad con ZX Spectrum Next por Holub https://wiki.specnext.dev/MAME:Installing",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).":
+            "MAME está actualizado (instalada 0.{installed}, última 0.{latest}).",
+        "MAME is up-to-date with a patched version (installed 0.{installed}, latest 0.{latest}).":
+            "MAME está actualizado con una versión parcheada (instalada 0.{installed}, última 0.{latest}).",
+        "MAME version: {version}":
+            "Versión de MAME: {version}",
+        "NextSync - by Jari Komppa and Julien Clauzel":
+            "NextSync - por Jari Komppa y Julien Clauzel",
+        "Using CSpect under downloads/cspect: {path}":
+            "Usando CSpect en downloads/cspect: {path}",
+        "Using MAME under: {path}":
+            "Usando MAME en: {path}",
+        "Using hdfmonkey bundled with CSpect: {path}":
+            "Usando el hdfmonkey incluido con CSpect: {path}",
+        "Welcome to ZX Next Unite {version}":
+            "Bienvenido a ZX Next Unite {version}",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).":
+            "ZX Next Unite está actualizado (instalada {installed}, última {latest}).",
+        "zx-next-unite - by Julien Clauzel 2024":
+            "zx-next-unite - por Julien Clauzel 2024",
         "No image loaded": "No hay imagen cargada",
         # ---- itch.io item viewer + web-link labels ----
         "About": "Acerca de",
@@ -896,6 +935,45 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        # ---- SD Card console: banner, detection, update checks ----
+        "CSpect - by Mike Dailly http://cspect.org":
+            "CSpect - por Mike Dailly http://cspect.org",
+        "CSpect is up to date (installed {installed}, latest {latest}).":
+            "O CSpect está atualizado (instalada {installed}, mais recente {latest}).",
+        "Checking for a newer MAME release…":
+            "A procurar uma versão mais recente do MAME…",
+        "Checking for a newer ZX Next Unite release on GitHub…":
+            "A procurar no GitHub uma versão mais recente do ZX Next Unite…",
+        "Checking itch.io for a newer CSpect release…":
+            "A procurar no itch.io uma versão mais recente do CSpect…",
+        "HDF Monkey - by Matt Westcott":
+            "HDF Monkey - por Matt Westcott",
+        "Inspired by HDFM-GOOEY - by em00k":
+            "Inspirado em HDFM-GOOEY - por em00k",
+        "Loaded configuration file.":
+            "Ficheiro de configuração carregado.",
+        "MAME - ZX Spectrum Next support by Holub https://wiki.specnext.dev/MAME:Installing":
+            "MAME - suporte para ZX Spectrum Next por Holub https://wiki.specnext.dev/MAME:Installing",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).":
+            "O MAME está atualizado (instalada 0.{installed}, mais recente 0.{latest}).",
+        "MAME is up-to-date with a patched version (installed 0.{installed}, latest 0.{latest}).":
+            "O MAME está atualizado com uma versão modificada (instalada 0.{installed}, mais recente 0.{latest}).",
+        "MAME version: {version}":
+            "Versão do MAME: {version}",
+        "NextSync - by Jari Komppa and Julien Clauzel":
+            "NextSync - por Jari Komppa e Julien Clauzel",
+        "Using CSpect under downloads/cspect: {path}":
+            "A usar o CSpect em downloads/cspect: {path}",
+        "Using MAME under: {path}":
+            "A usar o MAME em: {path}",
+        "Using hdfmonkey bundled with CSpect: {path}":
+            "A usar o hdfmonkey incluído no CSpect: {path}",
+        "Welcome to ZX Next Unite {version}":
+            "Bem-vindo ao ZX Next Unite {version}",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).":
+            "O ZX Next Unite está atualizado (instalada {installed}, mais recente {latest}).",
+        "zx-next-unite - by Julien Clauzel 2024":
+            "zx-next-unite - por Julien Clauzel 2024",
         "No image loaded": "Nenhuma imagem carregada",
         # ---- itch.io item viewer + web-link labels ----
         "About": "Sobre",
@@ -1373,6 +1451,45 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        # ---- SD Card console: banner, detection, update checks ----
+        "CSpect - by Mike Dailly http://cspect.org":
+            "CSpect - autor: Mike Dailly http://cspect.org",
+        "CSpect is up to date (installed {installed}, latest {latest}).":
+            "CSpect jest aktualny (zainstalowana {installed}, najnowsza {latest}).",
+        "Checking for a newer MAME release…":
+            "Sprawdzanie nowszej wersji MAME…",
+        "Checking for a newer ZX Next Unite release on GitHub…":
+            "Sprawdzanie w GitHubie nowszej wersji ZX Next Unite…",
+        "Checking itch.io for a newer CSpect release…":
+            "Sprawdzanie w itch.io nowszej wersji CSpect…",
+        "HDF Monkey - by Matt Westcott":
+            "HDF Monkey - autor: Matt Westcott",
+        "Inspired by HDFM-GOOEY - by em00k":
+            "Zainspirowane przez HDFM-GOOEY - autor: em00k",
+        "Loaded configuration file.":
+            "Wczytano plik konfiguracyjny.",
+        "MAME - ZX Spectrum Next support by Holub https://wiki.specnext.dev/MAME:Installing":
+            "MAME - obsługa ZX Spectrum Next: Holub https://wiki.specnext.dev/MAME:Installing",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).":
+            "MAME jest aktualny (zainstalowana 0.{installed}, najnowsza 0.{latest}).",
+        "MAME is up-to-date with a patched version (installed 0.{installed}, latest 0.{latest}).":
+            "MAME jest aktualny w wersji ze zmianami (zainstalowana 0.{installed}, najnowsza 0.{latest}).",
+        "MAME version: {version}":
+            "Wersja MAME: {version}",
+        "NextSync - by Jari Komppa and Julien Clauzel":
+            "NextSync - autorzy: Jari Komppa i Julien Clauzel",
+        "Using CSpect under downloads/cspect: {path}":
+            "Używany CSpect w downloads/cspect: {path}",
+        "Using MAME under: {path}":
+            "Używany MAME w: {path}",
+        "Using hdfmonkey bundled with CSpect: {path}":
+            "Używany hdfmonkey dołączony do CSpect: {path}",
+        "Welcome to ZX Next Unite {version}":
+            "Witaj w ZX Next Unite {version}",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).":
+            "ZX Next Unite jest aktualny (zainstalowana {installed}, najnowsza {latest}).",
+        "zx-next-unite - by Julien Clauzel 2024":
+            "zx-next-unite - autor: Julien Clauzel 2024",
         "No image loaded": "Nie wczytano obrazu",
         # ---- itch.io item viewer + web-link labels ----
         "About": "Informacje",
@@ -1851,6 +1968,45 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        # ---- SD Card console: banner, detection, update checks ----
+        "CSpect - by Mike Dailly http://cspect.org":
+            "CSpect - автор: Mike Dailly http://cspect.org",
+        "CSpect is up to date (installed {installed}, latest {latest}).":
+            "CSpect актуален (установлена {installed}, последняя {latest}).",
+        "Checking for a newer MAME release…":
+            "Проверка новой версии MAME…",
+        "Checking for a newer ZX Next Unite release on GitHub…":
+            "Проверка на GitHub новой версии ZX Next Unite…",
+        "Checking itch.io for a newer CSpect release…":
+            "Проверка на itch.io новой версии CSpect…",
+        "HDF Monkey - by Matt Westcott":
+            "HDF Monkey - автор: Matt Westcott",
+        "Inspired by HDFM-GOOEY - by em00k":
+            "Вдохновлено HDFM-GOOEY - автор: em00k",
+        "Loaded configuration file.":
+            "Файл конфигурации загружен.",
+        "MAME - ZX Spectrum Next support by Holub https://wiki.specnext.dev/MAME:Installing":
+            "MAME - поддержка ZX Spectrum Next: Holub https://wiki.specnext.dev/MAME:Installing",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).":
+            "MAME актуален (установлена 0.{installed}, последняя 0.{latest}).",
+        "MAME is up-to-date with a patched version (installed 0.{installed}, latest 0.{latest}).":
+            "MAME актуален (используется модифицированная сборка; установлена 0.{installed}, последняя 0.{latest}).",
+        "MAME version: {version}":
+            "Версия MAME: {version}",
+        "NextSync - by Jari Komppa and Julien Clauzel":
+            "NextSync - авторы: Jari Komppa и Julien Clauzel",
+        "Using CSpect under downloads/cspect: {path}":
+            "Используется CSpect из downloads/cspect: {path}",
+        "Using MAME under: {path}":
+            "Используется MAME: {path}",
+        "Using hdfmonkey bundled with CSpect: {path}":
+            "Используется hdfmonkey из комплекта CSpect: {path}",
+        "Welcome to ZX Next Unite {version}":
+            "Добро пожаловать в ZX Next Unite {version}",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).":
+            "ZX Next Unite актуален (установлена {installed}, последняя {latest}).",
+        "zx-next-unite - by Julien Clauzel 2024":
+            "zx-next-unite - автор: Julien Clauzel 2024",
         "No image loaded": "Образ не загружен",
         # ---- itch.io item viewer + web-link labels ----
         "About": "Описание",
@@ -2328,6 +2484,45 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        # ---- SD Card console: banner, detection, update checks ----
+        "CSpect - by Mike Dailly http://cspect.org":
+            "CSpect - autor: Mike Dailly http://cspect.org",
+        "CSpect is up to date (installed {installed}, latest {latest}).":
+            "CSpect je aktuální (nainstalovaná {installed}, nejnovější {latest}).",
+        "Checking for a newer MAME release…":
+            "Hledá se novější verze MAME…",
+        "Checking for a newer ZX Next Unite release on GitHub…":
+            "Na GitHubu se hledá novější verze ZX Next Unite…",
+        "Checking itch.io for a newer CSpect release…":
+            "Na itch.io se hledá novější verze CSpectu…",
+        "HDF Monkey - by Matt Westcott":
+            "HDF Monkey - autor: Matt Westcott",
+        "Inspired by HDFM-GOOEY - by em00k":
+            "Inspirováno HDFM-GOOEY - autor: em00k",
+        "Loaded configuration file.":
+            "Konfigurační soubor načten.",
+        "MAME - ZX Spectrum Next support by Holub https://wiki.specnext.dev/MAME:Installing":
+            "MAME - podpora ZX Spectrum Next: Holub https://wiki.specnext.dev/MAME:Installing",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).":
+            "MAME je aktuální (nainstalovaná 0.{installed}, nejnovější 0.{latest}).",
+        "MAME is up-to-date with a patched version (installed 0.{installed}, latest 0.{latest}).":
+            "MAME je aktuální v upravené verzi (nainstalovaná 0.{installed}, nejnovější 0.{latest}).",
+        "MAME version: {version}":
+            "Verze MAME: {version}",
+        "NextSync - by Jari Komppa and Julien Clauzel":
+            "NextSync - autoři: Jari Komppa a Julien Clauzel",
+        "Using CSpect under downloads/cspect: {path}":
+            "Používá se CSpect v downloads/cspect: {path}",
+        "Using MAME under: {path}":
+            "Používá se MAME v: {path}",
+        "Using hdfmonkey bundled with CSpect: {path}":
+            "Používá se hdfmonkey dodaný s CSpectem: {path}",
+        "Welcome to ZX Next Unite {version}":
+            "Vítejte v ZX Next Unite {version}",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).":
+            "ZX Next Unite je aktuální (nainstalovaná {installed}, nejnovější {latest}).",
+        "zx-next-unite - by Julien Clauzel 2024":
+            "zx-next-unite - autor: Julien Clauzel 2024",
         "No image loaded": "Není načten žádný obraz",
         # ---- itch.io item viewer + web-link labels ----
         "About": "O hře",
@@ -2808,6 +3003,45 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        # ---- SD Card console: banner, detection, update checks ----
+        "CSpect - by Mike Dailly http://cspect.org":
+            "CSpect - par Mike Dailly http://cspect.org",
+        "CSpect is up to date (installed {installed}, latest {latest}).":
+            "CSpect est à jour (installée {installed}, dernière {latest}).",
+        "Checking for a newer MAME release…":
+            "Recherche d'une version plus récente de MAME…",
+        "Checking for a newer ZX Next Unite release on GitHub…":
+            "Recherche sur GitHub d'une version plus récente de ZX Next Unite…",
+        "Checking itch.io for a newer CSpect release…":
+            "Recherche sur itch.io d'une version plus récente de CSpect…",
+        "HDF Monkey - by Matt Westcott":
+            "HDF Monkey - par Matt Westcott",
+        "Inspired by HDFM-GOOEY - by em00k":
+            "Inspiré de HDFM-GOOEY - par em00k",
+        "Loaded configuration file.":
+            "Fichier de configuration chargé.",
+        "MAME - ZX Spectrum Next support by Holub https://wiki.specnext.dev/MAME:Installing":
+            "MAME - prise en charge du ZX Spectrum Next par Holub https://wiki.specnext.dev/MAME:Installing",
+        "MAME is up-to-date (installed 0.{installed}, latest 0.{latest}).":
+            "MAME est à jour (installée 0.{installed}, dernière 0.{latest}).",
+        "MAME is up-to-date with a patched version (installed 0.{installed}, latest 0.{latest}).":
+            "MAME est à jour avec une version modifiée (installée 0.{installed}, dernière 0.{latest}).",
+        "MAME version: {version}":
+            "Version de MAME : {version}",
+        "NextSync - by Jari Komppa and Julien Clauzel":
+            "NextSync - par Jari Komppa et Julien Clauzel",
+        "Using CSpect under downloads/cspect: {path}":
+            "CSpect utilisé depuis downloads/cspect : {path}",
+        "Using MAME under: {path}":
+            "MAME utilisé depuis : {path}",
+        "Using hdfmonkey bundled with CSpect: {path}":
+            "hdfmonkey fourni avec CSpect utilisé : {path}",
+        "Welcome to ZX Next Unite {version}":
+            "Bienvenue dans ZX Next Unite {version}",
+        "ZX Next Unite is up to date (installed {installed}, latest {latest}).":
+            "ZX Next Unite est à jour (installée {installed}, dernière {latest}).",
+        "zx-next-unite - by Julien Clauzel 2024":
+            "zx-next-unite - par Julien Clauzel 2024",
         "No image loaded": "Aucune image chargée",
         # ---- itch.io item viewer + web-link labels ----
         "About": "À propos",

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -2707,8 +2707,14 @@ class MainWindow(QMainWindow):
 
         self.listWidgetLog = QListWidget(self)
 
-        for l in INIT_LOG:
-            add_main_log_window(l)
+        # INIT_LOG is built at import time, before a language is known, so
+        # each line is translated here as it is emitted. The banner carries the
+        # version, so it goes through its own {version} template; the credit
+        # lines translate the prose around the names, which stay as written.
+        add_main_log_window(ui_tr_now("Welcome to ZX Next Unite {version}")
+                            .format(version=ZX_NEXT_UNITE_VERSION))
+        for l in INIT_LOG[1:]:
+            add_main_log_window(ui_tr_now(l))
 
         self.listWidgetHelp = QListWidget(self)
 
@@ -3797,7 +3803,8 @@ class MainWindow(QMainWindow):
         # (blocking) 'mame -version' probe returns on a worker thread.
         _mame_found_path = getattr(self, "_mame_executable_path", None)
         if _mame_found_path:
-            add_main_log_window(f"Using MAME under: {_mame_found_path}")
+            add_main_log_window(ui_tr_now("Using MAME under: {path}")
+                                .format(path=_mame_found_path))
 
             def _mame_version_probe(progress_callback=None, _p=_mame_found_path):
                 # First non-empty line of 'mame -version' output, e.g.
@@ -3820,7 +3827,8 @@ class MainWindow(QMainWindow):
 
             def _mame_version_log(line):
                 if line:
-                    add_main_log_window(f"MAME version: {line}")
+                    add_main_log_window(ui_tr_now("MAME version: {version}")
+                                        .format(version=line))
 
             _mame_ver_worker = self._Worker(_mame_version_probe)
             _mame_ver_worker.signals.result.connect(_mame_version_log)
@@ -3934,7 +3942,9 @@ class MainWindow(QMainWindow):
                 # The CSpect group was hidden at construction because no emulator
                 # was found; reveal it now that a bundled copy exists.
                 self.cspect_group.setVisible(True)
-                add_main_log_window(f"Using CSpect under downloads/cspect: {cspect_path}")
+                add_main_log_window(ui_tr_now(
+                    "Using CSpect under downloads/cspect: {path}"
+                ).format(path=cspect_path))
                 # Bind hdfmonkey to the copy bundled with THIS (newest) CSpect
                 # build. Each itch.io CSpect ships its own hdfmonkey under
                 # <build>/hdfmonkey/<platform>/, so after an update the matching
@@ -3948,7 +3958,9 @@ class MainWindow(QMainWindow):
 
             if hdfmonkey_path and not self._hdfmonkey_executable_path:
                 self._hdfmonkey_executable_path = hdfmonkey_path
-                add_main_log_window(f"Using hdfmonkey bundled with CSpect: {hdfmonkey_path}")
+                add_main_log_window(ui_tr_now(
+                    "Using hdfmonkey bundled with CSpect: {path}"
+                ).format(path=hdfmonkey_path))
                 # A bundled hdfmonkey makes the download/install wizard
                 # unnecessary; hide it and restore the image controls.
                 self.download_and_install_hdfmonkey_button.setVisible(False)


### PR DESCRIPTION
The SD Card tab greets every launch with a block of English. This translates the part a user actually reads at startup — exactly the sample reported.

## What is covered (19 strings × 6 languages)

**Banner and credits.** `INIT_LOG` is a module constant built at *import* time, before any language is known, so these lines are translated **as they are emitted** rather than where they are defined. The banner goes through a `{version}` template, because the constant already has the version baked in and so could never match a catalog key. Author names and URLs stay exactly as written — only the prose around them is translated (`NextSync - par Jari Komppa et Julien Clauzel`, `Вдохновлено HDFM-GOOEY - автор: em00k`).

**Detection block.** `Loaded configuration file.`, `Using MAME under:`, `MAME version:`, `Using CSpect under downloads/cspect:`, `Using hdfmonkey bundled with CSpect:`. Paths and version strings are data — interpolated, never translated.

**Update checks.** The three startup checks and their up-to-date replies for MAME (including the patched-build variant), CSpect and ZX Next Unite.

## Tests

`test_i18n.test_sdcard_console` asserts the whole block is catalogued in all six languages, that the banner constant is deliberately **not** a catalog key — which is what proves the template path is the one in use — and that every credit line still carries its author name and URL after translation.

## What is *not* covered yet

136 further console lines remain English, concentrated in the MAME/CSpect/hdfmonkey install and update chains (`zxnu_emulator_ops.py`, 74) and the hdfmonkey transfer operations (`zxnu_sdcard_ops.py`, 54). A good share of those are diagnostics — argv dumps, HTTP failure detail — which by the rule already applied to the NextSync console stay English deliberately so a pasted log stays greppable.

Version stays at 9.4.8: that version is on `main` but was never tagged, so this lands under it rather than churning a new number.

`ruff check .` and the full suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)