### PR TITLE
Fix the restored tab never initialising (ZXDB opened with no pictures)

### DIFF
--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -34,6 +34,7 @@ SUITES = [
     ("test_data_root.py",       240, None),
     ("test_hdfmonkey_discovery.py", 120, None),
     ("test_mame_install.py",     120, None),
+    ("test_startup_tab_activation.py", 120, None),
     ("test_pane_imports.py",    120, None),
     ("test_hdf_workers.py",     120, None),
     ("test_classic_sync.py",    180, None),

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -26,6 +26,10 @@ import tempfile
 import time
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+# The compact-button checks print translated labels ("W górę", "Вверх"), which
+# a cp1252 console cannot encode — without this the suite dies in its own
+# print() rather than on anything it is testing.
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from PySide6.QtCore import QItemSelectionModel, QMimeData, QPointF, Qt, QUrl

--- a/tests/test_startup_tab_activation.py
+++ b/tests/test_startup_tab_activation.py
@@ -1,0 +1,128 @@
+"""Startup tab-activation tests (zxnu_main._deferred_startup_tab_activation).
+
+When the app is restored onto a tab, currentChanged has not been connected
+yet, so __init__ activates that tab by hand. Two ways that went wrong:
+
+1. It compared the live tab text to the tab-title CONSTANT with ==. Tab titles
+   carry runtime suffixes — _set_tab_badge appends " (N)" and the spinner
+   replaces the leading globe glyph — so the moment a badge is present the
+   comparison fails and the restored tab is never initialised at all. The
+   currentChanged handler has always used startswith(); the startup path must
+   match it, otherwise the behaviour depends on whether a background fetch
+   happened to finish first.
+
+2. The ZXDB branch called the plain first-visit activation. Every launch also
+   kicks off the Unite! "Latest" fan-out, which drives the same pane through
+   zxdb_on_latest; ZXDB's newest rows are created before anyone uploads media,
+   so that page renders as blank cells. The branch must go through
+   _zxdb_startup_initial_load, which waits for the fan-out and then loads the
+   pane's own (picture-bearing) page.
+
+Both are asserted at the source level: the block is a closure inside
+MainWindow.__init__, so it cannot be imported, and exercising it for real
+would need the network.
+
+Run with: python tests/test_startup_tab_activation.py
+"""
+import ast
+import os
+import sys
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, REPO)
+
+from zxnu_config import (  # noqa: E402
+    ZX_NEXT_UNITE_TAB_TITLE_GETIT,
+    ZX_NEXT_UNITE_TAB_TITLE_ZXART,
+    ZX_NEXT_UNITE_TAB_TITLE_ZXDB,
+)
+
+FAIL = []
+
+
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+def find_function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+source = open(os.path.join(REPO, "zxnu_main.py"), encoding="utf-8").read()
+tree = ast.parse(source)
+startup = find_function(tree, "_deferred_startup_tab_activation")
+check("the deferred startup activation exists", startup is not None)
+if startup is None:
+    sys.exit(1)
+
+# ---- 1. tab titles must be matched by PREFIX, never by equality ----------
+eq_compares = []
+prefix_calls = 0
+for node in ast.walk(startup):
+    if isinstance(node, ast.Compare) and any(
+            isinstance(op, ast.Eq) for op in node.ops):
+        names = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+        if any(x.startswith("ZX_NEXT_UNITE_TAB_TITLE_") for x in names):
+            eq_compares.append(node.lineno)
+    if (isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "startswith"):
+        names = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+        if any(x.startswith("ZX_NEXT_UNITE_TAB_TITLE_") for x in names):
+            prefix_calls += 1
+
+check("no tab title is matched with == (badges/spinners break equality)",
+      not eq_compares, f"== at lines {eq_compares}")
+check("every restored tab is matched with startswith()",
+      prefix_calls >= 5, f"only {prefix_calls} prefix matches")
+
+# The suffixes that make equality fail, straight from the badge formatter's
+# own format string ({base} ({count})).
+for base in (ZX_NEXT_UNITE_TAB_TITLE_ZXDB, ZX_NEXT_UNITE_TAB_TITLE_GETIT,
+             ZX_NEXT_UNITE_TAB_TITLE_ZXART):
+    badged = f"{base} (20)"
+    check(f"a badged title still prefix-matches {base[:18]!r}",
+          badged.startswith(base) and badged != base, badged)
+
+# ---- 2. the ZXDB branch must use the fan-out-aware startup load ----------
+called = set()
+for node in ast.walk(startup):
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        called.add(node.func.attr)
+check("the ZXDB branch uses _zxdb_startup_initial_load",
+      "_zxdb_startup_initial_load" in called, str(sorted(called)))
+check("...and not the plain first-visit activation, which the Unite! "
+      "'Latest' fan-out would overwrite",
+      "_zxdb_on_tab_activated" not in called, str(sorted(called)))
+
+# ---- 3. that startup load must actually exist and be exported -----------
+pane = ast.parse(open(os.path.join(REPO, "zxnu_zxdb_pane.py"),
+                      encoding="utf-8").read())
+fn = find_function(pane, "zxdb_startup_initial_load")
+check("zxdb_startup_initial_load is defined in the ZXDB pane", fn is not None)
+check("it is exported on the host as _zxdb_startup_initial_load",
+      "host._zxdb_startup_initial_load" in open(
+          os.path.join(REPO, "zxnu_zxdb_pane.py"), encoding="utf-8").read())
+if fn is not None:
+    body = ast.dump(fn)
+    check("it waits for the in-flight fan-out rather than superseding it "
+          "(a superseded fetch never fires on_complete, which Unite! awaits)",
+          "_zxdb_search_loading" in body and "singleShot" in body)
+    check("it leaves a user-driven query alone",
+          "zxdb_search_input" in body)
+    check("it has a bounded wait so the tab is never left empty",
+          "_ticks" in body)
+
+print()
+if FAIL:
+    print(f"{len(FAIL)} FAILURE(S): " + ", ".join(FAIL))
+    sys.exit(1)
+print("all startup tab-activation checks passed")
+sys.exit(0)

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -87,7 +87,14 @@ ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 # UI language pinned to English so the first-run OS-language adoption can't
 # translate the texts these phases compare (phase 10 covers that flow).
 BASE_CFG = ("mame_update_check=false\ncspect_update_check=false\n"
-            "zxnu_update_check=false\nui_language=en\n")
+            "zxnu_update_check=false\nui_language=en\n"
+            # The startup tab activation shows the one-time content disclaimer
+            # for the online panes. It is a MODAL dialog, so a phase that has
+            # not agreed to it blocks forever. (Before the tab titles were
+            # matched by prefix, a badge on the restored tab made that branch
+            # unreachable and the dialog never appeared — which is exactly the
+            # bug that left ZXDB uninitialised on restart.)
+            "content_disclaimer_agreed=1\n")
 
 
 def find_hdfmonkey():
@@ -239,7 +246,7 @@ elif PHASE == 10:
     ensure_scratch(fresh=False)
     with open(CFG, "w", encoding="utf-8") as f:
         f.write("mame_update_check=false\ncspect_update_check=false\n"
-                "zxnu_update_check=false\n")
+                "zxnu_update_check=false\ncontent_disclaimer_agreed=1\n")
     os.environ["ZX_NEXT_UNITE_UI_LANGUAGE"] = "es"
 elif PHASE == 11:
     # NextSync Remote Explorer with pygame absent (every phase blocks pygame —
@@ -266,7 +273,7 @@ elif PHASE in (6, 7):
                     + "delete_to_recycle_bin=false\n")
         else:
             f.write("mame_update_check=false\ncspect_update_check=false\n"
-                    "ui_language=en\n")
+                    "ui_language=en\ncontent_disclaimer_agreed=1\n")
 else:
     print(f"Unknown phase {PHASE}")
     sys.exit(2)

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -3719,11 +3719,11 @@ class MainWindow(QMainWindow):
                 current_title = wid_inner.tab.tabText(wid_inner.tab.currentIndex())
             except Exception:
                 return
-            if current_title == ZX_NEXT_UNITE_TAB_TITLE_GOOEY:
+            if current_title.startswith(ZX_NEXT_UNITE_TAB_TITLE_GOOEY):
                 # App restored onto the SD-card tab: kick off the idle glow now,
                 # since currentChanged wasn't connected during config restore.
                 _start_transfer_idle_animation()
-            elif current_title == ZX_NEXT_UNITE_TAB_TITLE_GETIT:
+            elif current_title.startswith(ZX_NEXT_UNITE_TAB_TITLE_GETIT):
                 _show_content_disclaimer()
                 self._getit_fetch_motd()
                 # Preserve any pending query (e.g. mirrored from an AllInOne
@@ -3732,15 +3732,20 @@ class MainWindow(QMainWindow):
                         and not self._getit_search_loading
                         and not self.getit_search_input.text().strip()):
                     self._getit_on_latest()
-            elif current_title == ZX_NEXT_UNITE_TAB_TITLE_ZXDB:
+            elif current_title.startswith(ZX_NEXT_UNITE_TAB_TITLE_ZXDB):
                 _show_content_disclaimer()
-                self._zxdb_on_tab_activated()
-            elif current_title == ZX_NEXT_UNITE_TAB_TITLE_ZXART:
+                # Restored straight onto ZXDB: the Unite! "Latest" fan-out
+                # above drives this pane too, and ZXDB's newest rows have no
+                # screenshots yet. Wait for that fetch, then load the pane's
+                # own (picture-bearing) first page — see the docstring on
+                # _zxdb_startup_initial_load.
+                self._zxdb_startup_initial_load()
+            elif current_title.startswith(ZX_NEXT_UNITE_TAB_TITLE_ZXART):
                 _show_content_disclaimer()
                 self._zxart_on_tab_activated()
-            elif current_title == ZX_NEXT_UNITE_TAB_TITLE_ALLINONE:
+            elif current_title.startswith(ZX_NEXT_UNITE_TAB_TITLE_ALLINONE):
                 _show_content_disclaimer()
-            elif current_title == ZX_NEXT_UNITE_TAB_TITLE_NEXTSYNC:
+            elif current_title.startswith(ZX_NEXT_UNITE_TAB_TITLE_NEXTSYNC):
                 # App restored directly onto the NextSync tab: start the Remote
                 # Explorer sub-tab animation (currentChanged wasn't connected yet)
                 # and auto-prepare so the Start button is ready.

--- a/zxnu_zxdb_pane.py
+++ b/zxnu_zxdb_pane.py
@@ -3060,6 +3060,53 @@ def build_zxdb_pane(
         # by-letter fetches before the first render completes.
         host._zxdb_ac_ready = True
 
+    def zxdb_startup_initial_load(_ticks=20, _saw_fanout=False, _waits=400):
+        """Give the ZXDB tab a picture-rich first page when the app is
+        restored straight onto it.
+
+        Every launch kicks off the Unite! "Latest" multi-search before the
+        restored tab is activated, and that fan-out drives THIS pane through
+        zxdb_on_latest. ZXDB's newest rows are database entries created long
+        before anyone uploads media to them, so that page is a grid of blank
+        cells — the "no pictures on restart" report. The pane's own first-visit
+        content (a random page) is drawn from established titles and does have
+        screenshots, but a plain activation loses the race: it runs before the
+        fan-out's ZXDB fetch starts, and the fan-out then overwrites it.
+
+        Taking over early is not an option either — superseding the fan-out's
+        fetch means its on_complete never fires, and Unite! waits on that
+        callback. So this waits for the fan-out's ZXDB load to start AND
+        finish, then runs the normal first-visit load. If no fan-out ever
+        materialises (feature flag off, offline, Unite! hidden) the tick budget
+        expires and the load runs anyway, so the tab is never left empty.
+
+        A user-driven query owns the pane outright and is never replaced.
+        """
+        if host.zxdb_search_input.text().strip():
+            return                          # a real query owns the pane
+        if host._zxdb_search_loading:
+            # A fetch is in flight — the fan-out's. Waiting for it does NOT
+            # spend the budget: on a slow link it can easily outlast a fixed
+            # window, and giving up mid-flight would leave the screenshot-less
+            # page on screen, i.e. the very bug this exists to fix. The
+            # separate _waits cap keeps a wedged request from polling forever.
+            if _waits > 0:
+                QTimer.singleShot(
+                    150,
+                    lambda: zxdb_startup_initial_load(_ticks, True, _waits - 1))
+            return
+        if not _saw_fanout and _ticks > 0:
+            # No fan-out yet. It is kicked off just before this runs, so give
+            # it a moment to start before concluding there won't be one.
+            QTimer.singleShot(
+                150, lambda: zxdb_startup_initial_load(_ticks - 1, False, _waits))
+            return
+        # The fan-out (if any) has finished; replace its page with ours.
+        host._zxdb_loaded_once = False
+        host._zxdb_last_query = ""
+        zxdb_on_tab_activated()
+
+    host._zxdb_startup_initial_load = zxdb_startup_initial_load
     host._zxdb_on_tab_activated = zxdb_on_tab_activated
     host.zxdb_run_search = zxdb_run_search
     host.zxdb_on_latest = zxdb_on_latest


### PR DESCRIPTION
Quitting on the ZXDB tab and relaunching showed a grid of titles with **no images**. Reproduced headlessly and traced to two faults, both in the startup path that activates the restored tab by hand (`currentChanged` is only connected after the config is loaded).

## 1. Tab titles were matched with `==`

The startup block compared the live tab text to the bare title **constants**. Real tab text carries runtime suffixes — `_set_tab_badge` appends `" (N)"`, and the search spinner rewrites the leading globe glyph. Every launch also kicks off the Unite! "Latest" multi-search *before* this code reads the title, so by then the online tabs are usually badged and the comparison fails: **the restored tab is never initialised at all.**

`on_tab_changed` has always used `startswith()` — which is exactly why switching away and back fixed it, and the detail that identified the bug. All six branches now match by prefix, like that handler.

Same bug was silently suppressing the one-time **content disclaimer** on those tabs. It now appears as intended. The offscreen phases had never agreed to it (they could not reach it), so they now pre-agree — otherwise the modal blocks them.

## 2. The pane then lost a race with the Unite! fan-out

With the branch reachable, the plain first-visit activation still lost: the fan-out drives this same pane through `zxdb_on_latest` and starts just after it, overwriting the page.

That page is genuinely image-less. Measured against the live API:

| startup selection | entries with a screenshot |
|---|---|
| `latest` (`date_desc`) | **0 / 20** |
| `random` | **20 / 20** |

ZXDB's newest rows are database entries created long before anyone uploads media, so "latest" is a wall of blank cells. (Worth recording: switching ZXDB's startup to "Latest" to match GetIt/zxArt — the intuitive fix — would have made this strictly worse.)

Superseding the fan-out is not an option either: a superseded fetch returns early and **never reaches its `on_complete`**, which the Unite! fan-out waits on. So `zxdb_startup_initial_load` waits for the fan-out to start *and* finish, then runs the pane's own load. A user-driven query is never replaced, and the wait is bounded (and does not spend its budget while a fetch is in flight, so a slow link still gets the takeover) so the tab is never left empty.

## Tests

`tests/test_startup_tab_activation.py` guards both faults at the source level — the block is a closure inside `MainWindow.__init__`, so it cannot be imported, and exercising it for real needs the network. It asserts no tab title is matched by equality, every branch uses `startswith`, and the ZXDB branch goes through the fan-out-aware load. Verified non-vacuous by re-introducing each fault and confirming the matching check fails.

Also gave `test_remote_explorer_widget.py` the `stdout.reconfigure` the other suites already have: it prints translated labels (`W górę`, `Вверх`) and was dying inside its own `print()` on a cp1252 console.

## Verification note

The headless harness confirms the tab now loads scattered random ids instead of the sequential newest ones. Its picture count is lower than the API ground truth for those same ids (which do have 2–9 screenshots each) — that looks like fetch shortfall under 20 concurrent requests in the offscreen harness rather than app behaviour, and the real app was confirmed good by hand.

`ruff check .` and the full suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)