### PR TITLE
i18n: localise the SD Card / emulator consoles and the message-box dialogs

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -73,7 +73,7 @@ zip) stays untouched and a Flatpak failure can never block a release.
    sources:
      - type: git
        url: https://github.com/jclauzel/ZX-Next-Unite.git
-       tag: v9.4.8
+       tag: v9.4.9
        commit: <full commit sha of the tag>
    ```
 

--- a/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
@@ -50,6 +50,7 @@
     <color type="primary" scheme_preference="dark">#1c1c60</color>
   </branding>
   <releases>
+    <release version="9.4.9" date="2026-07-31"/>
     <release version="9.4.8" date="2026-07-31"/>
     <release version="9.4.7" date="2026-07-31"/>
     <release version="9.4.6" date="2026-07-30"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.4.8"
+version = "9.4.9"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.4.8"
+ZX_NEXT_UNITE_VERSION = "9.4.9"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -639,7 +639,7 @@ def build_emulator_ops(
             f"Download (~{size_txt}) and install it into the downloads "
             f"folder?\nNote: the fully extracted install is large (~500 MB).")
         _attach_release_notes(box, release.get("notes"))
-        go = box.addButton("Download and install", QMessageBox.AcceptRole)
+        go = box.addButton(ui_tr_now("Download and install"), QMessageBox.AcceptRole)
         box.addButton("Cancel", QMessageBox.RejectRole)
         box.setDefaultButton(go)
         box.exec()
@@ -1038,7 +1038,7 @@ def build_emulator_ops(
         size_txt = f"{size / 1048576:.0f} MB" if size else "about 90 MB"
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
-        box.setWindowTitle("MAME update available")
+        box.setWindowTitle(ui_tr_now("MAME update available"))
         box.setText(
             "A newer version of MAME is available.\n\n"
             f"Installed: 0.{installed_num}\n"
@@ -1048,10 +1048,11 @@ def build_emulator_ops(
             "The existing files in the downloads MAME folder will be "
             "overwritten.")
         _attach_release_notes(box, info.get("notes"))
-        upd = box.addButton("Update", QMessageBox.AcceptRole)
+        upd = box.addButton(ui_tr_now("Update"), QMessageBox.AcceptRole)
         # Escape hatch to any other recent release — including an older one,
         # which is how the update path itself can be exercised again.
-        other = box.addButton("Choose another release…", QMessageBox.ActionRole)
+        other = box.addButton(
+            ui_tr_now("Choose another release…"), QMessageBox.ActionRole)
         box.addButton("Cancel", QMessageBox.RejectRole)
         box.setDefaultButton(upd)
         box.exec()
@@ -1206,7 +1207,7 @@ def build_emulator_ops(
             "choose Open." if is_app_bundle else "")
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
-        box.setWindowTitle("Update downloaded")
+        box.setWindowTitle(ui_tr_now("Update downloaded"))
         box.setText(
             "The new version was saved as:\n\n"
             f"{new_path}\n\n"
@@ -1214,7 +1215,7 @@ def build_emulator_ops(
             "Your settings (hdfg.cfg) and downloads are picked up as-is —\n"
             "both versions run from the same folder." + gatekeeper_note)
         yes = box.addButton(f"Close and start {name}", QMessageBox.AcceptRole)
-        box.addButton("Later", QMessageBox.RejectRole)
+        box.addButton(ui_tr_now("Later"), QMessageBox.RejectRole)
         box.setDefaultButton(yes)
         box.exec()
         if box.clickedButton() is not yes:
@@ -1367,7 +1368,7 @@ def build_emulator_ops(
                 "update with 'git pull' instead of the Windows binary.")
             box = QMessageBox(host)
             box.setIcon(QMessageBox.Information)
-            box.setWindowTitle("ZX Next Unite update available")
+            box.setWindowTitle(ui_tr_now("ZX Next Unite update available"))
             box.setText(
                 f"ZX Next Unite {tag} is available "
                 f"(you are running {ZX_NEXT_UNITE_VERSION}).\n\n"
@@ -1376,8 +1377,9 @@ def build_emulator_ops(
                 "    git pull\n\n"
                 "instead of downloading the Windows binary.")
             _attach_notes(box)
-            openrel = box.addButton("Open the releases page", QMessageBox.AcceptRole)
-            box.addButton("Close", QMessageBox.RejectRole)
+            openrel = box.addButton(
+                ui_tr_now("Open the releases page"), QMessageBox.AcceptRole)
+            box.addButton(ui_tr_now("Close"), QMessageBox.RejectRole)
             box.setDefaultButton(openrel)
             box.exec()
             if box.clickedButton() is openrel:
@@ -1402,7 +1404,7 @@ def build_emulator_ops(
         size_txt = f"{size / 1048576:.0f} MB" if size else "?"
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
-        box.setWindowTitle("ZX Next Unite update available")
+        box.setWindowTitle(ui_tr_now("ZX Next Unite update available"))
         box.setText(
             f"ZX Next Unite {tag} is available — download?\n\n"
             f"Installed: {ZX_NEXT_UNITE_VERSION}\n"
@@ -1646,14 +1648,14 @@ def build_emulator_ops(
         latest_name = info.get("version_name") or "a newer build"
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
-        box.setWindowTitle("CSpect update available")
+        box.setWindowTitle(ui_tr_now("CSpect update available"))
         box.setText(
             "A newer version of CSpect is available on itch.io.\n\n"
             f"Installed: {installed_name}\n"
             f"Latest: {latest_name}\n\n"
             "Download and install the newest version now?")
         _attach_release_notes(box, info.get("notes"))
-        yes = box.addButton("Yes", QMessageBox.AcceptRole)
+        yes = box.addButton(ui_tr_now("Yes"), QMessageBox.AcceptRole)
         box.addButton("Cancel", QMessageBox.RejectRole)
         box.setDefaultButton(yes)
         box.exec()
@@ -2061,7 +2063,7 @@ def build_hdfmonkey_install_ops(
         downloads_root = _hdfmonkey_downloads_root()
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Warning)
-        box.setWindowTitle("hdfmonkey download failed")
+        box.setWindowTitle(ui_tr_now("hdfmonkey download failed"))
         box.setText(
             "The automatic hdfmonkey download from specnext.com failed — the "
             "forum may be asking for a login or an anti-robot confirmation "
@@ -2159,7 +2161,7 @@ def build_hdfmonkey_install_ops(
         download, so the user can choose the fuller route instead."""
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Information)
-        box.setWindowTitle("Install hdfmonkey")
+        box.setWindowTitle(ui_tr_now("Install hdfmonkey"))
         box.setText(
             "TIP: Did you know that if you have purchased CSpect from "
             "itch.io you can do a full end-to-end CSpect install from "

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -316,19 +316,24 @@ def build_emulator_ops(
             except subprocess.CalledProcessError as ex:
                 if ex.returncode == 1:
                     logging.error("CSpect.exe is not present in the same local directory as zx-next-unite.Please install it from http://cspect.org")
-                    add_main_log_window("ERROR: CSpect.exe is not present in the same local directory as zx-next-unite.Please install it from http://cspect.org")
+                    add_main_log_window(ui_tr_now(
+                        "ERROR: CSpect.exe is not present in the same local "
+                        "directory as zx-next-unite. Please install it from "
+                        "http://cspect.org"))
                 else:
                     logging.error(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
                     add_main_log_window(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
 
                 if platform.system() != "Windows":
                     logging.error("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
-                    add_main_log_window("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
+                    add_main_log_window(ui_tr_now(
+                        "On MacOS and Linux mono is required as it runs under "
+                        "it. Please make sure mono is installed."))
                     if os.environ.get("FLATPAK_ID"):
-                        add_main_log_window(
+                        add_main_log_window(ui_tr_now(
                             "Running as a Flatpak: mono must be installed on "
                             "the HOST system — the launch is delegated there "
-                            "via flatpak-spawn.")
+                            "via flatpak-spawn."))
 
             set_all_buttons_enabled()
 
@@ -341,9 +346,9 @@ def build_emulator_ops(
         # missing) — otherwise MAME could never be launched without hdfmonkey.
         _sel_image = host.imageinput.currentText().strip().strip('"')
         if not (_sel_image and os.path.isfile(_sel_image)):
-            add_main_log_window(
+            add_main_log_window(ui_tr_now(
                 "Select a valid ZX Spectrum Next disk image (.img/.hdf) "
-                "before launching MAME.")
+                "before launching MAME."))
             return
 
         # Flatpak mode (Linux) launches `flatpak run org.mamedev.MAME …`
@@ -353,7 +358,8 @@ def build_emulator_ops(
         mame_path = getattr(host, "_mame_executable_path", None)
         if not _flatpak and not mame_path:
             logging.error("MAME executable not found on PATH. Cannot launch MAME.")
-            add_main_log_window("ERROR: MAME executable not found on PATH. Cannot launch MAME.")
+            add_main_log_window(ui_tr_now(
+                "ERROR: MAME executable not found on PATH. Cannot launch MAME."))
             return
 
         # Pull the (possibly user-customised) command line from the cfg file,
@@ -659,7 +665,7 @@ def build_emulator_ops(
                 "Windows (x64 / arm64).\n\nDownload the official binaries for "
                 "your system from:\nhttps://www.mamedev.org/release.html")
             return
-        add_main_log_window("Listing the available MAME releases…")
+        add_main_log_window(ui_tr_now("Listing the available MAME releases…"))
         try:
             releases = _fetch_mame_releases(arch)
         except Exception as e:
@@ -673,7 +679,8 @@ def build_emulator_ops(
             return
         chosen = _pick_mame_release(releases, title)
         if chosen is None:
-            add_main_log_window("MAME install ▸ release picker cancelled.")
+            add_main_log_window(ui_tr_now(
+                "MAME install ▸ release picker cancelled."))
             return
         _confirm_and_start_mame_install(chosen, arch, title)
 
@@ -851,9 +858,9 @@ def build_emulator_ops(
         # the detected path so the hint is right wherever the build unpacked.
         roms_dir = os.path.join(os.path.dirname(detected), "roms")
         add_main_log_window(f"MAME install ▸ SUCCESS — MAME detected at: {detected}")
-        add_main_log_window(
+        add_main_log_window(ui_tr_now(
             "MAME is ready to launch now — no restart needed. Use the "
-            "'🕹  Launch Mame' button.")
+            "'🕹  Launch Mame' button."))
         add_main_log_window(
             "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See "
             f"{MAME_INSTALL_WIKI_URL} → \"Get TBBLUE (the Next 'boot ROM')\". "
@@ -892,9 +899,9 @@ def build_emulator_ops(
                 host.button_install_mame.setText(ui_tr_now("⬇  Install MAME"))
             except RuntimeError:
                 pass
-            add_main_log_window(
+            add_main_log_window(ui_tr_now(
                 "MAME install ▸ FAILED — the download and extraction finished, "
-                "but no mame.exe could be found in downloads/mame.")
+                "but no mame.exe could be found in downloads/mame."))
             logging.error("MAME install: mame.exe not found after extraction.")
             try:
                 host._show_toast(
@@ -919,9 +926,9 @@ def build_emulator_ops(
         except RuntimeError:
             pass
         detail = err[1] if isinstance(err, (tuple, list)) and len(err) > 1 else err
-        add_main_log_window(
-            f"MAME install ▸ FAILED — {detail}. You can download it manually "
-            "from https://www.mamedev.org/release.html")
+        add_main_log_window(ui_tr_now(
+            "MAME install ▸ FAILED — {error}. You can download it manually "
+            "from https://www.mamedev.org/release.html").format(error=detail))
         logging.error(f"Failed to download/install MAME: {err}")
         try:
             QMessageBox.warning(
@@ -948,8 +955,9 @@ def build_emulator_ops(
             host.button_install_mame.setText("⬇  Installing MAME… 0%")
         except RuntimeError:
             pass
-        add_main_log_window(
-            f"MAME install ▸ Starting: {tag} ({asset_name}, ~{size_txt}).")
+        add_main_log_window(ui_tr_now(
+            "MAME install ▸ Starting: {tag} ({asset}, ~{size}).").format(
+                tag=tag, asset=asset_name, size=size_txt))
         # Channel for the worker's phase log lines + button percentage. It is
         # stored on self so it outlives this call: otherwise it would be
         # garbage-collected the moment we return, cancelling the queued emits
@@ -1049,13 +1057,13 @@ def build_emulator_ops(
         box.exec()
         clicked = box.clickedButton()
         if clicked is upd:
-            add_main_log_window(
-                f"MAME update ▸ user chose to update to {tag}.")
+            add_main_log_window(ui_tr_now(
+                "MAME update ▸ user chose to update to {tag}.").format(tag=tag))
             _start_mame_install(tag, asset_name, url, size, size_txt,
                                 sha256=info.get("sha256"))
         elif clicked is other:
-            add_main_log_window(
-                "MAME update ▸ user chose to pick a release manually.")
+            add_main_log_window(ui_tr_now(
+                "MAME update ▸ user chose to pick a release manually."))
             _choose_and_install_mame("Choose a MAME release")
 
     def _check_mame_update_async():
@@ -1111,14 +1119,14 @@ def build_emulator_ops(
                 installed_num = info.get("installed_num")
                 latest_num = info.get("latest_num")
                 if latest_num is None:
-                    add_main_log_window(
+                    add_main_log_window(ui_tr_now(
                         "MAME update check: could not determine the "
-                        "latest release; skipping.")
+                        "latest release; skipping."))
                     return
                 if installed_num is None:
-                    add_main_log_window(
+                    add_main_log_window(ui_tr_now(
                         "MAME update check: could not determine the installed "
-                        "MAME version; skipping.")
+                        "MAME version; skipping."))
                     return
                 if latest_num <= installed_num:
                     if info.get("patched"):
@@ -1139,9 +1147,9 @@ def build_emulator_ops(
         def _on_error(err):
             detail = err[1] if isinstance(err, (tuple, list)) and len(err) > 1 else err
             logging.info(f"MAME update check skipped: {detail}")
-            add_main_log_window(
+            add_main_log_window(ui_tr_now(
                 "MAME update check: could not reach the release site; "
-                "skipping.")
+                "skipping."))
 
         add_main_log_window(ui_tr_now("Checking for a newer MAME release…"))
         getit_run_in_thread(_job, _on_result, _on_error)
@@ -1319,7 +1327,8 @@ def build_emulator_ops(
                         f"ZX Next Unite update: unpacked to {runnable}")
                 _zxnu_offer_restart(runnable)
             elif holder["error"] == "cancelled":
-                add_main_log_window("ZX Next Unite update: download cancelled.")
+                add_main_log_window(ui_tr_now(
+                    "ZX Next Unite update: download cancelled."))
             elif os.path.isfile(dest):
                 # The package arrived but could not be unpacked — keep it
                 # so the user can extract it by hand.
@@ -1411,7 +1420,8 @@ def build_emulator_ops(
             _zxnu_download_update(tag, asset_name, url, size,
                                   expected_sha256=sha256)
         else:
-            add_main_log_window("ZX Next Unite update ▸ skipped by user.")
+            add_main_log_window(ui_tr_now(
+                "ZX Next Unite update ▸ skipped by user."))
 
     def _check_zxnu_update_async():
         """At startup, when the Settings toggle is on, look up this app's
@@ -1422,9 +1432,9 @@ def build_emulator_ops(
             # Sandboxed install: /app is read-only and updates arrive via
             # the Flatpak remote, so the in-app self-updater must stay out
             # of the way.
-            add_main_log_window(
+            add_main_log_window(ui_tr_now(
                 "ZX Next Unite update check: running as a Flatpak — "
-                "updates come from your software center, skipping.")
+                "updates come from your software center, skipping."))
             return
         pref = configuration_dictionary.get(
             SETTING_ZXNU_UPDATE_CHECK, "").strip().lower()
@@ -1460,9 +1470,9 @@ def build_emulator_ops(
         def _on_error(err):
             detail = err[1] if isinstance(err, (tuple, list)) and len(err) > 1 else err
             logging.info(f"ZXNU update check skipped: {detail}")
-            add_main_log_window(
+            add_main_log_window(ui_tr_now(
                 "ZX Next Unite update check: could not reach GitHub "
-                "(offline, or no release published yet); skipping.")
+                "(offline, or no release published yet); skipping."))
 
         add_main_log_window(ui_tr_now(
             "Checking for a newer ZX Next Unite release on GitHub…"))
@@ -1652,7 +1662,8 @@ def build_emulator_ops(
                 f"CSpect update ▸ user chose to update to {latest_name}.")
             _start_cspect_update_install(info)
         else:
-            add_main_log_window("CSpect update ▸ user cancelled the update.")
+            add_main_log_window(ui_tr_now(
+                "CSpect update ▸ user cancelled the update."))
 
     def _check_cspect_update_async():
         """At startup — once an itch.io API key is configured and the check is
@@ -1736,7 +1747,8 @@ def build_emulator_ops(
         def _on_error(err):
             detail = (err[1] if isinstance(err, (tuple, list)) and len(err) > 1
                       else err)
-            add_main_log_window(f"CSpect update check skipped: {detail}")
+            add_main_log_window(ui_tr_now(
+                "CSpect update check skipped: {reason}").format(reason=detail))
             logging.info(f"CSpect update check skipped: {detail}")
 
         add_main_log_window(ui_tr_now(

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,61 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        # ---- dialogs (message boxes) ----
+        "CSpect update available":
+            "Actualización de CSpect disponible",
+        "Choose another release…":
+            "Elegir otra versión…",
+        "Close":
+            "Cerrar",
+        "Download and install":
+            "Descargar e instalar",
+        "File or directory already exists locally.":
+            "El archivo o directorio ya existe localmente.",
+        "File or directory exists":
+            "El archivo o directorio ya existe",
+        "Ignore (always in this sync)":
+            "Ignorar (siempre en esta sincronización)",
+        "Ignore (one time)":
+            "Ignorar (una vez)",
+        "Install from .zip…":
+            "Instalar desde .zip…",
+        "Install hdfmonkey":
+            "Instalar hdfmonkey",
+        "Later":
+            "Más tarde",
+        "MAME update available":
+            "Actualización de MAME disponible",
+        "Open itch.io page":
+            "Abrir la página de itch.io",
+        "Open the releases page":
+            "Abrir la página de versiones",
+        "Overwrite local file (always in this sync)":
+            "Sobrescribir el archivo local (siempre en esta sincronización)",
+        "Overwrite local file (one time)":
+            "Sobrescribir el archivo local (una vez)",
+        "The automated download failed.":
+            "La descarga automática falló.",
+        "This is going to completely delete the files in {path} and its sub folders, so they will be unrecoverable.\n\nAre you sure want to continue?":
+            "Esto eliminará por completo los archivos de {path} y sus subcarpetas, de forma irrecuperable.\n\n¿Seguro que quieres continuar?",
+        "Tip: set a default for this in Settings → \"NextSync — when a sent file or directory exists locally\".":
+            "Consejo: define un valor predeterminado en Ajustes → \"NextSync — when a sent file or directory exists locally\".",
+        "Uninstall":
+            "Desinstalar",
+        "Update":
+            "Actualizar",
+        "Update downloaded":
+            "Actualización descargada",
+        "Yes":
+            "Sí",
+        "You can download it manually from the itch.io page in your browser, then install it from the downloaded .zip.":
+            "Puedes descargarlo manualmente desde la página de itch.io en tu navegador y luego instalarlo desde el .zip descargado.",
+        "ZX Next Unite update available":
+            "Actualización de ZX Next Unite disponible",
+        "hdfmonkey download failed":
+            "Falló la descarga de hdfmonkey",
+        "itch.io download":
+            "Descarga de itch.io",
         # ---- emulator install / update console ----
         "CSpect update check skipped: {reason}":
             "Comprobación de CSpect omitida: {reason}",
@@ -1045,6 +1100,61 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        # ---- dialogs (message boxes) ----
+        "CSpect update available":
+            "Atualização do CSpect disponível",
+        "Choose another release…":
+            "Escolher outra versão…",
+        "Close":
+            "Fechar",
+        "Download and install":
+            "Transferir e instalar",
+        "File or directory already exists locally.":
+            "O ficheiro ou diretório já existe localmente.",
+        "File or directory exists":
+            "O ficheiro ou diretório já existe",
+        "Ignore (always in this sync)":
+            "Ignorar (sempre nesta sincronização)",
+        "Ignore (one time)":
+            "Ignorar (uma vez)",
+        "Install from .zip…":
+            "Instalar a partir de .zip…",
+        "Install hdfmonkey":
+            "Instalar o hdfmonkey",
+        "Later":
+            "Mais tarde",
+        "MAME update available":
+            "Atualização do MAME disponível",
+        "Open itch.io page":
+            "Abrir a página do itch.io",
+        "Open the releases page":
+            "Abrir a página de versões",
+        "Overwrite local file (always in this sync)":
+            "Substituir o ficheiro local (sempre nesta sincronização)",
+        "Overwrite local file (one time)":
+            "Substituir o ficheiro local (uma vez)",
+        "The automated download failed.":
+            "A transferência automática falhou.",
+        "This is going to completely delete the files in {path} and its sub folders, so they will be unrecoverable.\n\nAre you sure want to continue?":
+            "Isto vai eliminar completamente os ficheiros em {path} e nas suas subpastas, de forma irrecuperável.\n\nTens a certeza de que queres continuar?",
+        "Tip: set a default for this in Settings → \"NextSync — when a sent file or directory exists locally\".":
+            "Dica: define um valor predefinido em Definições → \"NextSync — when a sent file or directory exists locally\".",
+        "Uninstall":
+            "Desinstalar",
+        "Update":
+            "Atualizar",
+        "Update downloaded":
+            "Atualização transferida",
+        "Yes":
+            "Sim",
+        "You can download it manually from the itch.io page in your browser, then install it from the downloaded .zip.":
+            "Podes transferi-lo manualmente a partir da página do itch.io no teu navegador e depois instalá-lo a partir do .zip transferido.",
+        "ZX Next Unite update available":
+            "Atualização do ZX Next Unite disponível",
+        "hdfmonkey download failed":
+            "Falhou a transferência do hdfmonkey",
+        "itch.io download":
+            "Transferência do itch.io",
         # ---- emulator install / update console ----
         "CSpect update check skipped: {reason}":
             "Verificação do CSpect ignorada: {reason}",
@@ -1671,6 +1781,61 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        # ---- dialogs (message boxes) ----
+        "CSpect update available":
+            "Dostępna aktualizacja CSpect",
+        "Choose another release…":
+            "Wybierz inną wersję…",
+        "Close":
+            "Zamknij",
+        "Download and install":
+            "Pobierz i zainstaluj",
+        "File or directory already exists locally.":
+            "Plik lub katalog już istnieje lokalnie.",
+        "File or directory exists":
+            "Plik lub katalog już istnieje",
+        "Ignore (always in this sync)":
+            "Pomiń (zawsze w tej synchronizacji)",
+        "Ignore (one time)":
+            "Pomiń (raz)",
+        "Install from .zip…":
+            "Zainstaluj z pliku .zip…",
+        "Install hdfmonkey":
+            "Zainstaluj hdfmonkey",
+        "Later":
+            "Później",
+        "MAME update available":
+            "Dostępna aktualizacja MAME",
+        "Open itch.io page":
+            "Otwórz stronę itch.io",
+        "Open the releases page":
+            "Otwórz stronę wydań",
+        "Overwrite local file (always in this sync)":
+            "Nadpisz plik lokalny (zawsze w tej synchronizacji)",
+        "Overwrite local file (one time)":
+            "Nadpisz plik lokalny (raz)",
+        "The automated download failed.":
+            "Automatyczne pobieranie nie powiodło się.",
+        "This is going to completely delete the files in {path} and its sub folders, so they will be unrecoverable.\n\nAre you sure want to continue?":
+            "Spowoduje to całkowite usunięcie plików w {path} i jego podfolderach — bez możliwości odzyskania.\n\nCzy na pewno chcesz kontynuować?",
+        "Tip: set a default for this in Settings → \"NextSync — when a sent file or directory exists locally\".":
+            "Wskazówka: ustaw domyślne zachowanie w Ustawieniach → \"NextSync — when a sent file or directory exists locally\".",
+        "Uninstall":
+            "Odinstaluj",
+        "Update":
+            "Aktualizuj",
+        "Update downloaded":
+            "Aktualizacja pobrana",
+        "Yes":
+            "Tak",
+        "You can download it manually from the itch.io page in your browser, then install it from the downloaded .zip.":
+            "Możesz pobrać go ręcznie ze strony itch.io w przeglądarce, a następnie zainstalować z pobranego pliku .zip.",
+        "ZX Next Unite update available":
+            "Dostępna aktualizacja ZX Next Unite",
+        "hdfmonkey download failed":
+            "Pobieranie hdfmonkey nie powiodło się",
+        "itch.io download":
+            "Pobieranie z itch.io",
         # ---- emulator install / update console ----
         "CSpect update check skipped: {reason}":
             "Pominięto sprawdzanie CSpect: {reason}",
@@ -2298,6 +2463,61 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        # ---- dialogs (message boxes) ----
+        "CSpect update available":
+            "Доступно обновление CSpect",
+        "Choose another release…":
+            "Выбрать другую версию…",
+        "Close":
+            "Закрыть",
+        "Download and install":
+            "Скачать и установить",
+        "File or directory already exists locally.":
+            "Файл или папка уже существует локально.",
+        "File or directory exists":
+            "Файл или папка уже существует",
+        "Ignore (always in this sync)":
+            "Пропускать (всегда в этой синхронизации)",
+        "Ignore (one time)":
+            "Пропустить (один раз)",
+        "Install from .zip…":
+            "Установить из .zip…",
+        "Install hdfmonkey":
+            "Установить hdfmonkey",
+        "Later":
+            "Позже",
+        "MAME update available":
+            "Доступно обновление MAME",
+        "Open itch.io page":
+            "Открыть страницу itch.io",
+        "Open the releases page":
+            "Открыть страницу релизов",
+        "Overwrite local file (always in this sync)":
+            "Перезаписывать локальный файл (всегда в этой синхронизации)",
+        "Overwrite local file (one time)":
+            "Перезаписать локальный файл (один раз)",
+        "The automated download failed.":
+            "Автоматическая загрузка не удалась.",
+        "This is going to completely delete the files in {path} and its sub folders, so they will be unrecoverable.\n\nAre you sure want to continue?":
+            "Это полностью удалит файлы в {path} и вложенных папках без возможности восстановления.\n\nПродолжить?",
+        "Tip: set a default for this in Settings → \"NextSync — when a sent file or directory exists locally\".":
+            "Совет: задайте поведение по умолчанию в Настройках → \"NextSync — when a sent file or directory exists locally\".",
+        "Uninstall":
+            "Удалить",
+        "Update":
+            "Обновить",
+        "Update downloaded":
+            "Обновление загружено",
+        "Yes":
+            "Да",
+        "You can download it manually from the itch.io page in your browser, then install it from the downloaded .zip.":
+            "Вы можете скачать его вручную со страницы itch.io в браузере, а затем установить из загруженного .zip.",
+        "ZX Next Unite update available":
+            "Доступно обновление ZX Next Unite",
+        "hdfmonkey download failed":
+            "Не удалось скачать hdfmonkey",
+        "itch.io download":
+            "Загрузка с itch.io",
         # ---- emulator install / update console ----
         "CSpect update check skipped: {reason}":
             "Проверка CSpect пропущена: {reason}",
@@ -2924,6 +3144,61 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        # ---- dialogs (message boxes) ----
+        "CSpect update available":
+            "K dispozici je aktualizace CSpectu",
+        "Choose another release…":
+            "Zvolit jinou verzi…",
+        "Close":
+            "Zavřít",
+        "Download and install":
+            "Stáhnout a nainstalovat",
+        "File or directory already exists locally.":
+            "Soubor nebo složka již místně existuje.",
+        "File or directory exists":
+            "Soubor nebo složka již existuje",
+        "Ignore (always in this sync)":
+            "Ignorovat (vždy při této synchronizaci)",
+        "Ignore (one time)":
+            "Ignorovat (jednorázově)",
+        "Install from .zip…":
+            "Instalovat ze .zip…",
+        "Install hdfmonkey":
+            "Nainstalovat hdfmonkey",
+        "Later":
+            "Později",
+        "MAME update available":
+            "K dispozici je aktualizace MAME",
+        "Open itch.io page":
+            "Otevřít stránku itch.io",
+        "Open the releases page":
+            "Otevřít stránku vydání",
+        "Overwrite local file (always in this sync)":
+            "Přepsat místní soubor (vždy při této synchronizaci)",
+        "Overwrite local file (one time)":
+            "Přepsat místní soubor (jednorázově)",
+        "The automated download failed.":
+            "Automatické stažení selhalo.",
+        "This is going to completely delete the files in {path} and its sub folders, so they will be unrecoverable.\n\nAre you sure want to continue?":
+            "Tímto se zcela smažou soubory v {path} a jeho podsložkách, bez možnosti obnovy.\n\nOpravdu chcete pokračovat?",
+        "Tip: set a default for this in Settings → \"NextSync — when a sent file or directory exists locally\".":
+            "Tip: výchozí chování nastavíte v Nastavení → \"NextSync — when a sent file or directory exists locally\".",
+        "Uninstall":
+            "Odinstalovat",
+        "Update":
+            "Aktualizovat",
+        "Update downloaded":
+            "Aktualizace stažena",
+        "Yes":
+            "Ano",
+        "You can download it manually from the itch.io page in your browser, then install it from the downloaded .zip.":
+            "Můžete jej stáhnout ručně ze stránky itch.io v prohlížeči a poté nainstalovat ze staženého .zip.",
+        "ZX Next Unite update available":
+            "K dispozici je aktualizace ZX Next Unite",
+        "hdfmonkey download failed":
+            "Stažení hdfmonkey selhalo",
+        "itch.io download":
+            "Stahování z itch.io",
         # ---- emulator install / update console ----
         "CSpect update check skipped: {reason}":
             "Kontrola CSpectu přeskočena: {reason}",
@@ -3553,6 +3828,61 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        # ---- dialogs (message boxes) ----
+        "CSpect update available":
+            "Mise à jour de CSpect disponible",
+        "Choose another release…":
+            "Choisir une autre version…",
+        "Close":
+            "Fermer",
+        "Download and install":
+            "Télécharger et installer",
+        "File or directory already exists locally.":
+            "Le fichier ou dossier existe déjà en local.",
+        "File or directory exists":
+            "Le fichier ou dossier existe",
+        "Ignore (always in this sync)":
+            "Ignorer (toujours dans cette synchronisation)",
+        "Ignore (one time)":
+            "Ignorer (une fois)",
+        "Install from .zip…":
+            "Installer depuis un .zip…",
+        "Install hdfmonkey":
+            "Installer hdfmonkey",
+        "Later":
+            "Plus tard",
+        "MAME update available":
+            "Mise à jour de MAME disponible",
+        "Open itch.io page":
+            "Ouvrir la page itch.io",
+        "Open the releases page":
+            "Ouvrir la page des versions",
+        "Overwrite local file (always in this sync)":
+            "Écraser le fichier local (toujours dans cette synchronisation)",
+        "Overwrite local file (one time)":
+            "Écraser le fichier local (une fois)",
+        "The automated download failed.":
+            "Le téléchargement automatique a échoué.",
+        "This is going to completely delete the files in {path} and its sub folders, so they will be unrecoverable.\n\nAre you sure want to continue?":
+            "Cela va supprimer définitivement les fichiers de {path} et de ses sous-dossiers, sans récupération possible.\n\nVoulez-vous vraiment continuer ?",
+        "Tip: set a default for this in Settings → \"NextSync — when a sent file or directory exists locally\".":
+            "Astuce : définissez une valeur par défaut dans Réglages → \"NextSync — when a sent file or directory exists locally\".",
+        "Uninstall":
+            "Désinstaller",
+        "Update":
+            "Mettre à jour",
+        "Update downloaded":
+            "Mise à jour téléchargée",
+        "Yes":
+            "Oui",
+        "You can download it manually from the itch.io page in your browser, then install it from the downloaded .zip.":
+            "Vous pouvez le télécharger manuellement depuis la page itch.io dans votre navigateur, puis l'installer depuis le .zip téléchargé.",
+        "ZX Next Unite update available":
+            "Mise à jour de ZX Next Unite disponible",
+        "hdfmonkey download failed":
+            "Échec du téléchargement de hdfmonkey",
+        "itch.io download":
+            "Téléchargement itch.io",
         # ---- emulator install / update console ----
         "CSpect update check skipped: {reason}":
             "Vérification de CSpect ignorée : {reason}",

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,71 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        # ---- SD Card tab: console + dialogs ----
+        "Confirm Deletion":
+            "Confirmar eliminación",
+        "Create":
+            "Crear",
+        "Create New Folder":
+            "Crear carpeta nueva",
+        "Created {name} in {folder} on the image ({count} file(s), {bytes} bytes).":
+            "Creado {name} en {folder} en la imagen ({count} archivo(s), {bytes} bytes).",
+        "Delete files from the image to free space, or switch to a larger image.\nLarger SD card images can be downloaded from:":
+            "Elimina archivos de la imagen para liberar espacio, o cambia a una imagen más grande.\nPuedes descargar imágenes de tarjeta SD más grandes desde:",
+        "Download":
+            "Descargar",
+        "Download failed: no valid destination folder.":
+            "Error de descarga: no hay una carpeta de destino válida.",
+        "Downloading {name} from {url}":
+            "Descargando {name} desde {url}",
+        "ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.":
+            "ERROR: no se encontró hdfmonkey. Usa el botón 'Download and install HDF Monkey' (abajo a la derecha de la pestaña SD Card) para instalarlo automáticamente, o haz una instalación completa de CSpect desde la pestaña itch.io, que también incluye hdfmonkey. También se puede instalar manualmente desde https://github.com/gasman/hdfmonkey — reinicia la aplicación una vez instalado.",
+        "Extracted disk image: {path}":
+            "Imagen de disco extraída: {path}",
+        "Extracted {count} file(s) from {name} into {folder} on the image.":
+            "Extraído(s) {count} archivo(s) de {name} en {folder} en la imagen.",
+        "Failed downloading NextZXOS image: {error}":
+            "Error al descargar la imagen NextZXOS: {error}",
+        "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
+            "Error al ejecutar hdfmonkey; asegúrate de que está instalado en el mismo directorio local que zx-next-unite.",
+        "Failed extracting NextZXOS image: {error}":
+            "Error al extraer la imagen NextZXOS: {error}",
+        "Failed loading image: {path}.":
+            "Error al cargar la imagen: {path}.",
+        "No SD-card disk image selected — pick or create a .img/.hdf at the top of this tab to unlock the emulator Launch buttons.":
+            "No hay ninguna imagen de tarjeta SD seleccionada: elige o crea un .img/.hdf en la parte superior de esta pestaña para desbloquear los botones de inicio del emulador.",
+        "Nothing to move: items are already in this folder.":
+            "Nada que mover: los elementos ya están en esta carpeta.",
+        "Only {free} MB free out of {total} MB ({used} % used, {pct} % free).":
+            "Solo {free} MB libres de {total} MB ({used} % usado, {pct} % libre).",
+        "Please load an image file first !":
+            "¡Carga primero un archivo de imagen!",
+        "Please load an image first!":
+            "¡Carga primero una imagen!",
+        "Please select an image file or folder first to delete!":
+            "¡Selecciona primero un archivo o carpeta de la imagen para eliminar!",
+        "Please select an image file or folder first to rename!":
+            "¡Selecciona primero un archivo o carpeta de la imagen para renombrar!",
+        "Remote unzip cancelled — the image is unchanged.":
+            "Descompresión remota cancelada: la imagen no se ha modificado.",
+        "Remote unzip: download from the image failed or was cancelled — the image is unchanged.":
+            "Descompresión remota: la descarga desde la imagen falló o se canceló; la imagen no se ha modificado.",
+        "Remote unzip: upload into the image failed or was cancelled.":
+            "Descompresión remota: la subida a la imagen falló o se canceló.",
+        "Remote zip cancelled — no zip was created.":
+            "Compresión remota cancelada: no se creó ningún zip.",
+        "Remote zip: download from the image failed or was cancelled — no zip was created.":
+            "Compresión remota: la descarga desde la imagen falló o se canceló; no se creó ningún zip.",
+        "Remote zip: upload into the image failed or was cancelled.":
+            "Compresión remota: la subida a la imagen falló o se canceló.",
+        "SD Image Nearly Full":
+            "Imagen SD casi llena",
+        "The SD card image is nearly full.":
+            "La imagen de la tarjeta SD está casi llena.",
+        "The hdfmonkey provided by the CSpect itch.io package is not executable. Make it executable by running:":
+            "El hdfmonkey incluido en el paquete de CSpect de itch.io no es ejecutable. Hazlo ejecutable ejecutando:",
+        "The image is completely full ({total} MB capacity, 0 MB free).":
+            "La imagen está completamente llena (capacidad {total} MB, 0 MB libres).",
         # ---- SD Card console: banner, detection, update checks ----
         "CSpect - by Mike Dailly http://cspect.org":
             "CSpect - por Mike Dailly http://cspect.org",
@@ -935,6 +1000,71 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        # ---- SD Card tab: console + dialogs ----
+        "Confirm Deletion":
+            "Confirmar eliminação",
+        "Create":
+            "Criar",
+        "Create New Folder":
+            "Criar nova pasta",
+        "Created {name} in {folder} on the image ({count} file(s), {bytes} bytes).":
+            "Criado {name} em {folder} na imagem ({count} ficheiro(s), {bytes} bytes).",
+        "Delete files from the image to free space, or switch to a larger image.\nLarger SD card images can be downloaded from:":
+            "Elimina ficheiros da imagem para libertar espaço, ou muda para uma imagem maior.\nPodes transferir imagens de cartão SD maiores a partir de:",
+        "Download":
+            "Transferir",
+        "Download failed: no valid destination folder.":
+            "Falha na transferência: não há pasta de destino válida.",
+        "Downloading {name} from {url}":
+            "A transferir {name} de {url}",
+        "ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.":
+            "ERRO: o hdfmonkey não foi encontrado. Usa o botão 'Download and install HDF Monkey' (canto inferior direito do separador SD Card) para o instalar automaticamente, ou faz uma instalação completa do CSpect a partir do separador itch.io, que também inclui o hdfmonkey. Também pode ser instalado manualmente a partir de https://github.com/gasman/hdfmonkey — reinicia a aplicação depois de instalado.",
+        "Extracted disk image: {path}":
+            "Imagem de disco extraída: {path}",
+        "Extracted {count} file(s) from {name} into {folder} on the image.":
+            "Extraído(s) {count} ficheiro(s) de {name} para {folder} na imagem.",
+        "Failed downloading NextZXOS image: {error}":
+            "Falha ao transferir a imagem NextZXOS: {error}",
+        "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
+            "Falha ao executar o hdfmonkey; certifica-te de que está instalado na mesma pasta local que o zx-next-unite.",
+        "Failed extracting NextZXOS image: {error}":
+            "Falha ao extrair a imagem NextZXOS: {error}",
+        "Failed loading image: {path}.":
+            "Falha ao carregar a imagem: {path}.",
+        "No SD-card disk image selected — pick or create a .img/.hdf at the top of this tab to unlock the emulator Launch buttons.":
+            "Nenhuma imagem de cartão SD selecionada: escolhe ou cria um .img/.hdf no topo deste separador para desbloquear os botões de arranque do emulador.",
+        "Nothing to move: items are already in this folder.":
+            "Nada para mover: os itens já estão nesta pasta.",
+        "Only {free} MB free out of {total} MB ({used} % used, {pct} % free).":
+            "Apenas {free} MB livres de {total} MB ({used} % usado, {pct} % livre).",
+        "Please load an image file first !":
+            "Carrega primeiro um ficheiro de imagem!",
+        "Please load an image first!":
+            "Carrega primeiro uma imagem!",
+        "Please select an image file or folder first to delete!":
+            "Seleciona primeiro um ficheiro ou pasta da imagem para eliminar!",
+        "Please select an image file or folder first to rename!":
+            "Seleciona primeiro um ficheiro ou pasta da imagem para renomear!",
+        "Remote unzip cancelled — the image is unchanged.":
+            "Descompressão remota cancelada: a imagem não foi alterada.",
+        "Remote unzip: download from the image failed or was cancelled — the image is unchanged.":
+            "Descompressão remota: a transferência a partir da imagem falhou ou foi cancelada; a imagem não foi alterada.",
+        "Remote unzip: upload into the image failed or was cancelled.":
+            "Descompressão remota: o envio para a imagem falhou ou foi cancelado.",
+        "Remote zip cancelled — no zip was created.":
+            "Compressão remota cancelada: não foi criado nenhum zip.",
+        "Remote zip: download from the image failed or was cancelled — no zip was created.":
+            "Compressão remota: a transferência a partir da imagem falhou ou foi cancelada; não foi criado nenhum zip.",
+        "Remote zip: upload into the image failed or was cancelled.":
+            "Compressão remota: o envio para a imagem falhou ou foi cancelado.",
+        "SD Image Nearly Full":
+            "Imagem SD quase cheia",
+        "The SD card image is nearly full.":
+            "A imagem do cartão SD está quase cheia.",
+        "The hdfmonkey provided by the CSpect itch.io package is not executable. Make it executable by running:":
+            "O hdfmonkey incluído no pacote CSpect do itch.io não é executável. Torna-o executável executando:",
+        "The image is completely full ({total} MB capacity, 0 MB free).":
+            "A imagem está completamente cheia (capacidade {total} MB, 0 MB livres).",
         # ---- SD Card console: banner, detection, update checks ----
         "CSpect - by Mike Dailly http://cspect.org":
             "CSpect - por Mike Dailly http://cspect.org",
@@ -1451,6 +1581,71 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        # ---- SD Card tab: console + dialogs ----
+        "Confirm Deletion":
+            "Potwierdź usunięcie",
+        "Create":
+            "Utwórz",
+        "Create New Folder":
+            "Utwórz nowy folder",
+        "Created {name} in {folder} on the image ({count} file(s), {bytes} bytes).":
+            "Utworzono {name} w {folder} na obrazie ({count} plik(ów), {bytes} bajtów).",
+        "Delete files from the image to free space, or switch to a larger image.\nLarger SD card images can be downloaded from:":
+            "Usuń pliki z obrazu, aby zwolnić miejsce, lub przełącz się na większy obraz.\nWiększe obrazy kart SD można pobrać z:",
+        "Download":
+            "Pobierz",
+        "Download failed: no valid destination folder.":
+            "Pobieranie nie powiodło się: brak prawidłowego folderu docelowego.",
+        "Downloading {name} from {url}":
+            "Pobieranie {name} z {url}",
+        "ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.":
+            "BŁĄD: nie znaleziono hdfmonkey. Użyj przycisku 'Download and install HDF Monkey' (prawy dolny róg karty SD Card), aby zainstalować go automatycznie, albo wykonaj pełną instalację CSpect z karty itch.io, która również zawiera hdfmonkey. Można go też zainstalować ręcznie z https://github.com/gasman/hdfmonkey — po instalacji uruchom aplikację ponownie.",
+        "Extracted disk image: {path}":
+            "Wypakowano obraz dysku: {path}",
+        "Extracted {count} file(s) from {name} into {folder} on the image.":
+            "Wypakowano {count} plik(ów) z {name} do {folder} na obrazie.",
+        "Failed downloading NextZXOS image: {error}":
+            "Nie udało się pobrać obrazu NextZXOS: {error}",
+        "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
+            "Nie udało się uruchomić hdfmonkey — upewnij się, że jest zainstalowany w tym samym katalogu co zx-next-unite.",
+        "Failed extracting NextZXOS image: {error}":
+            "Nie udało się wypakować obrazu NextZXOS: {error}",
+        "Failed loading image: {path}.":
+            "Nie udało się wczytać obrazu: {path}.",
+        "No SD-card disk image selected — pick or create a .img/.hdf at the top of this tab to unlock the emulator Launch buttons.":
+            "Nie wybrano obrazu karty SD — wybierz lub utwórz plik .img/.hdf u góry tej karty, aby odblokować przyciski uruchamiania emulatora.",
+        "Nothing to move: items are already in this folder.":
+            "Nie ma czego przenosić: elementy są już w tym folderze.",
+        "Only {free} MB free out of {total} MB ({used} % used, {pct} % free).":
+            "Tylko {free} MB wolnych z {total} MB ({used} % zajęte, {pct} % wolne).",
+        "Please load an image file first !":
+            "Najpierw wczytaj plik obrazu!",
+        "Please load an image first!":
+            "Najpierw wczytaj obraz!",
+        "Please select an image file or folder first to delete!":
+            "Najpierw wybierz plik lub folder obrazu do usunięcia!",
+        "Please select an image file or folder first to rename!":
+            "Najpierw wybierz plik lub folder obrazu do zmiany nazwy!",
+        "Remote unzip cancelled — the image is unchanged.":
+            "Zdalne rozpakowanie anulowane — obraz bez zmian.",
+        "Remote unzip: download from the image failed or was cancelled — the image is unchanged.":
+            "Zdalne rozpakowanie: pobieranie z obrazu nie powiodło się lub zostało anulowane — obraz bez zmian.",
+        "Remote unzip: upload into the image failed or was cancelled.":
+            "Zdalne rozpakowanie: wysyłanie do obrazu nie powiodło się lub zostało anulowane.",
+        "Remote zip cancelled — no zip was created.":
+            "Zdalne pakowanie anulowane — nie utworzono pliku zip.",
+        "Remote zip: download from the image failed or was cancelled — no zip was created.":
+            "Zdalne pakowanie: pobieranie z obrazu nie powiodło się lub zostało anulowane — nie utworzono pliku zip.",
+        "Remote zip: upload into the image failed or was cancelled.":
+            "Zdalne pakowanie: wysyłanie do obrazu nie powiodło się lub zostało anulowane.",
+        "SD Image Nearly Full":
+            "Obraz SD prawie pełny",
+        "The SD card image is nearly full.":
+            "Obraz karty SD jest prawie pełny.",
+        "The hdfmonkey provided by the CSpect itch.io package is not executable. Make it executable by running:":
+            "hdfmonkey dołączony do pakietu CSpect z itch.io nie jest wykonywalny. Nadaj mu prawo wykonywania poleceniem:",
+        "The image is completely full ({total} MB capacity, 0 MB free).":
+            "Obraz jest całkowicie pełny (pojemność {total} MB, 0 MB wolnych).",
         # ---- SD Card console: banner, detection, update checks ----
         "CSpect - by Mike Dailly http://cspect.org":
             "CSpect - autor: Mike Dailly http://cspect.org",
@@ -1968,6 +2163,71 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        # ---- SD Card tab: console + dialogs ----
+        "Confirm Deletion":
+            "Подтвердите удаление",
+        "Create":
+            "Создать",
+        "Create New Folder":
+            "Создать новую папку",
+        "Created {name} in {folder} on the image ({count} file(s), {bytes} bytes).":
+            "Создан {name} в {folder} на образе ({count} файл(ов), {bytes} байт).",
+        "Delete files from the image to free space, or switch to a larger image.\nLarger SD card images can be downloaded from:":
+            "Удалите файлы из образа, чтобы освободить место, или выберите образ большего размера.\nОбразы SD-карт большего размера можно скачать здесь:",
+        "Download":
+            "Скачать",
+        "Download failed: no valid destination folder.":
+            "Загрузка не удалась: нет допустимой папки назначения.",
+        "Downloading {name} from {url}":
+            "Загрузка {name} с {url}",
+        "ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.":
+            "ОШИБКА: hdfmonkey не найден. Нажмите кнопку 'Download and install HDF Monkey' (внизу справа на вкладке SD Card), чтобы установить его автоматически, или выполните полную установку CSpect со вкладки itch.io — она также включает hdfmonkey. Его можно установить и вручную с https://github.com/gasman/hdfmonkey — после установки перезапустите приложение.",
+        "Extracted disk image: {path}":
+            "Образ диска распакован: {path}",
+        "Extracted {count} file(s) from {name} into {folder} on the image.":
+            "Извлечено файлов: {count} из {name} в {folder} на образе.",
+        "Failed downloading NextZXOS image: {error}":
+            "Не удалось скачать образ NextZXOS: {error}",
+        "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
+            "Не удалось запустить hdfmonkey — убедитесь, что он установлен в том же каталоге, что и zx-next-unite.",
+        "Failed extracting NextZXOS image: {error}":
+            "Не удалось распаковать образ NextZXOS: {error}",
+        "Failed loading image: {path}.":
+            "Не удалось загрузить образ: {path}.",
+        "No SD-card disk image selected — pick or create a .img/.hdf at the top of this tab to unlock the emulator Launch buttons.":
+            "Образ SD-карты не выбран — выберите или создайте .img/.hdf вверху этой вкладки, чтобы разблокировать кнопки запуска эмулятора.",
+        "Nothing to move: items are already in this folder.":
+            "Нечего перемещать: элементы уже в этой папке.",
+        "Only {free} MB free out of {total} MB ({used} % used, {pct} % free).":
+            "Свободно всего {free} МБ из {total} МБ ({used} % занято, {pct} % свободно).",
+        "Please load an image file first !":
+            "Сначала загрузите файл образа!",
+        "Please load an image first!":
+            "Сначала загрузите образ!",
+        "Please select an image file or folder first to delete!":
+            "Сначала выберите файл или папку образа для удаления!",
+        "Please select an image file or folder first to rename!":
+            "Сначала выберите файл или папку образа для переименования!",
+        "Remote unzip cancelled — the image is unchanged.":
+            "Удалённая распаковка отменена — образ не изменён.",
+        "Remote unzip: download from the image failed or was cancelled — the image is unchanged.":
+            "Удалённая распаковка: загрузка из образа не удалась или была отменена — образ не изменён.",
+        "Remote unzip: upload into the image failed or was cancelled.":
+            "Удалённая распаковка: запись в образ не удалась или была отменена.",
+        "Remote zip cancelled — no zip was created.":
+            "Удалённая упаковка отменена — zip не создан.",
+        "Remote zip: download from the image failed or was cancelled — no zip was created.":
+            "Удалённая упаковка: загрузка из образа не удалась или была отменена — zip не создан.",
+        "Remote zip: upload into the image failed or was cancelled.":
+            "Удалённая упаковка: запись в образ не удалась или была отменена.",
+        "SD Image Nearly Full":
+            "Образ SD почти заполнен",
+        "The SD card image is nearly full.":
+            "Образ SD-карты почти заполнен.",
+        "The hdfmonkey provided by the CSpect itch.io package is not executable. Make it executable by running:":
+            "hdfmonkey из пакета CSpect с itch.io не является исполняемым. Сделайте его исполняемым командой:",
+        "The image is completely full ({total} MB capacity, 0 MB free).":
+            "Образ полностью заполнен (объём {total} МБ, свободно 0 МБ).",
         # ---- SD Card console: banner, detection, update checks ----
         "CSpect - by Mike Dailly http://cspect.org":
             "CSpect - автор: Mike Dailly http://cspect.org",
@@ -2484,6 +2744,71 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        # ---- SD Card tab: console + dialogs ----
+        "Confirm Deletion":
+            "Potvrdit smazání",
+        "Create":
+            "Vytvořit",
+        "Create New Folder":
+            "Vytvořit novou složku",
+        "Created {name} in {folder} on the image ({count} file(s), {bytes} bytes).":
+            "Vytvořeno {name} v {folder} na obrazu ({count} souborů, {bytes} bajtů).",
+        "Delete files from the image to free space, or switch to a larger image.\nLarger SD card images can be downloaded from:":
+            "Smažte soubory z obrazu pro uvolnění místa, nebo přejděte na větší obraz.\nVětší obrazy SD karet lze stáhnout z:",
+        "Download":
+            "Stáhnout",
+        "Download failed: no valid destination folder.":
+            "Stahování selhalo: chybí platná cílová složka.",
+        "Downloading {name} from {url}":
+            "Stahuje se {name} z {url}",
+        "ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.":
+            "CHYBA: hdfmonkey nebyl nalezen. Použijte tlačítko 'Download and install HDF Monkey' (vpravo dole na kartě SD Card) pro automatickou instalaci, nebo proveďte plnou instalaci CSpectu z karty itch.io, která hdfmonkey rovněž obsahuje. Lze jej nainstalovat i ručně z https://github.com/gasman/hdfmonkey — po instalaci aplikaci restartujte.",
+        "Extracted disk image: {path}":
+            "Obraz disku rozbalen: {path}",
+        "Extracted {count} file(s) from {name} into {folder} on the image.":
+            "Rozbaleno {count} souborů z {name} do {folder} na obrazu.",
+        "Failed downloading NextZXOS image: {error}":
+            "Nepodařilo se stáhnout obraz NextZXOS: {error}",
+        "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
+            "Nepodařilo se spustit hdfmonkey — ujistěte se, že je nainstalován ve stejném adresáři jako zx-next-unite.",
+        "Failed extracting NextZXOS image: {error}":
+            "Nepodařilo se rozbalit obraz NextZXOS: {error}",
+        "Failed loading image: {path}.":
+            "Nepodařilo se načíst obraz: {path}.",
+        "No SD-card disk image selected — pick or create a .img/.hdf at the top of this tab to unlock the emulator Launch buttons.":
+            "Není vybrán žádný obraz SD karty — nahoře na této kartě zvolte nebo vytvořte .img/.hdf, aby se odemkla tlačítka pro spuštění emulátoru.",
+        "Nothing to move: items are already in this folder.":
+            "Není co přesouvat: položky už v této složce jsou.",
+        "Only {free} MB free out of {total} MB ({used} % used, {pct} % free).":
+            "Volných jen {free} MB z {total} MB ({used} % využito, {pct} % volných).",
+        "Please load an image file first !":
+            "Nejprve načtěte soubor obrazu!",
+        "Please load an image first!":
+            "Nejprve načtěte obraz!",
+        "Please select an image file or folder first to delete!":
+            "Nejprve vyberte soubor nebo složku obrazu ke smazání!",
+        "Please select an image file or folder first to rename!":
+            "Nejprve vyberte soubor nebo složku obrazu k přejmenování!",
+        "Remote unzip cancelled — the image is unchanged.":
+            "Vzdálené rozbalení zrušeno — obraz je beze změny.",
+        "Remote unzip: download from the image failed or was cancelled — the image is unchanged.":
+            "Vzdálené rozbalení: stahování z obrazu selhalo nebo bylo zrušeno — obraz je beze změny.",
+        "Remote unzip: upload into the image failed or was cancelled.":
+            "Vzdálené rozbalení: nahrání do obrazu selhalo nebo bylo zrušeno.",
+        "Remote zip cancelled — no zip was created.":
+            "Vzdálené zabalení zrušeno — žádný zip nebyl vytvořen.",
+        "Remote zip: download from the image failed or was cancelled — no zip was created.":
+            "Vzdálené zabalení: stahování z obrazu selhalo nebo bylo zrušeno — žádný zip nebyl vytvořen.",
+        "Remote zip: upload into the image failed or was cancelled.":
+            "Vzdálené zabalení: nahrání do obrazu selhalo nebo bylo zrušeno.",
+        "SD Image Nearly Full":
+            "Obraz SD je téměř plný",
+        "The SD card image is nearly full.":
+            "Obraz SD karty je téměř plný.",
+        "The hdfmonkey provided by the CSpect itch.io package is not executable. Make it executable by running:":
+            "hdfmonkey dodaný v balíčku CSpect z itch.io není spustitelný. Nastavte mu právo spouštění příkazem:",
+        "The image is completely full ({total} MB capacity, 0 MB free).":
+            "Obraz je zcela plný (kapacita {total} MB, 0 MB volných).",
         # ---- SD Card console: banner, detection, update checks ----
         "CSpect - by Mike Dailly http://cspect.org":
             "CSpect - autor: Mike Dailly http://cspect.org",
@@ -3003,6 +3328,71 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        # ---- SD Card tab: console + dialogs ----
+        "Confirm Deletion":
+            "Confirmer la suppression",
+        "Create":
+            "Créer",
+        "Create New Folder":
+            "Créer un nouveau dossier",
+        "Created {name} in {folder} on the image ({count} file(s), {bytes} bytes).":
+            "{name} créé dans {folder} sur l'image ({count} fichier(s), {bytes} octets).",
+        "Delete files from the image to free space, or switch to a larger image.\nLarger SD card images can be downloaded from:":
+            "Supprimez des fichiers de l'image pour libérer de l'espace, ou passez à une image plus grande.\nDes images de carte SD plus grandes peuvent être téléchargées depuis :",
+        "Download":
+            "Télécharger",
+        "Download failed: no valid destination folder.":
+            "Échec du téléchargement : aucun dossier de destination valide.",
+        "Downloading {name} from {url}":
+            "Téléchargement de {name} depuis {url}",
+        "ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.":
+            "ERREUR : hdfmonkey est introuvable. Utilisez le bouton 'Download and install HDF Monkey' (en bas à droite de l'onglet SD Card) pour l'installer automatiquement, ou faites une installation complète de CSpect depuis l'onglet itch.io, qui inclut aussi hdfmonkey. Il peut également être installé manuellement depuis https://github.com/gasman/hdfmonkey — redémarrez l'application une fois installé.",
+        "Extracted disk image: {path}":
+            "Image disque extraite : {path}",
+        "Extracted {count} file(s) from {name} into {folder} on the image.":
+            "{count} fichier(s) extrait(s) de {name} vers {folder} sur l'image.",
+        "Failed downloading NextZXOS image: {error}":
+            "Échec du téléchargement de l'image NextZXOS : {error}",
+        "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
+            "Échec de l'exécution de hdfmonkey ; vérifiez qu'il est installé dans le même dossier local que zx-next-unite.",
+        "Failed extracting NextZXOS image: {error}":
+            "Échec de l'extraction de l'image NextZXOS : {error}",
+        "Failed loading image: {path}.":
+            "Échec du chargement de l'image : {path}.",
+        "No SD-card disk image selected — pick or create a .img/.hdf at the top of this tab to unlock the emulator Launch buttons.":
+            "Aucune image de carte SD sélectionnée — choisissez ou créez un .img/.hdf en haut de cet onglet pour débloquer les boutons de lancement de l'émulateur.",
+        "Nothing to move: items are already in this folder.":
+            "Rien à déplacer : les éléments sont déjà dans ce dossier.",
+        "Only {free} MB free out of {total} MB ({used} % used, {pct} % free).":
+            "Seulement {free} Mo libres sur {total} Mo ({used} % utilisé, {pct} % libre).",
+        "Please load an image file first !":
+            "Chargez d'abord un fichier image !",
+        "Please load an image first!":
+            "Chargez d'abord une image !",
+        "Please select an image file or folder first to delete!":
+            "Sélectionnez d'abord un fichier ou dossier de l'image à supprimer !",
+        "Please select an image file or folder first to rename!":
+            "Sélectionnez d'abord un fichier ou dossier de l'image à renommer !",
+        "Remote unzip cancelled — the image is unchanged.":
+            "Décompression distante annulée — l'image est inchangée.",
+        "Remote unzip: download from the image failed or was cancelled — the image is unchanged.":
+            "Décompression distante : le téléchargement depuis l'image a échoué ou a été annulé — l'image est inchangée.",
+        "Remote unzip: upload into the image failed or was cancelled.":
+            "Décompression distante : l'envoi vers l'image a échoué ou a été annulé.",
+        "Remote zip cancelled — no zip was created.":
+            "Compression distante annulée — aucun zip n'a été créé.",
+        "Remote zip: download from the image failed or was cancelled — no zip was created.":
+            "Compression distante : le téléchargement depuis l'image a échoué ou a été annulé — aucun zip n'a été créé.",
+        "Remote zip: upload into the image failed or was cancelled.":
+            "Compression distante : l'envoi vers l'image a échoué ou a été annulé.",
+        "SD Image Nearly Full":
+            "Image SD presque pleine",
+        "The SD card image is nearly full.":
+            "L'image de la carte SD est presque pleine.",
+        "The hdfmonkey provided by the CSpect itch.io package is not executable. Make it executable by running:":
+            "Le hdfmonkey fourni par le paquet CSpect d'itch.io n'est pas exécutable. Rendez-le exécutable en lançant :",
+        "The image is completely full ({total} MB capacity, 0 MB free).":
+            "L'image est totalement pleine (capacité {total} Mo, 0 Mo libre).",
         # ---- SD Card console: banner, detection, update checks ----
         "CSpect - by Mike Dailly http://cspect.org":
             "CSpect - par Mike Dailly http://cspect.org",

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,51 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        # ---- emulator install / update console ----
+        "CSpect update check skipped: {reason}":
+            "Comprobación de CSpect omitida: {reason}",
+        "CSpect update ▸ user cancelled the update.":
+            "Actualización de CSpect ▸ el usuario canceló la actualización.",
+        "ERROR: CSpect.exe is not present in the same local directory as zx-next-unite. Please install it from http://cspect.org":
+            "ERROR: CSpect.exe no está en el mismo directorio local que zx-next-unite. Instálalo desde http://cspect.org",
+        "ERROR: MAME executable not found on PATH. Cannot launch MAME.":
+            "ERROR: no se encontró el ejecutable de MAME en el PATH. No se puede iniciar MAME.",
+        "Listing the available MAME releases…":
+            "Listando las versiones de MAME disponibles…",
+        "MAME install ▸ FAILED — the download and extraction finished, but no mame.exe could be found in downloads/mame.":
+            "Instalación de MAME ▸ FALLÓ — la descarga y extracción terminaron, pero no se encontró mame.exe en downloads/mame.",
+        "MAME install ▸ FAILED — {error}. You can download it manually from https://www.mamedev.org/release.html":
+            "Instalación de MAME ▸ FALLÓ — {error}. Puedes descargarlo manualmente desde https://www.mamedev.org/release.html",
+        "MAME install ▸ Starting: {tag} ({asset}, ~{size}).":
+            "Instalación de MAME ▸ iniciando: {tag} ({asset}, ~{size}).",
+        "MAME install ▸ release picker cancelled.":
+            "Instalación de MAME ▸ selección de versión cancelada.",
+        "MAME is ready to launch now — no restart needed. Use the '🕹  Launch Mame' button.":
+            "MAME ya se puede iniciar, sin reiniciar. Usa el botón '🕹  Launch Mame'.",
+        "MAME update check: could not determine the installed MAME version; skipping.":
+            "Comprobación de MAME: no se pudo determinar la versión instalada; se omite.",
+        "MAME update check: could not determine the latest release; skipping.":
+            "Comprobación de MAME: no se pudo determinar la última versión; se omite.",
+        "MAME update check: could not reach the release site; skipping.":
+            "Comprobación de MAME: no se pudo acceder al sitio de versiones; se omite.",
+        "MAME update ▸ user chose to pick a release manually.":
+            "Actualización de MAME ▸ el usuario eligió seleccionar una versión manualmente.",
+        "MAME update ▸ user chose to update to {tag}.":
+            "Actualización de MAME ▸ el usuario eligió actualizar a {tag}.",
+        "On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.":
+            "En MacOS y Linux se necesita mono, ya que se ejecuta sobre él. Asegúrate de que mono está instalado.",
+        "Running as a Flatpak: mono must be installed on the HOST system — the launch is delegated there via flatpak-spawn.":
+            "Ejecutándose como Flatpak: mono debe estar instalado en el sistema ANFITRIÓN; el lanzamiento se delega allí mediante flatpak-spawn.",
+        "Select a valid ZX Spectrum Next disk image (.img/.hdf) before launching MAME.":
+            "Selecciona una imagen de disco ZX Spectrum Next válida (.img/.hdf) antes de iniciar MAME.",
+        "ZX Next Unite update check: could not reach GitHub (offline, or no release published yet); skipping.":
+            "Comprobación de ZX Next Unite: no se pudo acceder a GitHub (sin conexión o sin versiones publicadas); se omite.",
+        "ZX Next Unite update check: running as a Flatpak — updates come from your software center, skipping.":
+            "Comprobación de ZX Next Unite: ejecutándose como Flatpak; las actualizaciones vienen de tu centro de software, se omite.",
+        "ZX Next Unite update ▸ skipped by user.":
+            "Actualización de ZX Next Unite ▸ omitida por el usuario.",
+        "ZX Next Unite update: download cancelled.":
+            "Actualización de ZX Next Unite: descarga cancelada.",
         # ---- SD Card tab: console + dialogs ----
         "Confirm Deletion":
             "Confirmar eliminación",
@@ -1000,6 +1045,51 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        # ---- emulator install / update console ----
+        "CSpect update check skipped: {reason}":
+            "Verificação do CSpect ignorada: {reason}",
+        "CSpect update ▸ user cancelled the update.":
+            "Atualização do CSpect ▸ o utilizador cancelou a atualização.",
+        "ERROR: CSpect.exe is not present in the same local directory as zx-next-unite. Please install it from http://cspect.org":
+            "ERRO: o CSpect.exe não está na mesma pasta local que o zx-next-unite. Instala-o a partir de http://cspect.org",
+        "ERROR: MAME executable not found on PATH. Cannot launch MAME.":
+            "ERRO: o executável do MAME não foi encontrado no PATH. Não é possível iniciar o MAME.",
+        "Listing the available MAME releases…":
+            "A listar as versões do MAME disponíveis…",
+        "MAME install ▸ FAILED — the download and extraction finished, but no mame.exe could be found in downloads/mame.":
+            "Instalação do MAME ▸ FALHOU — a transferência e extração terminaram, mas não se encontrou o mame.exe em downloads/mame.",
+        "MAME install ▸ FAILED — {error}. You can download it manually from https://www.mamedev.org/release.html":
+            "Instalação do MAME ▸ FALHOU — {error}. Podes transferi-lo manualmente a partir de https://www.mamedev.org/release.html",
+        "MAME install ▸ Starting: {tag} ({asset}, ~{size}).":
+            "Instalação do MAME ▸ a iniciar: {tag} ({asset}, ~{size}).",
+        "MAME install ▸ release picker cancelled.":
+            "Instalação do MAME ▸ seleção de versão cancelada.",
+        "MAME is ready to launch now — no restart needed. Use the '🕹  Launch Mame' button.":
+            "O MAME já pode ser iniciado, sem reiniciar. Usa o botão '🕹  Launch Mame'.",
+        "MAME update check: could not determine the installed MAME version; skipping.":
+            "Verificação do MAME: não foi possível determinar a versão instalada; a ignorar.",
+        "MAME update check: could not determine the latest release; skipping.":
+            "Verificação do MAME: não foi possível determinar a versão mais recente; a ignorar.",
+        "MAME update check: could not reach the release site; skipping.":
+            "Verificação do MAME: não foi possível aceder ao site das versões; a ignorar.",
+        "MAME update ▸ user chose to pick a release manually.":
+            "Atualização do MAME ▸ o utilizador escolheu selecionar uma versão manualmente.",
+        "MAME update ▸ user chose to update to {tag}.":
+            "Atualização do MAME ▸ o utilizador escolheu atualizar para {tag}.",
+        "On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.":
+            "No MacOS e no Linux é necessário o mono, pois é executado sobre ele. Certifica-te de que o mono está instalado.",
+        "Running as a Flatpak: mono must be installed on the HOST system — the launch is delegated there via flatpak-spawn.":
+            "A executar como Flatpak: o mono tem de estar instalado no sistema ANFITRIÃO; o arranque é delegado aí através do flatpak-spawn.",
+        "Select a valid ZX Spectrum Next disk image (.img/.hdf) before launching MAME.":
+            "Seleciona uma imagem de disco ZX Spectrum Next válida (.img/.hdf) antes de iniciar o MAME.",
+        "ZX Next Unite update check: could not reach GitHub (offline, or no release published yet); skipping.":
+            "Verificação do ZX Next Unite: não foi possível aceder ao GitHub (sem ligação ou sem versões publicadas); a ignorar.",
+        "ZX Next Unite update check: running as a Flatpak — updates come from your software center, skipping.":
+            "Verificação do ZX Next Unite: a executar como Flatpak; as atualizações vêm do teu centro de software, a ignorar.",
+        "ZX Next Unite update ▸ skipped by user.":
+            "Atualização do ZX Next Unite ▸ ignorada pelo utilizador.",
+        "ZX Next Unite update: download cancelled.":
+            "Atualização do ZX Next Unite: transferência cancelada.",
         # ---- SD Card tab: console + dialogs ----
         "Confirm Deletion":
             "Confirmar eliminação",
@@ -1581,6 +1671,51 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        # ---- emulator install / update console ----
+        "CSpect update check skipped: {reason}":
+            "Pominięto sprawdzanie CSpect: {reason}",
+        "CSpect update ▸ user cancelled the update.":
+            "Aktualizacja CSpect ▸ użytkownik anulował aktualizację.",
+        "ERROR: CSpect.exe is not present in the same local directory as zx-next-unite. Please install it from http://cspect.org":
+            "BŁĄD: CSpect.exe nie znajduje się w tym samym katalogu co zx-next-unite. Zainstaluj go z http://cspect.org",
+        "ERROR: MAME executable not found on PATH. Cannot launch MAME.":
+            "BŁĄD: nie znaleziono pliku wykonywalnego MAME w PATH. Nie można uruchomić MAME.",
+        "Listing the available MAME releases…":
+            "Pobieranie listy dostępnych wersji MAME…",
+        "MAME install ▸ FAILED — the download and extraction finished, but no mame.exe could be found in downloads/mame.":
+            "Instalacja MAME ▸ NIEPOWODZENIE — pobieranie i wypakowanie zakończone, ale nie znaleziono mame.exe w downloads/mame.",
+        "MAME install ▸ FAILED — {error}. You can download it manually from https://www.mamedev.org/release.html":
+            "Instalacja MAME ▸ NIEPOWODZENIE — {error}. Możesz pobrać go ręcznie z https://www.mamedev.org/release.html",
+        "MAME install ▸ Starting: {tag} ({asset}, ~{size}).":
+            "Instalacja MAME ▸ rozpoczynanie: {tag} ({asset}, ~{size}).",
+        "MAME install ▸ release picker cancelled.":
+            "Instalacja MAME ▸ anulowano wybór wersji.",
+        "MAME is ready to launch now — no restart needed. Use the '🕹  Launch Mame' button.":
+            "MAME jest gotowy do uruchomienia — bez restartu. Użyj przycisku '🕹  Launch Mame'.",
+        "MAME update check: could not determine the installed MAME version; skipping.":
+            "Sprawdzanie MAME: nie udało się ustalić zainstalowanej wersji — pomijanie.",
+        "MAME update check: could not determine the latest release; skipping.":
+            "Sprawdzanie MAME: nie udało się ustalić najnowszej wersji — pomijanie.",
+        "MAME update check: could not reach the release site; skipping.":
+            "Sprawdzanie MAME: nie udało się połączyć z witryną wydań — pomijanie.",
+        "MAME update ▸ user chose to pick a release manually.":
+            "Aktualizacja MAME ▸ użytkownik wybrał ręczny wybór wersji.",
+        "MAME update ▸ user chose to update to {tag}.":
+            "Aktualizacja MAME ▸ użytkownik wybrał aktualizację do {tag}.",
+        "On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.":
+            "W systemach MacOS i Linux wymagany jest mono, ponieważ program działa pod nim. Upewnij się, że mono jest zainstalowany.",
+        "Running as a Flatpak: mono must be installed on the HOST system — the launch is delegated there via flatpak-spawn.":
+            "Uruchomiono jako Flatpak: mono musi być zainstalowany w systemie GOSPODARZA — uruchomienie jest tam delegowane przez flatpak-spawn.",
+        "Select a valid ZX Spectrum Next disk image (.img/.hdf) before launching MAME.":
+            "Wybierz prawidłowy obraz dysku ZX Spectrum Next (.img/.hdf) przed uruchomieniem MAME.",
+        "ZX Next Unite update check: could not reach GitHub (offline, or no release published yet); skipping.":
+            "Sprawdzanie ZX Next Unite: nie udało się połączyć z GitHubem (brak sieci lub brak wydań) — pomijanie.",
+        "ZX Next Unite update check: running as a Flatpak — updates come from your software center, skipping.":
+            "Sprawdzanie ZX Next Unite: uruchomiono jako Flatpak — aktualizacje pochodzą z centrum oprogramowania, pomijanie.",
+        "ZX Next Unite update ▸ skipped by user.":
+            "Aktualizacja ZX Next Unite ▸ pominięta przez użytkownika.",
+        "ZX Next Unite update: download cancelled.":
+            "Aktualizacja ZX Next Unite: pobieranie anulowane.",
         # ---- SD Card tab: console + dialogs ----
         "Confirm Deletion":
             "Potwierdź usunięcie",
@@ -2163,6 +2298,51 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        # ---- emulator install / update console ----
+        "CSpect update check skipped: {reason}":
+            "Проверка CSpect пропущена: {reason}",
+        "CSpect update ▸ user cancelled the update.":
+            "Обновление CSpect ▸ пользователь отменил обновление.",
+        "ERROR: CSpect.exe is not present in the same local directory as zx-next-unite. Please install it from http://cspect.org":
+            "ОШИБКА: CSpect.exe отсутствует в том же каталоге, что и zx-next-unite. Установите его с http://cspect.org",
+        "ERROR: MAME executable not found on PATH. Cannot launch MAME.":
+            "ОШИБКА: исполняемый файл MAME не найден в PATH. Запуск MAME невозможен.",
+        "Listing the available MAME releases…":
+            "Получение списка доступных версий MAME…",
+        "MAME install ▸ FAILED — the download and extraction finished, but no mame.exe could be found in downloads/mame.":
+            "Установка MAME ▸ ОШИБКА — загрузка и распаковка завершены, но mame.exe не найден в downloads/mame.",
+        "MAME install ▸ FAILED — {error}. You can download it manually from https://www.mamedev.org/release.html":
+            "Установка MAME ▸ ОШИБКА — {error}. Скачать вручную можно с https://www.mamedev.org/release.html",
+        "MAME install ▸ Starting: {tag} ({asset}, ~{size}).":
+            "Установка MAME ▸ запуск: {tag} ({asset}, ~{size}).",
+        "MAME install ▸ release picker cancelled.":
+            "Установка MAME ▸ выбор версии отменён.",
+        "MAME is ready to launch now — no restart needed. Use the '🕹  Launch Mame' button.":
+            "MAME готов к запуску — перезапуск не нужен. Нажмите кнопку '🕹  Launch Mame'.",
+        "MAME update check: could not determine the installed MAME version; skipping.":
+            "Проверка MAME: не удалось определить установленную версию — пропуск.",
+        "MAME update check: could not determine the latest release; skipping.":
+            "Проверка MAME: не удалось определить последнюю версию — пропуск.",
+        "MAME update check: could not reach the release site; skipping.":
+            "Проверка MAME: не удалось связаться с сайтом релизов — пропуск.",
+        "MAME update ▸ user chose to pick a release manually.":
+            "Обновление MAME ▸ пользователь выбрал версию вручную.",
+        "MAME update ▸ user chose to update to {tag}.":
+            "Обновление MAME ▸ пользователь выбрал обновление до {tag}.",
+        "On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.":
+            "В MacOS и Linux требуется mono, так как запуск происходит через него. Убедитесь, что mono установлен.",
+        "Running as a Flatpak: mono must be installed on the HOST system — the launch is delegated there via flatpak-spawn.":
+            "Запуск в виде Flatpak: mono должен быть установлен в ОСНОВНОЙ системе — запуск делегируется туда через flatpak-spawn.",
+        "Select a valid ZX Spectrum Next disk image (.img/.hdf) before launching MAME.":
+            "Выберите корректный образ диска ZX Spectrum Next (.img/.hdf) перед запуском MAME.",
+        "ZX Next Unite update check: could not reach GitHub (offline, or no release published yet); skipping.":
+            "Проверка ZX Next Unite: не удалось связаться с GitHub (нет сети или релизы не опубликованы) — пропуск.",
+        "ZX Next Unite update check: running as a Flatpak — updates come from your software center, skipping.":
+            "Проверка ZX Next Unite: запуск в виде Flatpak — обновления приходят из центра приложений, пропуск.",
+        "ZX Next Unite update ▸ skipped by user.":
+            "Обновление ZX Next Unite ▸ пропущено пользователем.",
+        "ZX Next Unite update: download cancelled.":
+            "Обновление ZX Next Unite: загрузка отменена.",
         # ---- SD Card tab: console + dialogs ----
         "Confirm Deletion":
             "Подтвердите удаление",
@@ -2744,6 +2924,51 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        # ---- emulator install / update console ----
+        "CSpect update check skipped: {reason}":
+            "Kontrola CSpectu přeskočena: {reason}",
+        "CSpect update ▸ user cancelled the update.":
+            "Aktualizace CSpectu ▸ uživatel aktualizaci zrušil.",
+        "ERROR: CSpect.exe is not present in the same local directory as zx-next-unite. Please install it from http://cspect.org":
+            "CHYBA: CSpect.exe není ve stejném adresáři jako zx-next-unite. Nainstalujte jej z http://cspect.org",
+        "ERROR: MAME executable not found on PATH. Cannot launch MAME.":
+            "CHYBA: spustitelný soubor MAME nebyl nalezen v PATH. MAME nelze spustit.",
+        "Listing the available MAME releases…":
+            "Načítá se seznam dostupných verzí MAME…",
+        "MAME install ▸ FAILED — the download and extraction finished, but no mame.exe could be found in downloads/mame.":
+            "Instalace MAME ▸ SELHALA — stažení i rozbalení proběhlo, ale mame.exe nebyl v downloads/mame nalezen.",
+        "MAME install ▸ FAILED — {error}. You can download it manually from https://www.mamedev.org/release.html":
+            "Instalace MAME ▸ SELHALA — {error}. Ručně jej lze stáhnout z https://www.mamedev.org/release.html",
+        "MAME install ▸ Starting: {tag} ({asset}, ~{size}).":
+            "Instalace MAME ▸ spouští se: {tag} ({asset}, ~{size}).",
+        "MAME install ▸ release picker cancelled.":
+            "Instalace MAME ▸ výběr verze zrušen.",
+        "MAME is ready to launch now — no restart needed. Use the '🕹  Launch Mame' button.":
+            "MAME je připraven ke spuštění — bez restartu. Použijte tlačítko '🕹  Launch Mame'.",
+        "MAME update check: could not determine the installed MAME version; skipping.":
+            "Kontrola MAME: nepodařilo se zjistit nainstalovanou verzi — přeskakuje se.",
+        "MAME update check: could not determine the latest release; skipping.":
+            "Kontrola MAME: nepodařilo se zjistit nejnovější verzi — přeskakuje se.",
+        "MAME update check: could not reach the release site; skipping.":
+            "Kontrola MAME: nepodařilo se spojit se stránkou vydání — přeskakuje se.",
+        "MAME update ▸ user chose to pick a release manually.":
+            "Aktualizace MAME ▸ uživatel zvolil ruční výběr verze.",
+        "MAME update ▸ user chose to update to {tag}.":
+            "Aktualizace MAME ▸ uživatel zvolil aktualizaci na {tag}.",
+        "On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.":
+            "Na MacOS a Linuxu je vyžadován mono, protože pod ním program běží. Ujistěte se, že je mono nainstalován.",
+        "Running as a Flatpak: mono must be installed on the HOST system — the launch is delegated there via flatpak-spawn.":
+            "Běží jako Flatpak: mono musí být nainstalován v HOSTITELSKÉM systému — spuštění se tam deleguje přes flatpak-spawn.",
+        "Select a valid ZX Spectrum Next disk image (.img/.hdf) before launching MAME.":
+            "Před spuštěním MAME vyberte platný obraz disku ZX Spectrum Next (.img/.hdf).",
+        "ZX Next Unite update check: could not reach GitHub (offline, or no release published yet); skipping.":
+            "Kontrola ZX Next Unite: nepodařilo se spojit s GitHubem (offline nebo žádné vydání) — přeskakuje se.",
+        "ZX Next Unite update check: running as a Flatpak — updates come from your software center, skipping.":
+            "Kontrola ZX Next Unite: běží jako Flatpak — aktualizace přicházejí z centra softwaru, přeskakuje se.",
+        "ZX Next Unite update ▸ skipped by user.":
+            "Aktualizace ZX Next Unite ▸ přeskočena uživatelem.",
+        "ZX Next Unite update: download cancelled.":
+            "Aktualizace ZX Next Unite: stahování zrušeno.",
         # ---- SD Card tab: console + dialogs ----
         "Confirm Deletion":
             "Potvrdit smazání",
@@ -3328,6 +3553,51 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        # ---- emulator install / update console ----
+        "CSpect update check skipped: {reason}":
+            "Vérification de CSpect ignorée : {reason}",
+        "CSpect update ▸ user cancelled the update.":
+            "Mise à jour de CSpect ▸ l'utilisateur a annulé la mise à jour.",
+        "ERROR: CSpect.exe is not present in the same local directory as zx-next-unite. Please install it from http://cspect.org":
+            "ERREUR : CSpect.exe n'est pas dans le même dossier local que zx-next-unite. Installez-le depuis http://cspect.org",
+        "ERROR: MAME executable not found on PATH. Cannot launch MAME.":
+            "ERREUR : exécutable MAME introuvable dans le PATH. Impossible de lancer MAME.",
+        "Listing the available MAME releases…":
+            "Liste des versions de MAME disponibles…",
+        "MAME install ▸ FAILED — the download and extraction finished, but no mame.exe could be found in downloads/mame.":
+            "Installation de MAME ▸ ÉCHEC — le téléchargement et l'extraction sont terminés, mais aucun mame.exe n'a été trouvé dans downloads/mame.",
+        "MAME install ▸ FAILED — {error}. You can download it manually from https://www.mamedev.org/release.html":
+            "Installation de MAME ▸ ÉCHEC — {error}. Vous pouvez le télécharger manuellement depuis https://www.mamedev.org/release.html",
+        "MAME install ▸ Starting: {tag} ({asset}, ~{size}).":
+            "Installation de MAME ▸ démarrage : {tag} ({asset}, ~{size}).",
+        "MAME install ▸ release picker cancelled.":
+            "Installation de MAME ▸ choix de version annulé.",
+        "MAME is ready to launch now — no restart needed. Use the '🕹  Launch Mame' button.":
+            "MAME peut être lancé maintenant — aucun redémarrage nécessaire. Utilisez le bouton '🕹  Launch Mame'.",
+        "MAME update check: could not determine the installed MAME version; skipping.":
+            "Vérification de MAME : impossible de déterminer la version installée ; ignorée.",
+        "MAME update check: could not determine the latest release; skipping.":
+            "Vérification de MAME : impossible de déterminer la dernière version ; ignorée.",
+        "MAME update check: could not reach the release site; skipping.":
+            "Vérification de MAME : site des versions inaccessible ; ignorée.",
+        "MAME update ▸ user chose to pick a release manually.":
+            "Mise à jour de MAME ▸ l'utilisateur a choisi de sélectionner une version manuellement.",
+        "MAME update ▸ user chose to update to {tag}.":
+            "Mise à jour de MAME ▸ l'utilisateur a choisi de passer à {tag}.",
+        "On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.":
+            "Sur MacOS et Linux, mono est requis car l'exécution se fait via lui. Vérifiez que mono est installé.",
+        "Running as a Flatpak: mono must be installed on the HOST system — the launch is delegated there via flatpak-spawn.":
+            "Exécution en Flatpak : mono doit être installé sur le système HÔTE — le lancement y est délégué via flatpak-spawn.",
+        "Select a valid ZX Spectrum Next disk image (.img/.hdf) before launching MAME.":
+            "Sélectionnez une image disque ZX Spectrum Next valide (.img/.hdf) avant de lancer MAME.",
+        "ZX Next Unite update check: could not reach GitHub (offline, or no release published yet); skipping.":
+            "Vérification de ZX Next Unite : GitHub inaccessible (hors ligne, ou aucune version publiée) ; ignorée.",
+        "ZX Next Unite update check: running as a Flatpak — updates come from your software center, skipping.":
+            "Vérification de ZX Next Unite : exécution en Flatpak — les mises à jour viennent de votre logithèque, ignorée.",
+        "ZX Next Unite update ▸ skipped by user.":
+            "Mise à jour de ZX Next Unite ▸ ignorée par l'utilisateur.",
+        "ZX Next Unite update: download cancelled.":
+            "Mise à jour de ZX Next Unite : téléchargement annulé.",
         # ---- SD Card tab: console + dialogs ----
         "Confirm Deletion":
             "Confirmer la suppression",

--- a/zxnu_itchio_pane.py
+++ b/zxnu_itchio_pane.py
@@ -791,15 +791,17 @@ def build_itchio_pane(
                 url = (_e.get("url") or "").strip()
                 box = QMessageBox(host)
                 box.setIcon(QMessageBox.Warning)
-                box.setWindowTitle("itch.io download")
-                box.setText(_msg or "The automated download failed.")
-                box.setInformativeText(
+                box.setWindowTitle(ui_tr_now("itch.io download"))
+                box.setText(_msg or ui_tr_now("The automated download failed."))
+                box.setInformativeText(ui_tr_now(
                     "You can download it manually from the itch.io page in "
-                    "your browser, then install it from the downloaded .zip.")
-                open_btn = (box.addButton("Open itch.io page", QMessageBox.ActionRole)
+                    "your browser, then install it from the downloaded .zip."))
+                open_btn = (box.addButton(ui_tr_now("Open itch.io page"),
+                                          QMessageBox.ActionRole)
                             if url else None)
-                pick_btn = box.addButton("Install from .zip…", QMessageBox.AcceptRole)
-                box.addButton("Close", QMessageBox.RejectRole)
+                pick_btn = box.addButton(
+                    ui_tr_now("Install from .zip…"), QMessageBox.AcceptRole)
+                box.addButton(ui_tr_now("Close"), QMessageBox.RejectRole)
                 box.exec()
                 clicked = box.clickedButton()
                 if open_btn is not None and clicked is open_btn:
@@ -928,10 +930,12 @@ def build_itchio_pane(
                     _itchio_refresh_install_buttons(_viewer, False)
                     return
                 reply = QMessageBox.question(
-                    host, "Uninstall",
-                    f"This is going to completely delete the files in {path} "
-                    "and its sub folders, so they will be unrecoverable.\n\n"
-                    "Are you sure want to continue?",
+                    host, ui_tr_now("Uninstall"),
+                    ui_tr_now(
+                        "This is going to completely delete the files in "
+                        "{path} and its sub folders, so they will be "
+                        "unrecoverable.\n\nAre you sure want to continue?"
+                    ).format(path=path),
                     QMessageBox.Yes | QMessageBox.Cancel, QMessageBox.Cancel)
                 if reply != QMessageBox.Yes:
                     return

--- a/zxnu_nextsync_ops.py
+++ b/zxnu_nextsync_ops.py
@@ -875,16 +875,24 @@ def build_nextsync_server_job(
         try:
             box = QMessageBox(host)
             box.setIcon(QMessageBox.Question)
-            box.setWindowTitle("File or directory exists")
-            box.setText("File or directory already exists locally.")
+            box.setWindowTitle(ui_tr_now("File or directory exists"))
+            box.setText(ui_tr_now("File or directory already exists locally."))
+            # The Settings label is quoted verbatim: it is what the user has to
+            # find in the UI, and that row is itself translated by the walk.
             box.setInformativeText(
                 f"{path}\n\n"
-                "Tip: set a default for this in Settings → "
-                "\"NextSync — when a sent file or directory exists locally\".")
-            b_ow_one = box.addButton("Overwrite local file (one time)", QMessageBox.AcceptRole)
-            b_ow_all = box.addButton("Overwrite local file (always in this sync)", QMessageBox.AcceptRole)
-            b_ig_one = box.addButton("Ignore (one time)", QMessageBox.RejectRole)
-            b_ig_all = box.addButton("Ignore (always in this sync)", QMessageBox.RejectRole)
+                + ui_tr_now("Tip: set a default for this in Settings → "
+                            "\"NextSync — when a sent file or directory exists "
+                            "locally\"."))
+            b_ow_one = box.addButton(
+                ui_tr_now("Overwrite local file (one time)"), QMessageBox.AcceptRole)
+            b_ow_all = box.addButton(
+                ui_tr_now("Overwrite local file (always in this sync)"),
+                QMessageBox.AcceptRole)
+            b_ig_one = box.addButton(
+                ui_tr_now("Ignore (one time)"), QMessageBox.RejectRole)
+            b_ig_all = box.addButton(
+                ui_tr_now("Ignore (always in this sync)"), QMessageBox.RejectRole)
             box.exec()
             clicked = box.clickedButton()
             if clicked is b_ow_one:

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -83,7 +83,8 @@ def build_sdcard_utils(
     def delete_files_button_show_confirmation_buttons():
         if not host.image_selected_path:
             logging.info("Please select an image file or folder first to delete!")
-            add_main_log_window("Please select an image file or folder first to delete!")
+            add_main_log_window(ui_tr_now(
+                "Please select an image file or folder first to delete!"))
             return
         # When "Do not prompt for confirmation on deletion" is enabled, delete
         # straight away; otherwise ask for confirmation via a popup dialog.
@@ -116,7 +117,9 @@ def build_sdcard_utils(
             # when it exited cleanly — a genuine not-found / other failure is
             # already surfaced by execute_hdf_monkey.
             if hdfmonkeyexecresult.returncode == 0:
-                add_main_log_window("Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.")
+                add_main_log_window(ui_tr_now(
+                    "Failed executing hdfmonkey, please make sure it is "
+                    "installed in the same local directory as zx-next-unite."))
             return False
         except Exception as e:
             logging.error(f"Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.... {e}")
@@ -413,7 +416,9 @@ def build_sdcard_utils(
                             1200, lambda: _wiz.on_image_loaded())
                 else:
                     logging.error(f"Failed loading image :{host.right_disk_image_path}.")
-                    add_main_log_window(f"Failed loading image :{host.right_disk_image_path}.")
+                    add_main_log_window(ui_tr_now(
+                        "Failed loading image: {path}.").format(
+                            path=host.right_disk_image_path))
                     set_all_buttons_disabled()
                     enable_image_selection()
                     _update_image_usage_gauge("")
@@ -430,9 +435,9 @@ def build_sdcard_utils(
         # the Launch buttons stay greyed out (CSpect needs the mounted image
         # for -mmc=, MAME boots the image file directly), and the only other
         # hint is a hover tooltip on the disabled buttons.
-        add_main_log_window(
+        add_main_log_window(ui_tr_now(
             "No SD-card disk image selected — pick or create a .img/.hdf "
-            "at the top of this tab to unlock the emulator Launch buttons.")
+            "at the top of this tab to unlock the emulator Launch buttons."))
         # Same hint as a yellow advisory toast (see the helper for the
         # emulator-installed gating).
         _maybe_show_no_image_toast()
@@ -518,7 +523,7 @@ def build_sdcard_utils(
             host.button_create_directory_cancel.setVisible(True)
         else:
             logging.info("Please load an image file first !")
-            add_main_log_window("Please load an image file first !")
+            add_main_log_window(ui_tr_now("Please load an image file first !"))
 
         save_configuration_file()
 
@@ -535,7 +540,7 @@ def build_sdcard_utils(
             host.button_create_directory_cancel.setVisible(False)
         else:
             logging.info("Please load an image file first !")
-            add_main_log_window("Please load an image file first !")
+            add_main_log_window(ui_tr_now("Please load an image file first !"))
 
         save_configuration_file()
 
@@ -583,13 +588,13 @@ def build_sdcard_utils(
 
         if not _right_disk_content():
             logging.info("Please load an image file first !")
-            add_main_log_window("Please load an image file first !")
+            add_main_log_window(ui_tr_now("Please load an image file first !"))
             return
 
         nachars = "".join(DIRECTORY_CREATION_NOT_ALLOWED_CHARACTERS)
 
         dialog = QDialog(host)
-        dialog.setWindowTitle("Create New Folder")
+        dialog.setWindowTitle(ui_tr_now("Create New Folder"))
         dialog.setMinimumWidth(380)
         layout = QVBoxLayout(dialog)
 
@@ -608,7 +613,8 @@ def build_sdcard_utils(
         layout.addWidget(error_label)
 
         button_box = QDialogButtonBox(dialog)
-        create_button = button_box.addButton("Create", QDialogButtonBox.AcceptRole)
+        create_button = button_box.addButton(
+            ui_tr_now("Create"), QDialogButtonBox.AcceptRole)
         button_box.addButton("Cancel", QDialogButtonBox.RejectRole)
         layout.addWidget(button_box)
 
@@ -694,7 +700,8 @@ def build_sdcard_utils(
         dialog_layout.addWidget(download_progress)
 
         button_box = QDialogButtonBox(dialog)
-        download_button = button_box.addButton("Download", QDialogButtonBox.AcceptRole)
+        download_button = button_box.addButton(
+            ui_tr_now("Download"), QDialogButtonBox.AcceptRole)
         cancel_button = button_box.addButton("Cancel", QDialogButtonBox.RejectRole)
         dialog_layout.addWidget(button_box)
 
@@ -722,7 +729,8 @@ def build_sdcard_utils(
             download_progress.setVisible(True)
             download_progress.setValue(0)
 
-            add_main_log_window(f"Downloading {selected_label} from {selected_url}")
+            add_main_log_window(ui_tr_now("Downloading {name} from {url}").format(
+                name=selected_label, url=selected_url))
 
             try:
                 request = urllib.request.Request(
@@ -748,7 +756,9 @@ def build_sdcard_utils(
                 download_progress.setValue(100)
             except Exception as download_error:
                 logging.error(f"Failed downloading NextZXOS image: {download_error}")
-                add_main_log_window(f"Failed downloading NextZXOS image: {download_error}")
+                add_main_log_window(ui_tr_now(
+                    "Failed downloading NextZXOS image: {error}").format(
+                        error=download_error))
                 QMessageBox.critical(
                     dialog,
                     ui_tr_now("Download Failed"),
@@ -773,10 +783,14 @@ def build_sdcard_utils(
                         if image_members:
                             archive.extract(image_members[0], extract_dir)
                             image_to_load = os.path.join(extract_dir, image_members[0])
-                            add_main_log_window(f"Extracted disk image: {image_to_load}")
+                            add_main_log_window(ui_tr_now(
+                                "Extracted disk image: {path}").format(
+                                    path=image_to_load))
             except Exception as extract_error:
                 logging.error(f"Failed extracting NextZXOS image: {extract_error}")
-                add_main_log_window(f"Failed extracting NextZXOS image: {extract_error}")
+                add_main_log_window(ui_tr_now(
+                    "Failed extracting NextZXOS image: {error}").format(
+                        error=extract_error))
                 QMessageBox.critical(
                     dialog,
                     ui_tr_now("Extraction Failed"),
@@ -911,19 +925,26 @@ def build_sdcard_utils(
         used_pct = 100 - free_pct
         if free_pct < 10:
             if free_pct == 0:
-                space_line = f"The image is completely full ({total_mb} MB capacity, 0 MB free)."
+                space_line = ui_tr_now(
+                    "The image is completely full ({total} MB capacity, "
+                    "0 MB free).").format(total=total_mb)
             else:
-                space_line = (f"Only {free_mb} MB free out of {total_mb} MB "
-                              f"({used_pct:.1f} % used, {free_pct:.1f} % free).")
+                space_line = ui_tr_now(
+                    "Only {free} MB free out of {total} MB "
+                    "({used} % used, {pct} % free).").format(
+                        free=free_mb, total=total_mb,
+                        used=f"{used_pct:.1f}", pct=f"{free_pct:.1f}")
             msg = QMessageBox(host)
             msg.setIcon(QMessageBox.Warning)
-            msg.setWindowTitle("SD Image Nearly Full")
+            msg.setWindowTitle(ui_tr_now("SD Image Nearly Full"))
             msg.setText(
-                f"\u26a0\ufe0f  The SD card image is nearly full.\n\n"
-                f"{space_line}\n\n"
-                f"Delete files from the image to free space, or switch to a larger image.\n"
-                f"Larger SD card images can be downloaded from:\n"
-                f"https://zxnext.uk/hosted/"
+                "\u26a0\ufe0f  " + ui_tr_now(
+                    "The SD card image is nearly full.") + "\n\n"
+                + space_line + "\n\n"
+                + ui_tr_now(
+                    "Delete files from the image to free space, or switch to "
+                    "a larger image.\nLarger SD card images can be downloaded "
+                    "from:") + "\nhttps://zxnext.uk/hosted/"
             )
             msg.setStandardButtons(QMessageBox.Ok)
             msg.exec()
@@ -1034,9 +1055,9 @@ def build_sdcard_utils(
                     add_main_log_window(f"ERROR: Permission denied running hdfmonkey: {hdfmonkey_exe}")
                     if hdfmonkey_needs_exec_bit():
                         cmd = hdfmonkey_chmod_instruction(hdfmonkey_exe)
-                        add_main_log_window(
+                        add_main_log_window(ui_tr_now(
                             "The hdfmonkey provided by the CSpect itch.io package is not "
-                            "executable. Make it executable by running:")
+                            "executable. Make it executable by running:"))
                         add_main_log_window(f"    {cmd}")
 
         except (FileNotFoundError,subprocess.CalledProcessError) as ex:
@@ -1062,7 +1083,15 @@ def build_sdcard_utils(
                                       + (f" | stderr: {stderr_text}" if stderr_text else ""))
                 elif isinstance(ex, FileNotFoundError) or ex.returncode == 1:
                     logging.error(f"Failed executing hdfmonkey: {execution_cmd} - Once hdfmonkey is installed please close the application and restart it.")
-                    add_main_log_window("ERROR: hdfmonkey could not be found. Use the 'Download and install HDF Monkey' button (bottom right of the SD Card tab) to install it automatically, or do a full CSpect install from the itch.io tab, which also bundles hdfmonkey. It can also be installed manually from https://github.com/gasman/hdfmonkey — restart the app once installed.")
+                    add_main_log_window(ui_tr_now(
+                        "ERROR: hdfmonkey could not be found. Use the "
+                        "'Download and install HDF Monkey' button (bottom "
+                        "right of the SD Card tab) to install it "
+                        "automatically, or do a full CSpect install from the "
+                        "itch.io tab, which also bundles hdfmonkey. It can "
+                        "also be installed manually from "
+                        "https://github.com/gasman/hdfmonkey — restart the "
+                        "app once installed."))
                 elif ex.returncode == 255:
                     if execution_cmd is not None:
                         logging.error(f"ERROR: hdfmonkey failed - A file can't be opened: {execution_cmd} this is commonly caused by strange characters such as quotes and signs")
@@ -1158,7 +1187,7 @@ def build_image_edit_ops(
         selected = host.image_selected_paths or [(host.image_selected_path, host.image_selected_is_dir)]
 
         dialog = QDialog(host)
-        dialog.setWindowTitle("Confirm Deletion")
+        dialog.setWindowTitle(ui_tr_now("Confirm Deletion"))
         dialog.setMinimumWidth(420)
         layout = QVBoxLayout(dialog)
 
@@ -1207,12 +1236,14 @@ def build_image_edit_ops(
     def image_delete_files():
         if not _right_disk_content():
             logging.info("Please select an image file or folder first to delete!")
-            add_main_log_window("Please select an image file or folder first to delete!")
+            add_main_log_window(ui_tr_now(
+                "Please select an image file or folder first to delete!"))
             return
 
         if not host.image_selected_path:
             logging.info("Please select an image file or folder first to delete!")
-            add_main_log_window("Please select an image file or folder first to delete!")
+            add_main_log_window(ui_tr_now(
+                "Please select an image file or folder first to delete!"))
             return
 
         img_err = _check_image_writable(host.right_disk_image_path, check_free_space=False)
@@ -1337,7 +1368,8 @@ def build_image_edit_ops(
         the primary selection (single entry) and runs on a worker thread."""
         if not _right_disk_content() or not host.image_selected_path:
             logging.info("Please select an image file or folder first to rename!")
-            add_main_log_window("Please select an image file or folder first to rename!")
+            add_main_log_window(ui_tr_now(
+                "Please select an image file or folder first to rename!"))
             return
 
         src_path = host.image_selected_path.rstrip("/")
@@ -1477,11 +1509,13 @@ def build_local_explorer_ops(
             return
         try:
             os.rename(file_path, new_path)
-            add_main_log_window(f"Renamed: {file_path} -> {new_path}")
+            add_main_log_window(ui_tr_now("Renamed: {old} -> {new}").format(
+                old=file_path, new=new_path))
         except OSError as e:
             logging.error(f"Failed to rename {file_path} -> {new_path}: {e}",
                           exc_info=True)
-            add_main_log_window(f"Failed to rename {file_path}: {e}")
+            add_main_log_window(ui_tr_now(
+                "Failed to rename {path}: {error}").format(path=file_path, error=e))
             QMessageBox.critical(host, ui_tr_now("Rename failed"),
                                  ui_tr_now("Could not rename:") + f"\n{file_path}\n\n{e}")
         finally:
@@ -1812,7 +1846,8 @@ def build_local_explorer_ops(
         is called with a single bool (True only if the transfer finished without
         error or cancellation) — used by cut+paste to remove the source after."""
         if not dest_dir or not os.path.isdir(dest_dir):
-            add_main_log_window("Import failed: no valid destination folder.")
+            add_main_log_window(ui_tr_now(
+                "Import failed: no valid destination folder."))
             return
 
         items = []
@@ -1825,7 +1860,9 @@ def build_local_explorer_ops(
                 dest_abs = os.path.abspath(dest_dir)
                 # Guard against importing a folder into itself or a subfolder.
                 if dest_abs == src_abs or dest_abs.startswith(src_abs + os.sep):
-                    add_main_log_window(f"Skipped {src}: cannot import a folder into itself.")
+                    add_main_log_window(ui_tr_now(
+                        "Skipped {path}: cannot import a folder into itself."
+                    ).format(path=src))
                     continue
             base = os.path.basename(src.rstrip("/\\"))
             target = _nextsync_unique_path(os.path.join(dest_dir, base), src_is_dir)
@@ -1903,7 +1940,7 @@ def build_transfer_clipboard_ops(
 
         if not _right_disk_content():
             logging.warning("Please load an image file first !")
-            add_main_log_window("Please load an image file first !")
+            add_main_log_window(ui_tr_now("Please load an image file first !"))
             return
 
         set_all_buttons_disabled()
@@ -1966,11 +2003,12 @@ def build_transfer_clipboard_ops(
 
         if not _right_disk_content():
             logging.warning("Please load an image file first !")
-            add_main_log_window("Please load an image file first !")
+            add_main_log_window(ui_tr_now("Please load an image file first !"))
             return
 
         if not dest_dir or not os.path.isdir(dest_dir):
-            add_main_log_window("Download failed: no valid destination folder.")
+            add_main_log_window(ui_tr_now(
+                "Download failed: no valid destination folder."))
             return
 
         items = []
@@ -2191,7 +2229,7 @@ def build_transfer_clipboard_ops(
         copy finished without error or cancellation) so cut+paste can remove the
         source entries afterward."""
         if not _right_disk_content():
-            add_main_log_window("Please load an image file first !")
+            add_main_log_window(ui_tr_now("Please load an image file first !"))
             return
         img_err = _check_image_writable(host.right_disk_image_path)
         if img_err:
@@ -2381,7 +2419,8 @@ def build_transfer_clipboard_ops(
             # Cutting into the source's own image folder is a no-op move.
             if is_cut and img_paths and all(
                     (p.rstrip("/").rsplit("/", 1)[0] or "/") == target for p in img_paths):
-                add_main_log_window("Nothing to move: items are already in this folder.")
+                add_main_log_window(ui_tr_now(
+                    "Nothing to move: items are already in this folder."))
                 _explorer_clipboard_clear()
                 return
             def _after(success, _p=img_paths):
@@ -2476,7 +2515,7 @@ def build_transfer_clipboard_ops(
 
         if not _right_disk_content():
             logging.warning("Please load an image file first !")
-            add_main_log_window("Please load an image first!")
+            add_main_log_window(ui_tr_now("Please load an image first!"))
             return
 
         img_err = _check_image_writable(host.right_disk_image_path)
@@ -2534,7 +2573,7 @@ def build_transfer_clipboard_ops(
 
         if not _right_disk_content():
             logging.warning("Please load an image file first !")
-            add_main_log_window("Please load an image first!")
+            add_main_log_window(ui_tr_now("Please load an image first!"))
             return
 
         img_err = _check_image_writable(host.right_disk_image_path)
@@ -2666,9 +2705,9 @@ def build_transfer_clipboard_ops(
             local_zip = os.path.join(tmp, name)
             if not success or not os.path.isfile(local_zip):
                 shutil.rmtree(tmp, ignore_errors=True)
-                add_main_log_window("Remote unzip: download from the image "
-                                    "failed or was cancelled — the image "
-                                    "is unchanged.")
+                add_main_log_window(ui_tr_now(
+                    "Remote unzip: download from the image failed or was "
+                    "cancelled — the image is unchanged."))
                 return
             extract_dir = os.path.join(tmp, "_extracted")
             os.makedirs(extract_dir, exist_ok=True)
@@ -2677,8 +2716,8 @@ def build_transfer_clipboard_ops(
             if not res["ok"] or res["files"] == 0:
                 shutil.rmtree(tmp, ignore_errors=True)
                 if res["cancelled"]:
-                    add_main_log_window("Remote unzip cancelled — the "
-                                        "image is unchanged.")
+                    add_main_log_window(ui_tr_now(
+                        "Remote unzip cancelled — the image is unchanged."))
                 elif res["error"]:
                     add_main_log_window(f"ERROR: could not extract {name}: "
                                         f"{res['error']}")
@@ -2699,12 +2738,15 @@ def build_transfer_clipboard_ops(
                     extra = (f" ({skipped} unsafe "
                              f"{'entry' if skipped == 1 else 'entries'} "
                              "skipped)" if skipped else "")
-                    add_main_log_window(
-                        f"Extracted {res['files']} file(s) from {name} "
-                        f"into {dest_dir} on the image.{extra}")
+                    add_main_log_window(ui_tr_now(
+                        "Extracted {count} file(s) from {name} into {folder} "
+                        "on the image.").format(
+                            count=res["files"], name=name, folder=dest_dir)
+                        + extra)
                 else:
-                    add_main_log_window("Remote unzip: upload into the "
-                                        "image failed or was cancelled.")
+                    add_main_log_window(ui_tr_now(
+                        "Remote unzip: upload into the image failed or was "
+                        "cancelled."))
             image_upload_external_paths(tops, dest_dir, on_complete=_done)
 
         add_main_log_window(f"Remote unzip: fetching {zip_path} from "
@@ -2739,9 +2781,9 @@ def build_transfer_clipboard_ops(
         def _go(success):
             if not success:
                 shutil.rmtree(tmp, ignore_errors=True)
-                add_main_log_window("Remote zip: download from the image "
-                                    "failed or was cancelled — no zip was "
-                                    "created.")
+                add_main_log_window(ui_tr_now(
+                    "Remote zip: download from the image failed or was "
+                    "cancelled — no zip was created."))
                 return
             src_paths = [os.path.join(dl, e) for e in sorted(os.listdir(dl))]
             zip_local = os.path.join(tmp, zip_name)
@@ -2750,8 +2792,8 @@ def build_transfer_clipboard_ops(
             if not res["ok"]:
                 shutil.rmtree(tmp, ignore_errors=True)
                 if res["cancelled"]:
-                    add_main_log_window("Remote zip cancelled — no zip "
-                                        "was created.")
+                    add_main_log_window(ui_tr_now(
+                        "Remote zip cancelled — no zip was created."))
                 else:
                     add_main_log_window(f"ERROR: could not build "
                                         f"{zip_name}: {res['error']}")
@@ -2761,12 +2803,15 @@ def build_transfer_clipboard_ops(
             def _done(up_ok):
                 shutil.rmtree(tmp, ignore_errors=True)
                 if up_ok:
-                    add_main_log_window(
-                        f"Created {zip_name} in {dest_dir} on the image "
-                        f"({res['files']} file(s), {size:,} bytes).")
+                    add_main_log_window(ui_tr_now(
+                        "Created {name} in {folder} on the image "
+                        "({count} file(s), {bytes} bytes).").format(
+                            name=zip_name, folder=dest_dir,
+                            count=res["files"], bytes=f"{size:,}"))
                 else:
-                    add_main_log_window("Remote zip: upload into the "
-                                        "image failed or was cancelled.")
+                    add_main_log_window(ui_tr_now(
+                        "Remote zip: upload into the image failed or was "
+                        "cancelled."))
             image_upload_external_paths([zip_local], dest_dir,
                                         on_complete=_done)
 


### PR DESCRIPTION
Continues the localization sweep. **81 new strings × 6 languages** in three reviewable commits, taking the still-English surface from 106 user-facing console lines + 47 dialog literals down to **49 + 28**.

## What landed

**SD Card console and dialogs (32 strings).** The hdfmonkey transfer operations you named: the "load/select an image first" prompts (six call sites shared one string), import/download destination failures, the full remote zip/unzip lifecycle including the `Created X ({count} file(s), {bytes} bytes)` and `Extracted {count} file(s)` summaries, the NextZXOS download/extract results, and the hdfmonkey guidance (not found, not executable, wrong directory). Plus the dialogs: Create New Folder, Create, Download, Confirm Deletion, and the "SD Image Nearly Full" warning with its free-space sentence.

**Emulator install/update console (22 strings).** The MAME install chain (listing, picker cancelled, `Starting: {tag} ({asset}, ~{size})`, both FAILED variants, the ready-to-launch confirmation), the MAME update prompts and three check bail-outs, the ZX Next Unite self-update paths including the Flatpak and offline cases, CSpect cancel/skip, and the launch preconditions (MAME not on PATH, no valid image, CSpect.exe missing, the two mono requirements).

**Message boxes (27 strings).** The shared button vocabulary that recurs across many prompts — Update, Later, Close, Yes, Uninstall, Download and install, Choose another release…, Open the releases page, Open itch.io page, Install from .zip… — every window title, the NextSync sent-file conflict prompt in full (its four Overwrite/Ignore choices and the Settings tip), and the itch.io fallback and uninstall confirmation.

## Rules held throughout

Diagnostics stay English, as agreed for the NextSync console: hdfmonkey result codes and HTTP/SHA-256 detail, executable and argv echoes, raw exception text. A pasted log still matches the docs. Paths, sizes, tags and error text are interpolated through `{named}` fields, never translated — and the Settings row quoted inside the conflict tip stays verbatim because it names a control the user has to find.

## Verification

Across the four op/pane files: **162 `ui_tr_now` literals, all present in all six catalogs**, and every template genuinely `.format()`s in all seven languages — a dropped or renamed field would otherwise raise mid-operation, in one language only. The existing `test_i18n` tripwires cover placeholder parity and catalog completeness; `ruff check .` and the full suite are green.

## Still English (measured, not estimated)

49 user-facing console lines (27 in `zxnu_emulator_ops.py`, 16 in `zxnu_sdcard_ops.py`, 6 elsewhere) and 28 dialog literals (21 of them the longer emulator prompt bodies). These are mostly multi-line composed strings needing `{named}` templates rather than simple wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)