### PR TITLE
SD Card tab: start CSpect on a file straight from the explorers

### DIFF
--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -35,6 +35,7 @@ SUITES = [
     ("test_hdfmonkey_discovery.py", 120, None),
     ("test_mame_install.py",     120, None),
     ("test_startup_tab_activation.py", 120, None),
+    ("test_cspect_autostart.py",  120, None),
     ("test_pane_imports.py",    120, None),
     ("test_hdf_workers.py",     120, None),
     ("test_classic_sync.py",    180, None),

--- a/tests/test_cspect_autostart.py
+++ b/tests/test_cspect_autostart.py
@@ -1,0 +1,118 @@
+"""CSpect auto-start tests (SD Card tab).
+
+With CSpect installed the SD Card tab offers two right-click actions that boot
+a file straight into the emulator:
+
+  * image explorer  -> "Start CSpect with file X"           (file already on
+                                                             the mounted image)
+  * local explorer  -> "Send to SD Card and start CSpect with file X"
+                       (upload into the image first, then start)
+
+Both end up appending the file to CSpect's command line, which CSpect resolves
+against the -mmc root:
+
+    CSpect.exe … -zxnext -mmc=<image> games/foo.nex
+
+Covered here: the extension gate that decides whether the actions are offered
+at all, and the source-level contract of the two menus (both must be gated on
+CSpect actually being installed, and must sit at the top of their menu). The
+launch itself needs a built MainWindow and a real emulator, so it is not run.
+
+Run with: python tests/test_cspect_autostart.py
+"""
+import ast
+import os
+import sys
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, REPO)
+
+from zxnu_config import (  # noqa: E402
+    CSPECT_AUTOSTART_EXTENSIONS,
+    cspect_can_autostart,
+)
+
+FAIL = []
+
+
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+# ---- the extension gate -------------------------------------------------
+check("a .nex is offered (the format the feature was asked for)",
+      cspect_can_autostart("/games/foo.nex"))
+check("matching is case-insensitive", cspect_can_autostart("/A.NEX")
+      and cspect_can_autostart("/b.SnA"))
+check("snapshots and tapes are offered too",
+      all(cspect_can_autostart("/x" + e) for e in CSPECT_AUTOSTART_EXTENSIONS))
+check("a readme is NOT offered (the menu stays useful)",
+      not cspect_can_autostart("/docs/readme.txt"))
+check("an extensionless name is not offered",
+      not cspect_can_autostart("/games/README"))
+check("empty / None are safe", not cspect_can_autostart("")
+      and not cspect_can_autostart(None))
+check("a name merely CONTAINING an extension is not offered",
+      not cspect_can_autostart("/games/nex-collection"))
+
+# ---- the launcher takes the file as a trailing argument -----------------
+src = open(os.path.join(REPO, "zxnu_emulator_ops.py"), encoding="utf-8").read()
+tree = ast.parse(src)
+fn = next((n for n in ast.walk(tree)
+           if isinstance(n, ast.FunctionDef) and n.name == "launch_cspect"), None)
+check("launch_cspect accepts the auto-start file", fn is not None
+      and any(a.arg == "autostart_file" for a in fn.args.args))
+if fn is not None:
+    body = ast.dump(fn)
+    # Qt hands clicked() slots a bool; that must not be mistaken for a path.
+    check("a Qt clicked() bool cannot be taken for a file name",
+          "isinstance" in body,
+          "launch_cspect is also a clicked() slot")
+    check("the file is appended after -mmc, not before",
+          src.index("-mmc=") < src.index("autostart_file.strip().lstrip"))
+
+# ---- both menus are gated on CSpect being installed ---------------------
+ops = open(os.path.join(REPO, "zxnu_sdcard_ops.py"), encoding="utf-8").read()
+for label, marker in (
+        ("image explorer", 'ui_tr_now("Start CSpect with file {name}")'),
+        ("local explorer",
+         'ui_tr_now("Send to SD Card and start CSpect with file {name}"')):
+    at = ops.find(marker)
+    check(f"the {label} action exists", at != -1)
+    if at == -1:
+        continue
+    # The gate is the `if` above the addAction. The local action's handler
+    # body sits in between, so look back far enough to clear it.
+    window = ops[max(0, at - 2600):at]
+    check(f"the {label} action is gated on CSpect being installed",
+          "_cspect_executable_path" in window, "no detection gate found")
+    check(f"the {label} action is gated on a bootable extension",
+          "cspect_can_autostart" in window)
+
+# It must be the FIRST entry of the image menu (asked for: top of the list).
+img_at = ops.find('ui_tr_now("Start CSpect with file {name}")')
+newfolder_at = ops.find("new_folder_label = ")
+check("the image-explorer action sits above the rest of that menu",
+      img_at != -1 and newfolder_at != -1 and img_at < newfolder_at,
+      f"cspect={img_at} newfolder={newfolder_at}")
+
+# The local action must upload BEFORE launching, and not launch on failure.
+loc_at = ops.find("def _send_and_start")
+seg = ops[loc_at:loc_at + 1400] if loc_at != -1 else ""
+check("the local action uploads first, then launches",
+      seg.index("image_upload_external_paths") > seg.index("_launch_cspect_fn")
+      or "on_complete=_after" in seg,
+      "upload must drive the launch through its completion callback")
+check("a failed transfer does not start CSpect",
+      "if not success" in seg)
+
+print()
+if FAIL:
+    print(f"{len(FAIL)} FAILURE(S): " + ", ".join(FAIL))
+    sys.exit(1)
+print("all CSpect auto-start checks passed")
+sys.exit(0)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -1107,6 +1107,19 @@ MAME_JOYSTICK = (("Joystick On", "-joystick"), ("Joystick Off", "-joystickprovid
 MAME_ESC = (("Disable ESC Key Off", ""), ("Disable ESC Key On", "-confirm_quit"))
 
 
+# File types CSpect can load and start straight from the command line (passed
+# as its trailing argument, resolved against the -mmc root). Used to decide
+# whether the SD Card tab offers its "start CSpect with this file" actions —
+# offering them on a readme.txt would just be noise.
+CSPECT_AUTOSTART_EXTENSIONS = (".nex", ".sna", ".z80", ".tap", ".tzx", ".trd",
+                               ".scl", ".dsk", ".slt", ".szx")
+
+
+def cspect_can_autostart(path):
+    """True when *path* looks like something CSpect can boot directly."""
+    return bool(path) and str(path).lower().endswith(CSPECT_AUTOSTART_EXTENSIONS)
+
+
 def emulator_option_argument(options, index):
     """The command-line argument for entry *index* of an emulator option tuple
     (any of the ``CSPECT_*`` / ``MAME_*`` ``(label, argument)`` tuples above),

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -235,7 +235,20 @@ def build_emulator_ops(
             execute_shell_command("vim", "./" + ZX_NEXT_UNITE_CONFIG_FILE_NAME)
         return
 
-    def launch_cspect():
+    def launch_cspect(autostart_file=None):
+        """Launch CSpect against the loaded SD image.
+
+        *autostart_file* is a path INSIDE that image (e.g. "games/foo.nex").
+        When given it is appended as CSpect's final argument, which makes
+        CSpect load and start it right after boot:
+
+            CSpect.exe … -zxnext -mmc=<image> games/foo.nex
+
+        Note the parameter is positional on purpose: this function is also a
+        clicked() slot, and Qt passes the button's `checked` bool to slots that
+        accept an argument. That bool is filtered out by the isinstance() check
+        below rather than by a keyword-only signature, which Qt handles less
+        predictably across PySide versions."""
         if _right_disk_content():  # check that we have an image content first
             set_all_buttons_disabled()
 
@@ -290,6 +303,14 @@ def build_emulator_ops(
             mmc_path = f'"{img_path}"' if img_path else img_path
 
             cspect_arguments += " -mmc=" + mmc_path + " "
+
+            # Auto-start a file that lives on the mounted image. CSpect takes
+            # it as a trailing argument, resolved relative to the -mmc root, so
+            # the in-image path is used with its leading slash stripped.
+            if isinstance(autostart_file, str) and autostart_file.strip():
+                _auto = autostart_file.strip().lstrip("/")
+                cspect_arguments += (f'"{_auto}" ' if " " in _auto
+                                     else _auto + " ")
 
             # The command that will actually be invoked: the bundled itch.io
             # copy by absolute path, otherwise the CSpect.exe resolved from the

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,15 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        # ---- CSpect auto-start actions (SD Card tab menus) ----
+        "Send to SD Card and start CSpect with file {name}":
+            "Enviar a la tarjeta SD e iniciar CSpect con el archivo {name}",
+        "Send to SD Card and start CSpect: the transfer failed, CSpect was not started.":
+            "Enviar a la tarjeta SD e iniciar CSpect: la transferencia falló; CSpect no se ha iniciado.",
+        "Sending {name} to the SD card image, then starting CSpect…":
+            "Enviando {name} a la imagen de la tarjeta SD y luego iniciando CSpect…",
+        "Start CSpect with file {name}":
+            "Iniciar CSpect con el archivo {name}",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Actualización de CSpect disponible",
@@ -1100,6 +1109,15 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        # ---- CSpect auto-start actions (SD Card tab menus) ----
+        "Send to SD Card and start CSpect with file {name}":
+            "Enviar para o cartão SD e iniciar o CSpect com o ficheiro {name}",
+        "Send to SD Card and start CSpect: the transfer failed, CSpect was not started.":
+            "Enviar para o cartão SD e iniciar o CSpect: a transferência falhou; o CSpect não foi iniciado.",
+        "Sending {name} to the SD card image, then starting CSpect…":
+            "A enviar {name} para a imagem do cartão SD e depois a iniciar o CSpect…",
+        "Start CSpect with file {name}":
+            "Iniciar o CSpect com o ficheiro {name}",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Atualização do CSpect disponível",
@@ -1781,6 +1799,15 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        # ---- CSpect auto-start actions (SD Card tab menus) ----
+        "Send to SD Card and start CSpect with file {name}":
+            "Wyślij na kartę SD i uruchom CSpect z plikiem {name}",
+        "Send to SD Card and start CSpect: the transfer failed, CSpect was not started.":
+            "Wyślij na kartę SD i uruchom CSpect: transfer nie powiódł się — CSpect nie został uruchomiony.",
+        "Sending {name} to the SD card image, then starting CSpect…":
+            "Wysyłanie {name} do obrazu karty SD, potem uruchomienie CSpect…",
+        "Start CSpect with file {name}":
+            "Uruchom CSpect z plikiem {name}",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Dostępna aktualizacja CSpect",
@@ -2463,6 +2490,15 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        # ---- CSpect auto-start actions (SD Card tab menus) ----
+        "Send to SD Card and start CSpect with file {name}":
+            "Отправить на SD-карту и запустить CSpect с файлом {name}",
+        "Send to SD Card and start CSpect: the transfer failed, CSpect was not started.":
+            "Отправка на SD-карту и запуск CSpect: передача не удалась — CSpect не запущен.",
+        "Sending {name} to the SD card image, then starting CSpect…":
+            "Отправка {name} в образ SD-карты, затем запуск CSpect…",
+        "Start CSpect with file {name}":
+            "Запустить CSpect с файлом {name}",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Доступно обновление CSpect",
@@ -3144,6 +3180,15 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        # ---- CSpect auto-start actions (SD Card tab menus) ----
+        "Send to SD Card and start CSpect with file {name}":
+            "Odeslat na SD kartu a spustit CSpect se souborem {name}",
+        "Send to SD Card and start CSpect: the transfer failed, CSpect was not started.":
+            "Odeslat na SD kartu a spustit CSpect: přenos selhal — CSpect nebyl spuštěn.",
+        "Sending {name} to the SD card image, then starting CSpect…":
+            "Odesílání {name} do obrazu SD karty, poté spuštění CSpectu…",
+        "Start CSpect with file {name}":
+            "Spustit CSpect se souborem {name}",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "K dispozici je aktualizace CSpectu",
@@ -3828,6 +3873,15 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        # ---- CSpect auto-start actions (SD Card tab menus) ----
+        "Send to SD Card and start CSpect with file {name}":
+            "Envoyer vers la carte SD et lancer CSpect avec le fichier {name}",
+        "Send to SD Card and start CSpect: the transfer failed, CSpect was not started.":
+            "Envoyer vers la carte SD et lancer CSpect : le transfert a échoué, CSpect n'a pas été lancé.",
+        "Sending {name} to the SD card image, then starting CSpect…":
+            "Envoi de {name} vers l'image de la carte SD, puis lancement de CSpect…",
+        "Start CSpect with file {name}":
+            "Lancer CSpect avec le fichier {name}",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Mise à jour de CSpect disponible",

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -2056,6 +2056,9 @@ class MainWindow(QMainWindow):
         build_local_explorer_ops(
             self,
             add_main_log_window=add_main_log_window,
+            # Read via the getter hook: right_disk_image_explorer_content is a
+            # module global in zxnu_main, so the builder must not capture it.
+            _right_disk_content=lambda: right_disk_image_explorer_content,
             nextsync_refresh_explorer=nextsync_refresh_explorer,
             _nextsync_unique_path=lambda *a, **k: _nextsync_unique_path(*a, **k),
             _run_nextsync_import_task=lambda *a, **k: _run_nextsync_import_task(*a, **k),

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -1439,6 +1439,7 @@ def build_local_explorer_ops(
     host,
     *,
     add_main_log_window,
+    _right_disk_content,
     nextsync_refresh_explorer,
     _nextsync_unique_path,
     _run_nextsync_import_task,
@@ -1583,6 +1584,38 @@ def build_local_explorer_ops(
             lambda: QTimer.singleShot(0, lambda: _local_zip_selection(
                 _local_explorer_selected_paths_or(file_path),
                 local_explorer_refresh, add_main_log_window)))
+        # "Send to SD Card and start CSpect with <file>" — top of the menu,
+        # offered only with CSpect installed, an image loaded, and a file
+        # CSpect can boot. It uploads into the folder the image explorer is
+        # showing and, once that succeeds, starts CSpect on the uploaded copy
+        # (the in-image path, which is what CSpect resolves against -mmc).
+        if (not is_dir and cspect_can_autostart(file_path)
+                and _right_disk_content()
+                and getattr(host, "_cspect_executable_path", None)
+                and getattr(host, "_launch_cspect_fn", None)
+                and getattr(host, "image_upload_external_paths", None)):
+            def _send_and_start(_p=file_path):
+                target = (host.diskimageexplorerpathinput.text() or "/").strip()
+                target = ("/" + target.strip("/")) if target.strip("/") else "/"
+                in_image = (target.rstrip("/") + "/" + os.path.basename(_p))
+
+                def _after(success):
+                    if not success:
+                        add_main_log_window(ui_tr_now(
+                            "Send to SD Card and start CSpect: the transfer "
+                            "failed, CSpect was not started."))
+                        return
+                    host._launch_cspect_fn(in_image)
+                add_main_log_window(ui_tr_now(
+                    "Sending {name} to the SD card image, then starting "
+                    "CSpect…").format(name=os.path.basename(_p)))
+                host.image_upload_external_paths([_p], target, on_complete=_after)
+            menu.addAction(
+                ui_tr_now("Send to SD Card and start CSpect with file {name}"
+                          ).format(name=name),
+                lambda: QTimer.singleShot(0, _send_and_start))
+            menu.addSeparator()
+
         menu.addAction(action_copy_text)
         menu.addAction(action_copy_path)
         menu.addSeparator()
@@ -2508,6 +2541,8 @@ def build_transfer_clipboard_ops(
         return None
 
     def image_upload_external_paths(paths, target_dir, on_complete=None):
+        # (exposed on host below so the LOCAL explorer's menu — built by a
+        # different builder — can upload a file before starting CSpect)
         """Copy local files/folders (e.g. dropped from Windows Explorer) into
         the loaded disk image under *target_dir*. *on_complete*, when given, is
         called with a single bool (True only if the upload finished without error
@@ -2841,6 +2876,23 @@ def build_transfer_clipboard_ops(
             is_dir = bool(name_item.data(IMG_ISDIR_ROLE)) if name_item is not None else False
 
             selected_count = len(host.image_selected_paths)
+
+            # "Start CSpect with <file>" — top of the menu, and only when
+            # CSpect is actually installed and the row is a file CSpect can
+            # boot. CSpect takes the in-image path as its trailing argument,
+            # resolved against the -mmc root, so the file must already live on
+            # the mounted image (which it does: this is the image explorer).
+            item_path = (name_item.data(IMG_PATH_ROLE) or "") \
+                if name_item is not None else ""
+            if (not is_dir and cspect_can_autostart(item_path)
+                    and getattr(host, "_cspect_executable_path", None)
+                    and getattr(host, "_launch_cspect_fn", None)):
+                menu.addAction(
+                    ui_tr_now("Start CSpect with file {name}").format(
+                        name=os.path.basename(item_path)),
+                    lambda p=item_path: host._launch_cspect_fn(p))
+                menu.addSeparator()
+
             new_folder_label = "New Folder Here…" if is_dir else "New Folder…"
             menu.addAction(new_folder_label, image_newfolder_dialog)
             menu.addSeparator()


### PR DESCRIPTION
Adds the two right-click actions you described, plus their tests.

## The actions

Both sit at the **top** of their menu and appear only when CSpect is actually installed:

| Explorer | Action | Behaviour |
|---|---|---|
| Image (right) | **Start CSpect with file X** | the file is already on the mounted image, so CSpect launches on it directly |
| Local (left) | **Send to SD Card and start CSpect with file X** | uploads into the folder the image explorer is showing, then starts CSpect — **only if the transfer succeeded** |

## The command

`launch_cspect()` gained an optional `autostart_file`, appended after `-mmc` as CSpect's trailing argument:

```
CSpect.exe … -zxnext -mmc=<image> games/foo.nex
```

The in-image path is used with its leading slash stripped (CSpect resolves it against the MMC root) and quoted when it contains spaces. The app already passes `-mmc=<loaded image>`, so the image *is* the SD root — nothing else needed changing.

One subtlety worth flagging: the parameter is **positional, not keyword-only**. `launch_cspect` is also a `clicked()` slot, and Qt hands such slots the button's `checked` bool. An `isinstance(autostart_file, str)` check filters that out, which behaves consistently across PySide versions where a keyword-only signature does not.

## Scope of the offer

The actions appear only for files CSpect can boot — `CSPECT_AUTOSTART_EXTENSIONS`: `.nex` plus the common snapshot/tape/disk formats. Without that gate every `readme.txt` would grow a "start CSpect with…" entry at the top of its menu. All four new strings are translated into the seven languages.

## A bug the tripwire caught

`build_local_explorer_ops` had no `_right_disk_content` parameter, and my new gate needs to know an image is loaded. `tests/test_pane_imports` failed on the unresolved free variable — the strangler seam's free-variable check doing exactly what it exists for. Plumbed through properly via the getter hook rather than capturing the module global.

## Tests

`tests/test_cspect_autostart.py` covers the extension gate (including that a name merely *containing* `.nex` is not matched, and that matching is case-insensitive), that both actions are gated on CSpect being detected **and** on a bootable extension, that the image action sits above the rest of its menu, and that a failed transfer does not launch CSpect. Verified non-vacuous by removing a gate and confirming the check fails.

`ruff check .` and the full suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)