### PR TITLE
Fix "Start CSpect with file" on the image explorer: extract to the host first

### DIFF
--- a/tests/test_cspect_autostart.py
+++ b/tests/test_cspect_autostart.py
@@ -73,7 +73,37 @@ if fn is not None:
           "isinstance" in body,
           "launch_cspect is also a clicked() slot")
     check("the file is appended after -mmc, not before",
-          src.index("-mmc=") < src.index("autostart_file.strip().lstrip"))
+          src.index("-mmc=") < src.index("autostart_file.strip"))
+    # THE bug this feature shipped with: CSpect resolves the trailing argument
+    # against its own working directory, so an in-image path made it look for
+    # <cspect dir>/<in-image path> and fail. The argument must be an absolute
+    # HOST path, and must NOT have a leading slash stripped (that would maim
+    # /tmp/... on POSIX).
+    check("the auto-start argument is made an absolute host path",
+          "os.path.abspath(autostart_file" in src)
+    check("no leading-slash stripping (host path, not an image path)",
+          'autostart_file.strip().lstrip("/")' not in src)
+
+# ---- booting a file that lives on the image must extract it first --------
+ops_src = open(os.path.join(REPO, "zxnu_sdcard_ops.py"), encoding="utf-8").read()
+check("there is an extract-then-launch step for image files",
+      "def _cspect_start_from_image" in ops_src)
+seg_img = ops_src[ops_src.find("def _cspect_start_from_image"):]
+seg_img = seg_img[:seg_img.find("def _image_remote_zip")]
+check("it pulls the file out of the image with the hdfmonkey helper",
+      "image_get_paths_to_local" in seg_img)
+check("it launches the EXTRACTED host copy, not the in-image path",
+      "_launch_cspect_fn(local)" in seg_img)
+check("a failed extraction does not start CSpect",
+      "could not be read from the image" in seg_img)
+
+# The local action must launch the LOCAL file, never the in-image copy.
+seg_loc = ops_src[ops_src.find("def _send_and_start"):]
+seg_loc = seg_loc[:seg_loc.find("menu.addAction")]
+check("the local action starts CSpect on the local (host) file",
+      "_launch_cspect_fn(_p)" in seg_loc)
+check("...and no longer builds an in-image path to hand to CSpect",
+      "in_image" not in seg_loc)
 
 # ---- both menus are gated on CSpect being installed ---------------------
 ops = open(os.path.join(REPO, "zxnu_sdcard_ops.py"), encoding="utf-8").read()

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -238,11 +238,17 @@ def build_emulator_ops(
     def launch_cspect(autostart_file=None):
         """Launch CSpect against the loaded SD image.
 
-        *autostart_file* is a path INSIDE that image (e.g. "games/foo.nex").
-        When given it is appended as CSpect's final argument, which makes
-        CSpect load and start it right after boot:
+        *autostart_file* is a HOST path to a file CSpect should load and start
+        right after boot; it is appended as CSpect's final argument:
 
-            CSpect.exe … -zxnext -mmc=<image> games/foo.nex
+            CSpect.exe … -zxnext -mmc=<image> C:\\tmp\\foo.nex
+
+        It must be a host path, NOT a path inside the mounted image: CSpect
+        resolves this argument against its own working directory, so an
+        in-image path sends it looking for <cspect dir>/<that path> and it
+        fails with "Could not find a part of the path". A caller that wants to
+        boot something living on the image has to extract it to the host first
+        (see _cspect_start_from_image in zxnu_sdcard_ops).
 
         Note the parameter is positional on purpose: this function is also a
         clicked() slot, and Qt passes the button's `checked` bool to slots that
@@ -304,13 +310,14 @@ def build_emulator_ops(
 
             cspect_arguments += " -mmc=" + mmc_path + " "
 
-            # Auto-start a file that lives on the mounted image. CSpect takes
-            # it as a trailing argument, resolved relative to the -mmc root, so
-            # the in-image path is used with its leading slash stripped.
+            # Auto-start file: a HOST path, appended as CSpect's trailing
+            # argument. It is made absolute because CSpect may run from its
+            # own folder (the bundled itch.io copy does), and always quoted —
+            # this goes through the shell and Next files live under paths with
+            # spaces often enough.
             if isinstance(autostart_file, str) and autostart_file.strip():
-                _auto = autostart_file.strip().lstrip("/")
-                cspect_arguments += (f'"{_auto}" ' if " " in _auto
-                                     else _auto + " ")
+                _auto = os.path.abspath(autostart_file.strip().strip('"'))
+                cspect_arguments += f'"{_auto}" '
 
             # The command that will actually be invoked: the bundled itch.io
             # copy by absolute path, otherwise the CSpect.exe resolved from the

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,10 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        "Extracting {name} from the image, then starting CSpect…":
+            "Extrayendo {name} de la imagen y luego iniciando CSpect…",
+        "Start CSpect: {name} could not be read from the image, CSpect was not started.":
+            "Iniciar CSpect: no se pudo leer {name} de la imagen; CSpect no se ha iniciado.",
         # ---- CSpect auto-start actions (SD Card tab menus) ----
         "Send to SD Card and start CSpect with file {name}":
             "Enviar a la tarjeta SD e iniciar CSpect con el archivo {name}",
@@ -1109,6 +1113,10 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        "Extracting {name} from the image, then starting CSpect…":
+            "A extrair {name} da imagem e depois a iniciar o CSpect…",
+        "Start CSpect: {name} could not be read from the image, CSpect was not started.":
+            "Iniciar o CSpect: não foi possível ler {name} da imagem; o CSpect não foi iniciado.",
         # ---- CSpect auto-start actions (SD Card tab menus) ----
         "Send to SD Card and start CSpect with file {name}":
             "Enviar para o cartão SD e iniciar o CSpect com o ficheiro {name}",
@@ -1799,6 +1807,10 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        "Extracting {name} from the image, then starting CSpect…":
+            "Wypakowywanie {name} z obrazu, potem uruchomienie CSpect…",
+        "Start CSpect: {name} could not be read from the image, CSpect was not started.":
+            "Uruchom CSpect: nie udało się odczytać {name} z obrazu — CSpect nie został uruchomiony.",
         # ---- CSpect auto-start actions (SD Card tab menus) ----
         "Send to SD Card and start CSpect with file {name}":
             "Wyślij na kartę SD i uruchom CSpect z plikiem {name}",
@@ -2490,6 +2502,10 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        "Extracting {name} from the image, then starting CSpect…":
+            "Извлечение {name} из образа, затем запуск CSpect…",
+        "Start CSpect: {name} could not be read from the image, CSpect was not started.":
+            "Запуск CSpect: не удалось прочитать {name} из образа — CSpect не запущен.",
         # ---- CSpect auto-start actions (SD Card tab menus) ----
         "Send to SD Card and start CSpect with file {name}":
             "Отправить на SD-карту и запустить CSpect с файлом {name}",
@@ -3180,6 +3196,10 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        "Extracting {name} from the image, then starting CSpect…":
+            "Rozbaluje se {name} z obrazu, poté se spustí CSpect…",
+        "Start CSpect: {name} could not be read from the image, CSpect was not started.":
+            "Spustit CSpect: {name} se nepodařilo načíst z obrazu — CSpect nebyl spuštěn.",
         # ---- CSpect auto-start actions (SD Card tab menus) ----
         "Send to SD Card and start CSpect with file {name}":
             "Odeslat na SD kartu a spustit CSpect se souborem {name}",
@@ -3873,6 +3893,10 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        "Extracting {name} from the image, then starting CSpect…":
+            "Extraction de {name} depuis l'image, puis lancement de CSpect…",
+        "Start CSpect: {name} could not be read from the image, CSpect was not started.":
+            "Lancer CSpect : impossible de lire {name} depuis l'image, CSpect n'a pas été lancé.",
         # ---- CSpect auto-start actions (SD Card tab menus) ----
         "Send to SD Card and start CSpect with file {name}":
             "Envoyer vers la carte SD et lancer CSpect avec le fichier {name}",

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -1597,7 +1597,6 @@ def build_local_explorer_ops(
             def _send_and_start(_p=file_path):
                 target = (host.diskimageexplorerpathinput.text() or "/").strip()
                 target = ("/" + target.strip("/")) if target.strip("/") else "/"
-                in_image = (target.rstrip("/") + "/" + os.path.basename(_p))
 
                 def _after(success):
                     if not success:
@@ -1605,7 +1604,12 @@ def build_local_explorer_ops(
                             "Send to SD Card and start CSpect: the transfer "
                             "failed, CSpect was not started."))
                         return
-                    host._launch_cspect_fn(in_image)
+                    # CSpect is started on the LOCAL file, not on the copy just
+                    # written into the image: its trailing argument is resolved
+                    # against CSpect's working directory, so it must be a host
+                    # path. The image copy is what the program will find on the
+                    # SD card once it is running.
+                    host._launch_cspect_fn(_p)
                 add_main_log_window(ui_tr_now(
                     "Sending {name} to the SD card image, then starting "
                     "CSpect…").format(name=os.path.basename(_p)))
@@ -2790,6 +2794,42 @@ def build_transfer_clipboard_ops(
             [(zip_path, False)], tmp, refresh_fn=lambda: None,
             on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
 
+    def _cspect_start_from_image(image_path):
+        """Boot a file that lives INSIDE the mounted image with CSpect.
+
+        CSpect resolves its trailing file argument against its own working
+        directory — a HOST path — not against the -mmc root, so passing the
+        in-image path makes it look for <cspect dir>/<in-image path> and fail
+        with "Could not find a part of the path". The file therefore has to
+        exist on the host first: extract it (and nothing else) into a temp
+        folder with hdfmonkey, then start CSpect on that copy. The image stays
+        mounted as the SD card, so anything the program loads from the card
+        still resolves.
+
+        The temp copy is deliberately NOT deleted on completion: CSpect is
+        launched detached and reads the file after we return."""
+        if not _right_disk_content() or not image_path:
+            return
+        name = os.path.basename(image_path)
+        tmp = tempfile.mkdtemp(prefix="zxnu-cspect-")
+
+        def _go(ok):
+            local = os.path.join(tmp, name)
+            if not ok or not os.path.isfile(local):
+                add_main_log_window(ui_tr_now(
+                    "Start CSpect: {name} could not be read from the image, "
+                    "CSpect was not started.").format(name=name))
+                shutil.rmtree(tmp, ignore_errors=True)
+                return
+            host._launch_cspect_fn(local)
+
+        add_main_log_window(ui_tr_now(
+            "Extracting {name} from the image, then starting CSpect…").format(
+                name=name))
+        image_get_paths_to_local(
+            [(image_path, False)], tmp, refresh_fn=lambda: None,
+            on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
+
     def _image_remote_zip(items):
         """'Remote Zip' on the image selection: get the items to a temp
         dir, zip them on the PC, upload <first item>.zip back into the
@@ -2890,7 +2930,8 @@ def build_transfer_clipboard_ops(
                 menu.addAction(
                     ui_tr_now("Start CSpect with file {name}").format(
                         name=os.path.basename(item_path)),
-                    lambda p=item_path: host._launch_cspect_fn(p))
+                    lambda p=item_path: QTimer.singleShot(
+                        0, lambda: _cspect_start_from_image(p)))
                 menu.addSeparator()
 
             new_folder_label = "New Folder Here…" if is_dir else "New Folder…"


### PR DESCRIPTION
Fixes the error reported against #235:

> Error loading file ("games/Next/AngryBloaters/Bloaters.nex"): Could not find a part of the path `…\CSpect3_3_1_0\games\Next\AngryBloaters\Bloaters.nex`

## What I got wrong

I assumed CSpect resolves its trailing file argument against the `-mmc` root. **It doesn't** — it resolves it against its own working directory, so passing the in-image path sent CSpect looking for `<cspect dir>\games\Next\…` on the host filesystem. The error message says exactly that, and it's the giveaway I should have anticipated: the file lives *inside* the HDF image, so nothing on the host can open it by that path.

So yes — to your question — it needs extracting first, and it wasn't.

## The fix

**Image explorer.** `_cspect_start_from_image` pulls just that one entry out of the image into a temp folder using the existing hdfmonkey helper (`image_get_paths_to_local`), then starts CSpect on the extracted copy. A failed extraction logs and does not launch. The temp copy is deliberately not deleted — CSpect is launched detached and reads the file after we return. The image stays mounted as the SD card, so anything the program loads from the card still resolves.

**Local explorer.** Same fault, less visibly: it started CSpect on the path of the copy it had just written *into* the image. It now starts CSpect on the local file, which was a host path all along. The image copy is what the program finds on the SD card once running.

**`launch_cspect`.** No longer strips a leading slash from the argument — that was in-image thinking, and would have maimed `/tmp/…` on POSIX. The path is now made absolute (the bundled itch.io CSpect runs from its own folder, so a relative path would resolve against the wrong place) and always quoted.

## Tests

`tests/test_cspect_autostart.py` now pins the contract this got wrong: the argument must be an **absolute host path** with no leading-slash stripping; the image action must go through the extract step and launch the *extracted* copy; a failed extraction must not launch; and the local action must launch the local file rather than an in-image path. I confirmed the host-path checks fail when the old handling is put back.

`ruff check .` and the full suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)