### PR TITLE
i18n: localise the emulator update prompts and the last console lines

### DIFF
--- a/zxnu_config_io.py
+++ b/zxnu_config_io.py
@@ -948,12 +948,14 @@ def build_config_io(
 
             if ZX_NEXT_UNITE_VERBOSE_LOG_MODE:
                 logging.info("Configuration file saved successfully.")
-                add_main_log_window("Saved configuration file.")
+                add_main_log_window(ui_tr_now("Saved configuration file."))
 
 
         except IOError as e:
             logging.error(f"Failed to save configuration file with IOError: {e}")
-            add_main_log_window(f"Failed to save configuration file with IOError: {e}")
+            add_main_log_window(ui_tr_now(
+                "Failed to save configuration file with IOError: {error}"
+            ).format(error=e))
         except Exception as e:
             logging.error(f"An unexpected error occurred while saving the configuration file. Exception: {e}")
             add_main_log_window(f"An unexpected error occurred while saving the configuration file. Exception: {e}")

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -511,7 +511,8 @@ def build_emulator_ops(
                 )
         except Exception as ex:
             logging.error(f"ERROR: Failed to launch MAME: {ex}")
-            add_main_log_window(f"ERROR: Failed to launch MAME: {ex}")
+            add_main_log_window(ui_tr_now(
+                "ERROR: Failed to launch MAME: {error}").format(error=ex))
             return
 
         # Marshal captured output back to the UI thread via queued signals
@@ -530,7 +531,8 @@ def build_emulator_ops(
         mame_signals.output.connect(_on_mame_output, Qt.QueuedConnection)
 
         def _on_mame_finished(return_code):
-            add_main_log_window(f"MAME exited with code {return_code}.")
+            add_main_log_window(ui_tr_now(
+                "MAME exited with code {code}.").format(code=return_code))
             logging.info(f"MAME exited with code {return_code}.")
             # MAME aborts when the ZX Spectrum Next boot ROM (TBBLUE, e.g.
             # boot-30204.bin) is absent — a manual step the auto-install
@@ -661,14 +663,15 @@ def build_emulator_ops(
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
         box.setWindowTitle(title)
-        box.setText(
-            f"MAME release: {release['tag']}\n"
-            f"Package: {release['asset_name']} ({arch})\n\n"
-            f"Download (~{size_txt}) and install it into the downloads "
-            f"folder?\nNote: the fully extracted install is large (~500 MB).")
+        box.setText(ui_tr_now(
+            "MAME release: {tag}\nPackage: {asset} ({arch})\n\n"
+            "Download (~{size}) and install it into the downloads folder?\n"
+            "Note: the fully extracted install is large (~500 MB).").format(
+                tag=release["tag"], asset=release["asset_name"], arch=arch,
+                size=size_txt))
         _attach_release_notes(box, release.get("notes"))
         go = box.addButton(ui_tr_now("Download and install"), QMessageBox.AcceptRole)
-        box.addButton("Cancel", QMessageBox.RejectRole)
+        box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(go)
         box.exec()
         if box.clickedButton() is not go:
@@ -697,7 +700,8 @@ def build_emulator_ops(
         try:
             releases = _fetch_mame_releases(arch)
         except Exception as e:
-            add_main_log_window(f"Could not list the MAME releases: {e}")
+            add_main_log_window(ui_tr_now(
+                "Could not list the MAME releases: {error}").format(error=e))
             logging.error(f"MAME release listing failed: {e}")
             QMessageBox.warning(
                 host, title,
@@ -885,7 +889,9 @@ def build_emulator_ops(
         # goes in a 'roms' folder next to the mame binary; compute that from
         # the detected path so the hint is right wherever the build unpacked.
         roms_dir = os.path.join(os.path.dirname(detected), "roms")
-        add_main_log_window(f"MAME install ▸ SUCCESS — MAME detected at: {detected}")
+        add_main_log_window(ui_tr_now(
+            "MAME install ▸ SUCCESS — MAME detected at: {path}").format(
+                path=detected))
         add_main_log_window(ui_tr_now(
             "MAME is ready to launch now — no restart needed. Use the "
             "'🕹  Launch Mame' button."))
@@ -1049,7 +1055,7 @@ def build_emulator_ops(
             return
         excerpt = "\n".join(notes.splitlines()[:10]).strip()[:800]
         box.setInformativeText(
-            "What's changed:\n" + excerpt
+            ui_tr_now("What's changed:") + "\n" + excerpt
             + ("\n…" if len(excerpt) < len(notes) else ""))
         box.setDetailedText(notes)
 
@@ -1068,20 +1074,22 @@ def build_emulator_ops(
         box.setIcon(QMessageBox.Question)
         box.setWindowTitle(ui_tr_now("MAME update available"))
         box.setText(
-            "A newer version of MAME is available.\n\n"
-            f"Installed: 0.{installed_num}\n"
-            f"Latest: {tag}  (0.{latest_num})\n"
-            f"Package: {asset_name}\n\n"
-            f"Download (~{size_txt}) and update your MAME install now?\n"
-            "The existing files in the downloads MAME folder will be "
-            "overwritten.")
+            ui_tr_now(
+                "A newer version of MAME is available.\n\n"
+                "Installed: 0.{installed}\nLatest: {latest}  (0.{latest_num})\n"
+                "Package: {asset}\n\n"
+                "Download (~{size}) and update your MAME install now?\n"
+                "The existing files in the downloads MAME folder will be "
+                "overwritten.").format(
+                    installed=installed_num, latest=tag,
+                    latest_num=latest_num, asset=asset_name, size=size_txt))
         _attach_release_notes(box, info.get("notes"))
         upd = box.addButton(ui_tr_now("Update"), QMessageBox.AcceptRole)
         # Escape hatch to any other recent release — including an older one,
         # which is how the update path itself can be exercised again.
         other = box.addButton(
             ui_tr_now("Choose another release…"), QMessageBox.ActionRole)
-        box.addButton("Cancel", QMessageBox.RejectRole)
+        box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(upd)
         box.exec()
         clicked = box.clickedButton()
@@ -1237,25 +1245,32 @@ def build_emulator_ops(
         box.setIcon(QMessageBox.Question)
         box.setWindowTitle(ui_tr_now("Update downloaded"))
         box.setText(
-            "The new version was saved as:\n\n"
-            f"{new_path}\n\n"
-            f"Close ZX Next Unite now and start the new version ({name})?\n"
-            "Your settings (hdfg.cfg) and downloads are picked up as-is —\n"
-            "both versions run from the same folder." + gatekeeper_note)
-        yes = box.addButton(f"Close and start {name}", QMessageBox.AcceptRole)
+            ui_tr_now(
+                "The new version was saved as:\n\n{path}\n\n"
+                "Close ZX Next Unite now and start the new version ({name})?\n"
+                "Your settings (hdfg.cfg) and downloads are picked up as-is —\n"
+                "both versions run from the same folder.").format(
+                    path=new_path, name=name) + gatekeeper_note)
+        yes = box.addButton(
+            ui_tr_now("Close and start {name}").format(name=name),
+            QMessageBox.AcceptRole)
         box.addButton(ui_tr_now("Later"), QMessageBox.RejectRole)
         box.setDefaultButton(yes)
         box.exec()
         if box.clickedButton() is not yes:
-            add_main_log_window(
-                f"ZX Next Unite update: downloaded — start it any time: {new_path}")
+            add_main_log_window(ui_tr_now(
+                "ZX Next Unite update: downloaded — start it any time: {path}"
+            ).format(path=new_path))
             return
-        add_main_log_window(f"ZX Next Unite update: starting {name} and closing…")
+        add_main_log_window(ui_tr_now(
+            "ZX Next Unite update: starting {name} and closing…").format(name=name))
         try:
             launch = ["open", new_path] if is_app_bundle else [new_path]
             subprocess.Popen(launch, cwd=os.path.dirname(new_path) or None)
         except OSError as exc:
-            add_main_log_window(f"ZX Next Unite update: could not start {name}: {exc}")
+            add_main_log_window(ui_tr_now(
+                "ZX Next Unite update: could not start {name}: {error}").format(
+                    name=name, error=exc))
             QMessageBox.critical(host, "Could not start the new version",
                                  f"{new_path}\n\n{exc}")
             return
@@ -1352,8 +1367,9 @@ def build_emulator_ops(
                        " (no SHA-256 digest published; not verified)."))
                 runnable = holder["runnable"] or dest
                 if runnable != dest:
-                    add_main_log_window(
-                        f"ZX Next Unite update: unpacked to {runnable}")
+                    add_main_log_window(ui_tr_now(
+                        "ZX Next Unite update: unpacked to {path}").format(
+                            path=runnable))
                 _zxnu_offer_restart(runnable)
             elif holder["error"] == "cancelled":
                 add_main_log_window(ui_tr_now(
@@ -1370,8 +1386,9 @@ def build_emulator_ops(
                     f"but unpacking failed:\n{holder['error']}\n\n"
                     "You can extract it manually next to the current app.")
             else:
-                add_main_log_window(
-                    f"ZX Next Unite update: download FAILED: {holder['error']}")
+                add_main_log_window(ui_tr_now(
+                    "ZX Next Unite update: download FAILED: {error}").format(
+                        error=holder["error"]))
                 QMessageBox.critical(host, "Update download failed",
                                      f"Could not download the update:\n{holder['error']}")
 
@@ -1442,11 +1459,13 @@ def build_emulator_ops(
             "when to switch (you'll be offered a restart after the download).")
         _attach_notes(box)
         dl = box.addButton("Download", QMessageBox.AcceptRole)
-        box.addButton("Cancel", QMessageBox.RejectRole)
+        box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(dl)
         box.exec()
         if box.clickedButton() is dl:
-            add_main_log_window(f"ZX Next Unite update ▸ downloading {asset_name}…")
+            add_main_log_window(ui_tr_now(
+                "ZX Next Unite update ▸ downloading {asset}…").format(
+                    asset=asset_name))
             _zxnu_download_update(tag, asset_name, url, size,
                                   expected_sha256=sha256)
         else:
@@ -1491,8 +1510,10 @@ def build_emulator_ops(
                     ).format(installed=ZX_NEXT_UNITE_VERSION, latest=tag))
                     return
                 add_main_log_window(
-                    f"ZX Next Unite update available: {tag} "
-                    f"(installed {ZX_NEXT_UNITE_VERSION}).")
+                    ui_tr_now("ZX Next Unite update available: {latest} "
+                              "(installed {installed}).").format(
+                                  latest=tag,
+                                  installed=ZX_NEXT_UNITE_VERSION))
                 _prompt_zxnu_update(tag, release)
             except Exception as exc:
                 logging.info(f"ZXNU update check result handling failed: {exc}")
@@ -1654,7 +1675,8 @@ def build_emulator_ops(
             host._cspect_update_installing = False
             detail = (err[1] if isinstance(err, (tuple, list)) and len(err) > 1
                       else err)
-            add_main_log_window(f"CSpect update ▸ FAILED — {detail}")
+            add_main_log_window(ui_tr_now(
+            "CSpect update ▸ FAILED — {error}").format(error=detail))
             logging.error(f"CSpect update failed: {detail}")
             try:
                 QMessageBox.warning(
@@ -1684,12 +1706,13 @@ def build_emulator_ops(
             "Download and install the newest version now?")
         _attach_release_notes(box, info.get("notes"))
         yes = box.addButton(ui_tr_now("Yes"), QMessageBox.AcceptRole)
-        box.addButton("Cancel", QMessageBox.RejectRole)
+        box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(yes)
         box.exec()
         if box.clickedButton() is yes:
             add_main_log_window(
-                f"CSpect update ▸ user chose to update to {latest_name}.")
+                ui_tr_now("CSpect update ▸ user chose to update to {name}."
+                          ).format(name=latest_name))
             _start_cspect_update_install(info)
         else:
             add_main_log_window(ui_tr_now(
@@ -1746,7 +1769,7 @@ def build_emulator_ops(
             try:
                 skip = info.get("skip")
                 if skip:
-                    add_main_log_window(f"CSpect update check: {skip}.")
+                    add_main_log_window(ui_tr_now("CSpect update check: {reason}.").format(reason=skip))
                     return
                 installed_name = info.get("installed_name")
                 latest_name = info.get("version_name")
@@ -1757,8 +1780,10 @@ def build_emulator_ops(
                     ).format(installed=installed_name, latest=latest_name))
                     return
                 add_main_log_window(
-                    f"CSpect update ▸ newer build available: installed "
-                    f"{installed_name}, latest {latest_name}.")
+                    ui_tr_now("CSpect update ▸ newer build available: "
+                              "installed {installed}, latest {latest}."
+                              ).format(installed=installed_name,
+                                       latest=latest_name))
                 # itch.io's download API carries no per-build changelog, so
                 # point at the CSpect itch.io page where the release notes
                 # live (the shared helper shows this as the "what's changed"
@@ -2105,10 +2130,11 @@ def build_hdfmonkey_install_ops(
             f"below opens it so nothing needs to be typed:\n"
             f"    {downloads_root}\n"
             "4. Click \"I've dropped the zip - try again\".")
-        open_page_btn = box.addButton("Open download page", QMessageBox.ActionRole)
-        open_folder_btn = box.addButton("Open downloads folder", QMessageBox.ActionRole)
-        retry_btn = box.addButton("I've dropped the zip - try again", QMessageBox.AcceptRole)
-        box.addButton("Cancel", QMessageBox.RejectRole)
+        open_page_btn = box.addButton(ui_tr_now("Open download page"), QMessageBox.ActionRole)
+        open_folder_btn = box.addButton(ui_tr_now("Open downloads folder"), QMessageBox.ActionRole)
+        retry_btn = box.addButton(ui_tr_now("I've dropped the zip - try again"),
+                                QMessageBox.AcceptRole)
+        box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(retry_btn)
         while True:
             box.exec()
@@ -2199,8 +2225,9 @@ def build_hdfmonkey_install_ops(
             "Do you still want to install hdfmonkey only, or abort and then "
             "make an end-to-end install of CSpect using itch.io?")
         continue_btn = box.addButton(
-            "Continue hdfmonkey standalone install", QMessageBox.AcceptRole)
-        box.addButton("Cancel", QMessageBox.RejectRole)
+            ui_tr_now("Continue hdfmonkey standalone install"),
+            QMessageBox.AcceptRole)
+        box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(continue_btn)
         box.exec()
         if box.clickedButton() is continue_btn:

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,76 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        # ---- emulator update prompts (bodies + buttons) ----
+        "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
+            "Hay una versión más reciente de MAME.\n\nInstalada: 0.{installed}\nÚltima: {latest}  (0.{latest_num})\nPaquete: {asset}\n\n¿Descargar (~{size}) y actualizar tu instalación de MAME ahora?\nLos archivos existentes en la carpeta MAME se sobrescribirán.",
+        "Close and start {name}":
+            "Cerrar e iniciar {name}",
+        "Continue hdfmonkey standalone install":
+            "Continuar con la instalación independiente de hdfmonkey",
+        "I've dropped the zip - try again":
+            "Ya he puesto el zip: inténtalo de nuevo",
+        "MAME release: {tag}\nPackage: {asset} ({arch})\n\nDownload (~{size}) and install it into the downloads folder?\nNote: the fully extracted install is large (~500 MB).":
+            "Versión de MAME: {tag}\nPaquete: {asset} ({arch})\n\n¿Descargar (~{size}) e instalarlo en la carpeta de descargas?\nNota: la instalación completa ocupa bastante (~500 MB).",
+        "Open download page":
+            "Abrir la página de descarga",
+        "Open downloads folder":
+            "Abrir la carpeta de descargas",
+        "The new version was saved as:\n\n{path}\n\nClose ZX Next Unite now and start the new version ({name})?\nYour settings (hdfg.cfg) and downloads are picked up as-is —\nboth versions run from the same folder.":
+            "La nueva versión se guardó como:\n\n{path}\n\n¿Cerrar ZX Next Unite ahora e iniciar la nueva versión ({name})?\nTus ajustes (hdfg.cfg) y descargas se reutilizan tal cual —\nambas versiones se ejecutan desde la misma carpeta.",
+        "What's changed:":
+            "Novedades:",
+        # ---- emulator / config console (final batch) ----
+        "CSpect update check: {reason}.":
+            "Comprobación de CSpect: {reason}.",
+        "CSpect update ▸ FAILED — {error}":
+            "Actualización de CSpect ▸ FALLÓ — {error}",
+        "CSpect update ▸ newer build available: installed {installed}, latest {latest}.":
+            "Actualización de CSpect ▸ hay una compilación más reciente: instalada {installed}, última {latest}.",
+        "CSpect update ▸ user chose to update to {name}.":
+            "Actualización de CSpect ▸ el usuario eligió actualizar a {name}.",
+        "Could not list the MAME releases: {error}":
+            "No se pudieron listar las versiones de MAME: {error}",
+        "ERROR: Failed to launch MAME: {error}":
+            "ERROR: no se pudo iniciar MAME: {error}",
+        "ERROR: could not extract {name}: {error}":
+            "ERROR: no se pudo extraer {name}: {error}",
+        "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
+            "ERROR: hdfmonkey falló - no se puede abrir un archivo; esto suele deberse a caracteres extraños como comillas y signos",
+        "ERROR: hdfmonkey failed - A file can't be opened: {command} this is commonly caused by strange characters such as quotes and signs":
+            "ERROR: hdfmonkey falló - no se puede abrir un archivo: {command}; esto suele deberse a caracteres extraños como comillas y signos",
+        "Failed to save configuration file with IOError: {error}":
+            "Error al guardar el archivo de configuración (IOError): {error}",
+        "Found hdfmonkey alongside CSpect: {path}":
+            "hdfmonkey encontrado junto a CSpect: {path}",
+        "MAME exited with code {code}.":
+            "MAME finalizó con el código {code}.",
+        "MAME install ▸ SUCCESS — MAME detected at: {path}":
+            "Instalación de MAME ▸ CORRECTA — MAME detectado en: {path}",
+        "Pygame mode unavailable — run: pip install pygame-ce":
+            "Modo pygame no disponible — ejecuta: pip install pygame-ce",
+        "Remote unzip: fetching {path} from the image …":
+            "Descompresión remota: obteniendo {path} de la imagen …",
+        "Remote zip: fetching {count} item(s) from the image …":
+            "Compresión remota: obteniendo {count} elemento(s) de la imagen …",
+        "Saved configuration file.":
+            "Archivo de configuración guardado.",
+        "UI language set to '{lang}' to match the system language — change it on the Settings tab.":
+            "Idioma de la interfaz ajustado a '{lang}' para coincidir con el del sistema; puedes cambiarlo en la pestaña Ajustes.",
+        "ZX Next Unite update available: {latest} (installed {installed}).":
+            "Actualización de ZX Next Unite disponible: {latest} (instalada {installed}).",
+        "ZX Next Unite update ▸ downloading {asset}…":
+            "Actualización de ZX Next Unite ▸ descargando {asset}…",
+        "ZX Next Unite update: could not start {name}: {error}":
+            "Actualización de ZX Next Unite: no se pudo iniciar {name}: {error}",
+        "ZX Next Unite update: download FAILED: {error}":
+            "Actualización de ZX Next Unite: la descarga FALLÓ: {error}",
+        "ZX Next Unite update: downloaded — start it any time: {path}":
+            "Actualización de ZX Next Unite: descargada; puedes iniciarla cuando quieras: {path}",
+        "ZX Next Unite update: starting {name} and closing…":
+            "Actualización de ZX Next Unite: iniciando {name} y cerrando…",
+        "ZX Next Unite update: unpacked to {path}":
+            "Actualización de ZX Next Unite: descomprimida en {path}",
         "Extracting {name} from the image, then starting CSpect…":
             "Extrayendo {name} de la imagen y luego iniciando CSpect…",
         "Start CSpect: {name} could not be read from the image, CSpect was not started.":
@@ -1113,6 +1183,76 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        # ---- emulator update prompts (bodies + buttons) ----
+        "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
+            "Existe uma versão mais recente do MAME.\n\nInstalada: 0.{installed}\nMais recente: {latest}  (0.{latest_num})\nPacote: {asset}\n\nTransferir (~{size}) e atualizar a instalação do MAME agora?\nOs ficheiros existentes na pasta MAME serão substituídos.",
+        "Close and start {name}":
+            "Fechar e iniciar {name}",
+        "Continue hdfmonkey standalone install":
+            "Continuar a instalação autónoma do hdfmonkey",
+        "I've dropped the zip - try again":
+            "Já coloquei o zip - tenta de novo",
+        "MAME release: {tag}\nPackage: {asset} ({arch})\n\nDownload (~{size}) and install it into the downloads folder?\nNote: the fully extracted install is large (~500 MB).":
+            "Versão do MAME: {tag}\nPacote: {asset} ({arch})\n\nTransferir (~{size}) e instalar na pasta de transferências?\nNota: a instalação extraída é grande (~500 MB).",
+        "Open download page":
+            "Abrir a página de transferência",
+        "Open downloads folder":
+            "Abrir a pasta de transferências",
+        "The new version was saved as:\n\n{path}\n\nClose ZX Next Unite now and start the new version ({name})?\nYour settings (hdfg.cfg) and downloads are picked up as-is —\nboth versions run from the same folder.":
+            "A nova versão foi guardada como:\n\n{path}\n\nFechar o ZX Next Unite agora e iniciar a nova versão ({name})?\nAs tuas definições (hdfg.cfg) e transferências são reutilizadas tal como estão —\nambas as versões correm a partir da mesma pasta.",
+        "What's changed:":
+            "Novidades:",
+        # ---- emulator / config console (final batch) ----
+        "CSpect update check: {reason}.":
+            "Verificação do CSpect: {reason}.",
+        "CSpect update ▸ FAILED — {error}":
+            "Atualização do CSpect ▸ FALHOU — {error}",
+        "CSpect update ▸ newer build available: installed {installed}, latest {latest}.":
+            "Atualização do CSpect ▸ existe uma versão mais recente: instalada {installed}, mais recente {latest}.",
+        "CSpect update ▸ user chose to update to {name}.":
+            "Atualização do CSpect ▸ o utilizador escolheu atualizar para {name}.",
+        "Could not list the MAME releases: {error}":
+            "Não foi possível listar as versões do MAME: {error}",
+        "ERROR: Failed to launch MAME: {error}":
+            "ERRO: não foi possível iniciar o MAME: {error}",
+        "ERROR: could not extract {name}: {error}":
+            "ERRO: não foi possível extrair {name}: {error}",
+        "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
+            "ERRO: o hdfmonkey falhou - não é possível abrir um ficheiro; normalmente deve-se a caracteres estranhos como aspas e sinais",
+        "ERROR: hdfmonkey failed - A file can't be opened: {command} this is commonly caused by strange characters such as quotes and signs":
+            "ERRO: o hdfmonkey falhou - não é possível abrir um ficheiro: {command}; normalmente deve-se a caracteres estranhos como aspas e sinais",
+        "Failed to save configuration file with IOError: {error}":
+            "Falha ao guardar o ficheiro de configuração (IOError): {error}",
+        "Found hdfmonkey alongside CSpect: {path}":
+            "hdfmonkey encontrado junto ao CSpect: {path}",
+        "MAME exited with code {code}.":
+            "O MAME terminou com o código {code}.",
+        "MAME install ▸ SUCCESS — MAME detected at: {path}":
+            "Instalação do MAME ▸ CONCLUÍDA — MAME detetado em: {path}",
+        "Pygame mode unavailable — run: pip install pygame-ce":
+            "Modo pygame indisponível — executa: pip install pygame-ce",
+        "Remote unzip: fetching {path} from the image …":
+            "Descompressão remota: a obter {path} da imagem …",
+        "Remote zip: fetching {count} item(s) from the image …":
+            "Compressão remota: a obter {count} item(ns) da imagem …",
+        "Saved configuration file.":
+            "Ficheiro de configuração guardado.",
+        "UI language set to '{lang}' to match the system language — change it on the Settings tab.":
+            "Idioma da interface definido para '{lang}' para corresponder ao do sistema; podes alterá-lo no separador Definições.",
+        "ZX Next Unite update available: {latest} (installed {installed}).":
+            "Atualização do ZX Next Unite disponível: {latest} (instalada {installed}).",
+        "ZX Next Unite update ▸ downloading {asset}…":
+            "Atualização do ZX Next Unite ▸ a transferir {asset}…",
+        "ZX Next Unite update: could not start {name}: {error}":
+            "Atualização do ZX Next Unite: não foi possível iniciar {name}: {error}",
+        "ZX Next Unite update: download FAILED: {error}":
+            "Atualização do ZX Next Unite: a transferência FALHOU: {error}",
+        "ZX Next Unite update: downloaded — start it any time: {path}":
+            "Atualização do ZX Next Unite: transferida; podes iniciá-la quando quiseres: {path}",
+        "ZX Next Unite update: starting {name} and closing…":
+            "Atualização do ZX Next Unite: a iniciar {name} e a fechar…",
+        "ZX Next Unite update: unpacked to {path}":
+            "Atualização do ZX Next Unite: descompactada em {path}",
         "Extracting {name} from the image, then starting CSpect…":
             "A extrair {name} da imagem e depois a iniciar o CSpect…",
         "Start CSpect: {name} could not be read from the image, CSpect was not started.":
@@ -1807,6 +1947,76 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        # ---- emulator update prompts (bodies + buttons) ----
+        "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
+            "Dostępna jest nowsza wersja MAME.\n\nZainstalowana: 0.{installed}\nNajnowsza: {latest}  (0.{latest_num})\nPakiet: {asset}\n\nPobrać (~{size}) i zaktualizować instalację MAME teraz?\nIstniejące pliki w folderze MAME zostaną nadpisane.",
+        "Close and start {name}":
+            "Zamknij i uruchom {name}",
+        "Continue hdfmonkey standalone install":
+            "Kontynuuj samodzielną instalację hdfmonkey",
+        "I've dropped the zip - try again":
+            "Wrzuciłem plik zip — spróbuj ponownie",
+        "MAME release: {tag}\nPackage: {asset} ({arch})\n\nDownload (~{size}) and install it into the downloads folder?\nNote: the fully extracted install is large (~500 MB).":
+            "Wersja MAME: {tag}\nPakiet: {asset} ({arch})\n\nPobrać (~{size}) i zainstalować w folderze pobierania?\nUwaga: w pełni wypakowana instalacja jest duża (~500 MB).",
+        "Open download page":
+            "Otwórz stronę pobierania",
+        "Open downloads folder":
+            "Otwórz folder pobierania",
+        "The new version was saved as:\n\n{path}\n\nClose ZX Next Unite now and start the new version ({name})?\nYour settings (hdfg.cfg) and downloads are picked up as-is —\nboth versions run from the same folder.":
+            "Nowa wersja została zapisana jako:\n\n{path}\n\nZamknąć ZX Next Unite i uruchomić nową wersję ({name})?\nTwoje ustawienia (hdfg.cfg) i pobrane pliki są używane bez zmian —\nobie wersje działają z tego samego folderu.",
+        "What's changed:":
+            "Co nowego:",
+        # ---- emulator / config console (final batch) ----
+        "CSpect update check: {reason}.":
+            "Sprawdzanie CSpect: {reason}.",
+        "CSpect update ▸ FAILED — {error}":
+            "Aktualizacja CSpect ▸ NIEPOWODZENIE — {error}",
+        "CSpect update ▸ newer build available: installed {installed}, latest {latest}.":
+            "Aktualizacja CSpect ▸ dostępna nowsza kompilacja: zainstalowana {installed}, najnowsza {latest}.",
+        "CSpect update ▸ user chose to update to {name}.":
+            "Aktualizacja CSpect ▸ użytkownik wybrał aktualizację do {name}.",
+        "Could not list the MAME releases: {error}":
+            "Nie udało się pobrać listy wersji MAME: {error}",
+        "ERROR: Failed to launch MAME: {error}":
+            "BŁĄD: nie udało się uruchomić MAME: {error}",
+        "ERROR: could not extract {name}: {error}":
+            "BŁĄD: nie udało się wypakować {name}: {error}",
+        "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
+            "BŁĄD: hdfmonkey zawiódł - nie można otworzyć pliku; zwykle powodują to nietypowe znaki, np. cudzysłowy i symbole",
+        "ERROR: hdfmonkey failed - A file can't be opened: {command} this is commonly caused by strange characters such as quotes and signs":
+            "BŁĄD: hdfmonkey zawiódł - nie można otworzyć pliku: {command}; zwykle powodują to nietypowe znaki, np. cudzysłowy i symbole",
+        "Failed to save configuration file with IOError: {error}":
+            "Nie udało się zapisać pliku konfiguracyjnego (IOError): {error}",
+        "Found hdfmonkey alongside CSpect: {path}":
+            "Znaleziono hdfmonkey obok CSpect: {path}",
+        "MAME exited with code {code}.":
+            "MAME zakończył działanie z kodem {code}.",
+        "MAME install ▸ SUCCESS — MAME detected at: {path}":
+            "Instalacja MAME ▸ SUKCES — MAME wykryty w: {path}",
+        "Pygame mode unavailable — run: pip install pygame-ce":
+            "Tryb pygame niedostępny — uruchom: pip install pygame-ce",
+        "Remote unzip: fetching {path} from the image …":
+            "Zdalne rozpakowanie: pobieranie {path} z obrazu …",
+        "Remote zip: fetching {count} item(s) from the image …":
+            "Zdalne pakowanie: pobieranie {count} element(ów) z obrazu …",
+        "Saved configuration file.":
+            "Zapisano plik konfiguracyjny.",
+        "UI language set to '{lang}' to match the system language — change it on the Settings tab.":
+            "Język interfejsu ustawiono na '{lang}', zgodnie z językiem systemu — możesz go zmienić w karcie Ustawienia.",
+        "ZX Next Unite update available: {latest} (installed {installed}).":
+            "Dostępna aktualizacja ZX Next Unite: {latest} (zainstalowana {installed}).",
+        "ZX Next Unite update ▸ downloading {asset}…":
+            "Aktualizacja ZX Next Unite ▸ pobieranie {asset}…",
+        "ZX Next Unite update: could not start {name}: {error}":
+            "Aktualizacja ZX Next Unite: nie udało się uruchomić {name}: {error}",
+        "ZX Next Unite update: download FAILED: {error}":
+            "Aktualizacja ZX Next Unite: pobieranie NIE POWIODŁO SIĘ: {error}",
+        "ZX Next Unite update: downloaded — start it any time: {path}":
+            "Aktualizacja ZX Next Unite: pobrana — możesz ją uruchomić w dowolnej chwili: {path}",
+        "ZX Next Unite update: starting {name} and closing…":
+            "Aktualizacja ZX Next Unite: uruchamianie {name} i zamykanie…",
+        "ZX Next Unite update: unpacked to {path}":
+            "Aktualizacja ZX Next Unite: rozpakowano do {path}",
         "Extracting {name} from the image, then starting CSpect…":
             "Wypakowywanie {name} z obrazu, potem uruchomienie CSpect…",
         "Start CSpect: {name} could not be read from the image, CSpect was not started.":
@@ -2502,6 +2712,76 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        # ---- emulator update prompts (bodies + buttons) ----
+        "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
+            "Доступна более новая версия MAME.\n\nУстановлена: 0.{installed}\nПоследняя: {latest}  (0.{latest_num})\nПакет: {asset}\n\nСкачать (~{size}) и обновить установку MAME сейчас?\nСуществующие файлы в папке MAME будут перезаписаны.",
+        "Close and start {name}":
+            "Закрыть и запустить {name}",
+        "Continue hdfmonkey standalone install":
+            "Продолжить отдельную установку hdfmonkey",
+        "I've dropped the zip - try again":
+            "Я положил zip — попробовать снова",
+        "MAME release: {tag}\nPackage: {asset} ({arch})\n\nDownload (~{size}) and install it into the downloads folder?\nNote: the fully extracted install is large (~500 MB).":
+            "Версия MAME: {tag}\nПакет: {asset} ({arch})\n\nСкачать (~{size}) и установить в папку загрузок?\nПримечание: полностью распакованная установка занимает ~500 МБ.",
+        "Open download page":
+            "Открыть страницу загрузки",
+        "Open downloads folder":
+            "Открыть папку загрузок",
+        "The new version was saved as:\n\n{path}\n\nClose ZX Next Unite now and start the new version ({name})?\nYour settings (hdfg.cfg) and downloads are picked up as-is —\nboth versions run from the same folder.":
+            "Новая версия сохранена как:\n\n{path}\n\nЗакрыть ZX Next Unite и запустить новую версию ({name})?\nВаши настройки (hdfg.cfg) и загрузки используются как есть —\nобе версии запускаются из одной папки.",
+        "What's changed:":
+            "Что нового:",
+        # ---- emulator / config console (final batch) ----
+        "CSpect update check: {reason}.":
+            "Проверка CSpect: {reason}.",
+        "CSpect update ▸ FAILED — {error}":
+            "Обновление CSpect ▸ ОШИБКА — {error}",
+        "CSpect update ▸ newer build available: installed {installed}, latest {latest}.":
+            "Обновление CSpect ▸ доступна более новая сборка: установлена {installed}, последняя {latest}.",
+        "CSpect update ▸ user chose to update to {name}.":
+            "Обновление CSpect ▸ пользователь выбрал обновление до {name}.",
+        "Could not list the MAME releases: {error}":
+            "Не удалось получить список версий MAME: {error}",
+        "ERROR: Failed to launch MAME: {error}":
+            "ОШИБКА: не удалось запустить MAME: {error}",
+        "ERROR: could not extract {name}: {error}":
+            "ОШИБКА: не удалось извлечь {name}: {error}",
+        "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
+            "ОШИБКА: сбой hdfmonkey - не удаётся открыть файл; обычно причина в необычных символах, например кавычках и знаках",
+        "ERROR: hdfmonkey failed - A file can't be opened: {command} this is commonly caused by strange characters such as quotes and signs":
+            "ОШИБКА: сбой hdfmonkey - не удаётся открыть файл: {command}; обычно причина в необычных символах, например кавычках и знаках",
+        "Failed to save configuration file with IOError: {error}":
+            "Не удалось сохранить файл конфигурации (IOError): {error}",
+        "Found hdfmonkey alongside CSpect: {path}":
+            "hdfmonkey найден рядом с CSpect: {path}",
+        "MAME exited with code {code}.":
+            "MAME завершился с кодом {code}.",
+        "MAME install ▸ SUCCESS — MAME detected at: {path}":
+            "Установка MAME ▸ УСПЕШНО — MAME найден: {path}",
+        "Pygame mode unavailable — run: pip install pygame-ce":
+            "Режим pygame недоступен — выполните: pip install pygame-ce",
+        "Remote unzip: fetching {path} from the image …":
+            "Удалённая распаковка: получение {path} из образа …",
+        "Remote zip: fetching {count} item(s) from the image …":
+            "Удалённая упаковка: получение элементов из образа: {count} …",
+        "Saved configuration file.":
+            "Файл конфигурации сохранён.",
+        "UI language set to '{lang}' to match the system language — change it on the Settings tab.":
+            "Язык интерфейса установлен на '{lang}' в соответствии с системным — изменить можно на вкладке Настройки.",
+        "ZX Next Unite update available: {latest} (installed {installed}).":
+            "Доступно обновление ZX Next Unite: {latest} (установлена {installed}).",
+        "ZX Next Unite update ▸ downloading {asset}…":
+            "Обновление ZX Next Unite ▸ загрузка {asset}…",
+        "ZX Next Unite update: could not start {name}: {error}":
+            "Обновление ZX Next Unite: не удалось запустить {name}: {error}",
+        "ZX Next Unite update: download FAILED: {error}":
+            "Обновление ZX Next Unite: загрузка НЕ УДАЛАСЬ: {error}",
+        "ZX Next Unite update: downloaded — start it any time: {path}":
+            "Обновление ZX Next Unite: загружено — запустить можно в любой момент: {path}",
+        "ZX Next Unite update: starting {name} and closing…":
+            "Обновление ZX Next Unite: запуск {name} и закрытие…",
+        "ZX Next Unite update: unpacked to {path}":
+            "Обновление ZX Next Unite: распаковано в {path}",
         "Extracting {name} from the image, then starting CSpect…":
             "Извлечение {name} из образа, затем запуск CSpect…",
         "Start CSpect: {name} could not be read from the image, CSpect was not started.":
@@ -3196,6 +3476,76 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        # ---- emulator update prompts (bodies + buttons) ----
+        "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
+            "Je dostupná novější verze MAME.\n\nNainstalovaná: 0.{installed}\nNejnovější: {latest}  (0.{latest_num})\nBalíček: {asset}\n\nStáhnout (~{size}) a aktualizovat instalaci MAME nyní?\nStávající soubory ve složce MAME budou přepsány.",
+        "Close and start {name}":
+            "Zavřít a spustit {name}",
+        "Continue hdfmonkey standalone install":
+            "Pokračovat v samostatné instalaci hdfmonkey",
+        "I've dropped the zip - try again":
+            "Zip jsem vložil - zkusit znovu",
+        "MAME release: {tag}\nPackage: {asset} ({arch})\n\nDownload (~{size}) and install it into the downloads folder?\nNote: the fully extracted install is large (~500 MB).":
+            "Verze MAME: {tag}\nBalíček: {asset} ({arch})\n\nStáhnout (~{size}) a nainstalovat do složky stahování?\nPoznámka: plně rozbalená instalace je velká (~500 MB).",
+        "Open download page":
+            "Otevřít stránku stahování",
+        "Open downloads folder":
+            "Otevřít složku stahování",
+        "The new version was saved as:\n\n{path}\n\nClose ZX Next Unite now and start the new version ({name})?\nYour settings (hdfg.cfg) and downloads are picked up as-is —\nboth versions run from the same folder.":
+            "Nová verze byla uložena jako:\n\n{path}\n\nZavřít ZX Next Unite a spustit novou verzi ({name})?\nVaše nastavení (hdfg.cfg) a stažené soubory se použijí beze změny —\nobě verze běží ze stejné složky.",
+        "What's changed:":
+            "Co je nového:",
+        # ---- emulator / config console (final batch) ----
+        "CSpect update check: {reason}.":
+            "Kontrola CSpectu: {reason}.",
+        "CSpect update ▸ FAILED — {error}":
+            "Aktualizace CSpectu ▸ SELHALA — {error}",
+        "CSpect update ▸ newer build available: installed {installed}, latest {latest}.":
+            "Aktualizace CSpectu ▸ je dostupné novější sestavení: nainstalované {installed}, nejnovější {latest}.",
+        "CSpect update ▸ user chose to update to {name}.":
+            "Aktualizace CSpectu ▸ uživatel zvolil aktualizaci na {name}.",
+        "Could not list the MAME releases: {error}":
+            "Nepodařilo se načíst seznam verzí MAME: {error}",
+        "ERROR: Failed to launch MAME: {error}":
+            "CHYBA: nepodařilo se spustit MAME: {error}",
+        "ERROR: could not extract {name}: {error}":
+            "CHYBA: nepodařilo se rozbalit {name}: {error}",
+        "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
+            "CHYBA: hdfmonkey selhal - soubor nelze otevřít; obvykle to způsobují neobvyklé znaky jako uvozovky a symboly",
+        "ERROR: hdfmonkey failed - A file can't be opened: {command} this is commonly caused by strange characters such as quotes and signs":
+            "CHYBA: hdfmonkey selhal - soubor nelze otevřít: {command}; obvykle to způsobují neobvyklé znaky jako uvozovky a symboly",
+        "Failed to save configuration file with IOError: {error}":
+            "Nepodařilo se uložit konfigurační soubor (IOError): {error}",
+        "Found hdfmonkey alongside CSpect: {path}":
+            "hdfmonkey nalezen vedle CSpectu: {path}",
+        "MAME exited with code {code}.":
+            "MAME skončil s kódem {code}.",
+        "MAME install ▸ SUCCESS — MAME detected at: {path}":
+            "Instalace MAME ▸ ÚSPĚCH — MAME nalezen v: {path}",
+        "Pygame mode unavailable — run: pip install pygame-ce":
+            "Režim pygame není dostupný — spusťte: pip install pygame-ce",
+        "Remote unzip: fetching {path} from the image …":
+            "Vzdálené rozbalení: načítá se {path} z obrazu …",
+        "Remote zip: fetching {count} item(s) from the image …":
+            "Vzdálené zabalení: načítá se {count} položek z obrazu …",
+        "Saved configuration file.":
+            "Konfigurační soubor uložen.",
+        "UI language set to '{lang}' to match the system language — change it on the Settings tab.":
+            "Jazyk rozhraní nastaven na '{lang}' podle jazyka systému — změnit jej lze na kartě Nastavení.",
+        "ZX Next Unite update available: {latest} (installed {installed}).":
+            "K dispozici je aktualizace ZX Next Unite: {latest} (nainstalovaná {installed}).",
+        "ZX Next Unite update ▸ downloading {asset}…":
+            "Aktualizace ZX Next Unite ▸ stahuje se {asset}…",
+        "ZX Next Unite update: could not start {name}: {error}":
+            "Aktualizace ZX Next Unite: nepodařilo se spustit {name}: {error}",
+        "ZX Next Unite update: download FAILED: {error}":
+            "Aktualizace ZX Next Unite: stahování SELHALO: {error}",
+        "ZX Next Unite update: downloaded — start it any time: {path}":
+            "Aktualizace ZX Next Unite: stažena — spustit ji můžete kdykoli: {path}",
+        "ZX Next Unite update: starting {name} and closing…":
+            "Aktualizace ZX Next Unite: spouští se {name} a zavírá se…",
+        "ZX Next Unite update: unpacked to {path}":
+            "Aktualizace ZX Next Unite: rozbaleno do {path}",
         "Extracting {name} from the image, then starting CSpect…":
             "Rozbaluje se {name} z obrazu, poté se spustí CSpect…",
         "Start CSpect: {name} could not be read from the image, CSpect was not started.":
@@ -3893,6 +4243,76 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        # ---- emulator update prompts (bodies + buttons) ----
+        "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
+            "Une version plus récente de MAME est disponible.\n\nInstallée : 0.{installed}\nDernière : {latest}  (0.{latest_num})\nPaquet : {asset}\n\nTélécharger (~{size}) et mettre à jour votre installation MAME maintenant ?\nLes fichiers existants du dossier MAME seront écrasés.",
+        "Close and start {name}":
+            "Fermer et lancer {name}",
+        "Continue hdfmonkey standalone install":
+            "Continuer l'installation autonome de hdfmonkey",
+        "I've dropped the zip - try again":
+            "J'ai déposé le zip - réessayer",
+        "MAME release: {tag}\nPackage: {asset} ({arch})\n\nDownload (~{size}) and install it into the downloads folder?\nNote: the fully extracted install is large (~500 MB).":
+            "Version de MAME : {tag}\nPaquet : {asset} ({arch})\n\nTélécharger (~{size}) et l'installer dans le dossier de téléchargement ?\nNote : l'installation complète est volumineuse (~500 Mo).",
+        "Open download page":
+            "Ouvrir la page de téléchargement",
+        "Open downloads folder":
+            "Ouvrir le dossier de téléchargement",
+        "The new version was saved as:\n\n{path}\n\nClose ZX Next Unite now and start the new version ({name})?\nYour settings (hdfg.cfg) and downloads are picked up as-is —\nboth versions run from the same folder.":
+            "La nouvelle version a été enregistrée sous :\n\n{path}\n\nFermer ZX Next Unite maintenant et lancer la nouvelle version ({name}) ?\nVos réglages (hdfg.cfg) et téléchargements sont repris tels quels —\nles deux versions s'exécutent depuis le même dossier.",
+        "What's changed:":
+            "Nouveautés :",
+        # ---- emulator / config console (final batch) ----
+        "CSpect update check: {reason}.":
+            "Vérification de CSpect : {reason}.",
+        "CSpect update ▸ FAILED — {error}":
+            "Mise à jour de CSpect ▸ ÉCHEC — {error}",
+        "CSpect update ▸ newer build available: installed {installed}, latest {latest}.":
+            "Mise à jour de CSpect ▸ build plus récent disponible : installé {installed}, dernier {latest}.",
+        "CSpect update ▸ user chose to update to {name}.":
+            "Mise à jour de CSpect ▸ l'utilisateur a choisi de passer à {name}.",
+        "Could not list the MAME releases: {error}":
+            "Impossible de lister les versions de MAME : {error}",
+        "ERROR: Failed to launch MAME: {error}":
+            "ERREUR : impossible de lancer MAME : {error}",
+        "ERROR: could not extract {name}: {error}":
+            "ERREUR : impossible d'extraire {name} : {error}",
+        "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
+            "ERREUR : échec de hdfmonkey - impossible d'ouvrir un fichier ; cela vient généralement de caractères inhabituels comme les guillemets et les signes",
+        "ERROR: hdfmonkey failed - A file can't be opened: {command} this is commonly caused by strange characters such as quotes and signs":
+            "ERREUR : échec de hdfmonkey - impossible d'ouvrir un fichier : {command} ; cela vient généralement de caractères inhabituels comme les guillemets et les signes",
+        "Failed to save configuration file with IOError: {error}":
+            "Échec de l'enregistrement du fichier de configuration (IOError) : {error}",
+        "Found hdfmonkey alongside CSpect: {path}":
+            "hdfmonkey trouvé à côté de CSpect : {path}",
+        "MAME exited with code {code}.":
+            "MAME s'est terminé avec le code {code}.",
+        "MAME install ▸ SUCCESS — MAME detected at: {path}":
+            "Installation de MAME ▸ RÉUSSIE — MAME détecté dans : {path}",
+        "Pygame mode unavailable — run: pip install pygame-ce":
+            "Mode pygame indisponible — lancez : pip install pygame-ce",
+        "Remote unzip: fetching {path} from the image …":
+            "Décompression distante : récupération de {path} depuis l'image …",
+        "Remote zip: fetching {count} item(s) from the image …":
+            "Compression distante : récupération de {count} élément(s) depuis l'image …",
+        "Saved configuration file.":
+            "Fichier de configuration enregistré.",
+        "UI language set to '{lang}' to match the system language — change it on the Settings tab.":
+            "Langue de l'interface réglée sur '{lang}' pour correspondre au système — modifiable dans l'onglet Réglages.",
+        "ZX Next Unite update available: {latest} (installed {installed}).":
+            "Mise à jour de ZX Next Unite disponible : {latest} (installée {installed}).",
+        "ZX Next Unite update ▸ downloading {asset}…":
+            "Mise à jour de ZX Next Unite ▸ téléchargement de {asset}…",
+        "ZX Next Unite update: could not start {name}: {error}":
+            "Mise à jour de ZX Next Unite : impossible de lancer {name} : {error}",
+        "ZX Next Unite update: download FAILED: {error}":
+            "Mise à jour de ZX Next Unite : le téléchargement a ÉCHOUÉ : {error}",
+        "ZX Next Unite update: downloaded — start it any time: {path}":
+            "Mise à jour de ZX Next Unite : téléchargée — lancez-la quand vous voulez : {path}",
+        "ZX Next Unite update: starting {name} and closing…":
+            "Mise à jour de ZX Next Unite : lancement de {name} et fermeture…",
+        "ZX Next Unite update: unpacked to {path}":
+            "Mise à jour de ZX Next Unite : décompressée dans {path}",
         "Extracting {name} from the image, then starting CSpect…":
             "Extraction de {name} depuis l'image, puis lancement de CSpect…",
         "Start CSpect: {name} could not be read from the image, CSpect was not started.":

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -3915,7 +3915,9 @@ class MainWindow(QMainWindow):
             if _near_hdfmonkey:
                 self._hdfmonkey_executable_path = _near_hdfmonkey
                 _need_hdfmonkey = False
-                add_main_log_window(f"Found hdfmonkey alongside CSpect: {_near_hdfmonkey}")
+                add_main_log_window(ui_tr_now(
+                    "Found hdfmonkey alongside CSpect: {path}").format(
+                        path=_near_hdfmonkey))
                 self.download_and_install_hdfmonkey_button.setVisible(False)
                 self.button_new_folder.setVisible(True)
                 self.button_delete_files.setVisible(True)
@@ -4023,7 +4025,9 @@ class MainWindow(QMainWindow):
                 if near:
                     self._hdfmonkey_executable_path = near
                     need_hdfmonkey = False
-                    add_main_log_window(f"Found hdfmonkey alongside CSpect: {near}")
+                    add_main_log_window(ui_tr_now(
+                        "Found hdfmonkey alongside CSpect: {path}").format(
+                            path=near))
                     try:
                         self.download_and_install_hdfmonkey_button.setVisible(False)
                         self.button_new_folder.setVisible(True)
@@ -4184,9 +4188,10 @@ class MainWindow(QMainWindow):
             configuration_dictionary[SETTING_UI_LANGUAGE] = _ui_language
             save_configuration_file()   # one-time adoption (never re-runs)
             if _ui_language != "en":
-                add_main_log_window(
-                    f"UI language set to '{_ui_language}' to match the system "
-                    "language — change it on the Settings tab.")
+                add_main_log_window(ui_tr_now(
+                    "UI language set to '{lang}' to match the system "
+                    "language — change it on the Settings tab.").format(
+                        lang=_ui_language))
                 _lang_toast_title = ui_tr(
                     "🌐  Language set to match your system", _ui_language)
                 _lang_toast_body = ui_tr(

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -1325,7 +1325,8 @@ def build_nextsync_pane(
                 _nextsync_pygame_disable(
                     f"{why}\nInstall with: pip install pygame-ce")
                 add_nextsync_log_window(
-                    "Pygame mode unavailable — run: pip install pygame-ce")
+                    ui_tr_now(
+                        "Pygame mode unavailable — run: pip install pygame-ce"))
                 return
             try:
                 widget = _nextsync_build_retro_log()

--- a/zxnu_retro_ui.py
+++ b/zxnu_retro_ui.py
@@ -98,8 +98,8 @@ def build_main_retro_log(
             if not ok:
                 _main_pygame_disable(
                     f"{why}\nInstall with: pip install pygame-ce")
-                add_main_log_window(
-                    "Pygame mode unavailable — run: pip install pygame-ce")
+                add_main_log_window(ui_tr_now(
+                    "Pygame mode unavailable — run: pip install pygame-ce"))
                 return
             try:
                 widget = _main_build_retro_log()

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -123,7 +123,9 @@ def build_sdcard_utils(
             return False
         except Exception as e:
             logging.error(f"Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.... {e}")
-            add_main_log_window(f"Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.... {e}")
+            add_main_log_window(ui_tr_now(
+                "Failed executing hdfmonkey, please make sure it is "
+                "installed in the same local directory as zx-next-unite.") + f" {e}")
             return False
 
     def _add_to_image_history(path: str):
@@ -615,7 +617,7 @@ def build_sdcard_utils(
         button_box = QDialogButtonBox(dialog)
         create_button = button_box.addButton(
             ui_tr_now("Create"), QDialogButtonBox.AcceptRole)
-        button_box.addButton("Cancel", QDialogButtonBox.RejectRole)
+        button_box.addButton(ui_tr_now("Cancel"), QDialogButtonBox.RejectRole)
         layout.addWidget(button_box)
 
         def _on_create():
@@ -702,7 +704,7 @@ def build_sdcard_utils(
         button_box = QDialogButtonBox(dialog)
         download_button = button_box.addButton(
             ui_tr_now("Download"), QDialogButtonBox.AcceptRole)
-        cancel_button = button_box.addButton("Cancel", QDialogButtonBox.RejectRole)
+        cancel_button = button_box.addButton(ui_tr_now("Cancel"), QDialogButtonBox.RejectRole)
         dialog_layout.addWidget(button_box)
 
         cancel_button.clicked.connect(dialog.reject)
@@ -1095,10 +1097,17 @@ def build_sdcard_utils(
                 elif ex.returncode == 255:
                     if execution_cmd is not None:
                         logging.error(f"ERROR: hdfmonkey failed - A file can't be opened: {execution_cmd} this is commonly caused by strange characters such as quotes and signs")
-                        add_main_log_window(f"ERROR: hdfmonkey failed - A file can't be opened: {execution_cmd} this is commonly caused by strange characters such as quotes and signs")
+                        add_main_log_window(ui_tr_now(
+                            "ERROR: hdfmonkey failed - A file can't be opened: "
+                            "{command} this is commonly caused by strange "
+                            "characters such as quotes and signs").format(
+                                command=execution_cmd))
                     else:
                         logging.error(f"ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs")
-                        add_main_log_window(f"ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs")
+                        add_main_log_window(ui_tr_now(
+                            "ERROR: hdfmonkey failed - A file can't be opened "
+                            "this is commonly caused by strange characters "
+                            "such as quotes and signs"))
                 else:
                     err_detail = f" | stderr: {stderr_text}" if stderr_text else ""
                     if HDFMONKEY_EXECUTABLE is not None and execution_cmd is not None:
@@ -1222,8 +1231,9 @@ def build_image_edit_ops(
         layout.addWidget(warn)
 
         button_box = QDialogButtonBox(dialog)
-        delete_button = button_box.addButton("Delete", QDialogButtonBox.AcceptRole)
-        cancel_button = button_box.addButton("Cancel", QDialogButtonBox.RejectRole)
+        delete_button = button_box.addButton(
+            ui_tr_now("Delete"), QDialogButtonBox.AcceptRole)
+        cancel_button = button_box.addButton(ui_tr_now("Cancel"), QDialogButtonBox.RejectRole)
         layout.addWidget(button_box)
 
         delete_button.clicked.connect(dialog.accept)
@@ -2758,14 +2768,15 @@ def build_transfer_clipboard_ops(
                     add_main_log_window(ui_tr_now(
                         "Remote unzip cancelled — the image is unchanged."))
                 elif res["error"]:
-                    add_main_log_window(f"ERROR: could not extract {name}: "
-                                        f"{res['error']}")
+                    add_main_log_window(ui_tr_now(
+                        "ERROR: could not extract {name}: {error}").format(
+                            name=name, error=res["error"]))
                     QMessageBox.critical(
                         host, ui_tr_now("Remote unzip failed"),
                         ui_tr_now("Could not extract {name}:").format(name=name) + f"\n{res['error']}")
                 else:
-                    add_main_log_window(f"{name} contains no extractable "
-                                        "files.")
+                    add_main_log_window(ui_tr_now(
+                        "{name} contains no extractable files.").format(name=name))
                 return
             tops = [os.path.join(extract_dir, e)
                     for e in sorted(os.listdir(extract_dir))]
@@ -2788,8 +2799,8 @@ def build_transfer_clipboard_ops(
                         "cancelled."))
             image_upload_external_paths(tops, dest_dir, on_complete=_done)
 
-        add_main_log_window(f"Remote unzip: fetching {zip_path} from "
-                            "the image …")
+        add_main_log_window(ui_tr_now(
+            "Remote unzip: fetching {path} from the image …").format(path=zip_path))
         image_get_paths_to_local(
             [(zip_path, False)], tmp, refresh_fn=lambda: None,
             on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
@@ -2890,8 +2901,9 @@ def build_transfer_clipboard_ops(
             image_upload_external_paths([zip_local], dest_dir,
                                         on_complete=_done)
 
-        add_main_log_window(f"Remote zip: fetching {len(items)} item(s) "
-                            "from the image …")
+        add_main_log_window(ui_tr_now(
+            "Remote zip: fetching {count} item(s) from the image …").format(
+                count=len(items)))
         image_get_paths_to_local(
             items, dl, refresh_fn=lambda: None,
             on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))

--- a/zxnu_unite_pane.py
+++ b/zxnu_unite_pane.py
@@ -1381,9 +1381,9 @@ def build_unite_ops(
                 _allinone_pygame_disable(
                     f"{why}\nInstall with: pip install pygame-ce")
                 try:
-                    host.allinone_status_label.setText(
+                    host.allinone_status_label.setText(ui_tr_now(
                         "Pygame mode unavailable — run: pip install pygame-ce"
-                    )
+                    ))
                 except Exception:
                     pass
                 return


### PR DESCRIPTION
Continues (and nearly closes) the localization sweep: **34 more strings × 6 languages**.

## What landed

**The update prompt bodies** — the largest user-facing text that was still English. The MAME release-picker confirmation, the MAME update offer (installed / latest / package / size), and the "new version was saved as… close and start it?" dialog, all converted from f-strings to `{named}` templates.

**Their buttons**: Cancel, Download, `Close and start {name}`, Open download page, Open downloads folder, "I've dropped the zip - try again", Continue hdfmonkey standalone install, and the "What's changed:" notes header.

**Console lines**: the ZX Next Unite self-update chain (downloading / unpacked / downloaded / starting / could not start / download FAILED / update available), CSpect update failures and choices, MAME launch failures and exit code, the SD-card remote zip/unzip fetch lines and both hdfmonkey "file can't be opened" variants, plus configuration saved/IOError, "Found hdfmonkey alongside CSpect", and the first-run UI-language notice.

## The sweep earned its keep again

Making `"Pygame mode unavailable — run: pip install pygame-ce"` catalogued immediately caused `test_i18n`'s runtime-text sweep to fail — because **two other call sites** (`zxnu_unite_pane`, `zxnu_nextsync_pane`) were still writing that same string untranslated. Neither showed up in my `add_main_log_window` survey, because they are `setText` on a status label. Both now go through `ui_tr_now`. That is precisely the gap the sweep was added to catch, and it caught it the moment the string became catalogued.

## Verification

**266 `ui_tr_now` literals app-wide**, every one present in all six catalogs, and every template renders through `.format()` in all seven languages. `ruff check .` and the full suite are green.

## What is deliberately still English

31 diagnostics — argv echoes, HTTP/SHA-256 detail, raw exception text — so a pasted log still matches the docs and the `.dot` source.

## What is still outstanding

About 14 strings: the CSpect update prompt body, the TBBLUE boot-ROM guidance, the hdfmonkey download-failed explainer, the itch.io TIP, and the four source-install / no-package self-update variants. All are long multi-line bodies of the same shape as the ones converted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)