### PR TITLE
SD Card tab: start a file in MAME too; finish the console localization

### DIFF
--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -36,6 +36,7 @@ SUITES = [
     ("test_mame_install.py",     120, None),
     ("test_startup_tab_activation.py", 120, None),
     ("test_cspect_autostart.py",  120, None),
+    ("test_mame_autostart.py",   120, None),
     ("test_pane_imports.py",    120, None),
     ("test_hdf_workers.py",     120, None),
     ("test_classic_sync.py",    180, None),

--- a/tests/test_cspect_autostart.py
+++ b/tests/test_cspect_autostart.py
@@ -8,10 +8,14 @@ a file straight into the emulator:
   * local explorer  -> "Send to SD Card and start CSpect with file X"
                        (upload into the image first, then start)
 
-Both end up appending the file to CSpect's command line, which CSpect resolves
-against the -mmc root:
+Both end up appending the file to CSpect's command line. CSpect resolves that
+trailing argument against its OWN working directory, not against the -mmc root
+— so it must be a host path, and a file living on the image has to be extracted
+to the host first (the bug this feature shipped with):
 
-    CSpect.exe … -zxnext -mmc=<image> games/foo.nex
+    CSpect.exe … -zxnext -mmc=<image> C:\\…\\extracted\\foo.nex
+
+See tests/test_mame_autostart.py for the MAME twin of these actions.
 
 Covered here: the extension gate that decides whether the actions are offered
 at all, and the source-level contract of the two menus (both must be gated on

--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -1,0 +1,218 @@
+"""MAME auto-start tests (SD Card tab).
+
+The MAME twin of test_cspect_autostart.py. With MAME usable the SD Card tab
+offers two right-click actions that boot a file straight into the emulator:
+
+  * image explorer  -> "Start MAME with file X"        (file is on the image)
+  * local explorer  -> "Send to SD Card and start MAME with file X"
+                       (upload into the image first, then start)
+
+WHAT MAME ACTUALLY NEEDS — verified against a real MAME 0.288 rather than
+assumed, because the widely repeated advice is wrong. A raw file does NOT need
+a software-list entry and does NOT need copying into a software/<system>
+folder: `mame -listmedia tbblue` reports .nex among the *snapshot* extensions
+and
+
+    mame tbblue -snapshot <host path>.nex -hard1 <image>
+
+boots it (checked to run and, with a bogus path, to fail loudly). The software
+list the folklore refers to, hash/specnext_sd.xml, describes hash-matched
+SD-card images — a different mechanism that cannot describe a file it has never
+seen, so dropping a .nex into software/specnext would match nothing.
+
+The path must be a HOST path: MAME's loader knows nothing about the contents of
+the emulated SD card, so a file living on the image has to be extracted first.
+That is the same trap the CSpect feature shipped with, and it is pinned below.
+
+The launch itself needs a built MainWindow and a real emulator, so the argv
+assembly is checked at source level.
+
+Run with: python tests/test_mame_autostart.py
+"""
+import ast
+import os
+import sys
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, REPO)
+
+from zxnu_config import (  # noqa: E402
+    MAME_CASSETTE_EXTENSIONS,
+    MAME_QUICKLOAD_EXTENSIONS,
+    MAME_SNAPSHOT_EXTENSIONS,
+    mame_autostart_argument,
+    mame_can_autostart,
+)
+
+FAIL = []
+
+
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+# ---- the media switch per file type -------------------------------------
+check("a .nex loads as a snapshot (the format the feature is for)",
+      mame_autostart_argument("/games/foo.nex") == "-snapshot")
+check("matching is case-insensitive",
+      mame_autostart_argument("/A.NEX") == "-snapshot"
+      and mame_autostart_argument("/b.SnA") == "-snapshot")
+check("every snapshot extension maps to -snapshot",
+      all(mame_autostart_argument("/x" + e) == "-snapshot"
+          for e in MAME_SNAPSHOT_EXTENSIONS))
+check("tapes map to -cassette, not -snapshot",
+      all(mame_autostart_argument("/x" + e) == "-cassette"
+          for e in MAME_CASSETTE_EXTENSIONS))
+check("quickloads map to -quickload",
+      all(mame_autostart_argument("/x" + e) == "-quickload"
+          for e in MAME_QUICKLOAD_EXTENSIONS))
+check("the three media sets do not overlap",
+      not (set(MAME_SNAPSHOT_EXTENSIONS) & set(MAME_CASSETTE_EXTENSIONS))
+      and not (set(MAME_SNAPSHOT_EXTENSIONS) & set(MAME_QUICKLOAD_EXTENSIONS))
+      and not (set(MAME_CASSETTE_EXTENSIONS) & set(MAME_QUICKLOAD_EXTENSIONS)))
+
+# ---- the gate stays useful ----------------------------------------------
+check("a readme is NOT offered", not mame_can_autostart("/docs/readme.txt"))
+check("an extensionless name is not offered",
+      not mame_can_autostart("/games/README"))
+check("empty / None are safe",
+      not mame_can_autostart("") and not mame_can_autostart(None)
+      and mame_autostart_argument(None) == "")
+check("a name merely CONTAINING an extension is not offered",
+      not mame_can_autostart("/games/nex-collection"))
+check("generic audio is not offered as a tape",
+      not mame_can_autostart("/music/track.wav")
+      and not mame_can_autostart("/music/track.flac"))
+check("CSpect-only disk formats are not offered for MAME",
+      not any(mame_can_autostart("/x" + e)
+              for e in (".trd", ".scl", ".dsk", ".slt", ".szx")),
+      "MAME's Next drivers take no such media")
+
+# ---- the launcher takes the file and builds the right argv ---------------
+src = open(os.path.join(REPO, "zxnu_emulator_ops.py"), encoding="utf-8").read()
+tree = ast.parse(src)
+fn = next((n for n in ast.walk(tree)
+           if isinstance(n, ast.FunctionDef) and n.name == "launch_mame"), None)
+check("launch_mame accepts the auto-start file", fn is not None
+      and any(a.arg == "autostart_file" for a in fn.args.args))
+if fn is not None:
+    body = ast.dump(fn)
+    # button_start_mame.clicked connects straight to launch_mame, so Qt hands
+    # it the checked bool. Without the guard that bool becomes a "file name".
+    # Matched precisely: a bare `"isinstance" in body` would also be satisfied
+    # by any unrelated isinstance() the function grows later.
+    guarded = any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id == "isinstance"
+        and n.args and isinstance(n.args[0], ast.Name)
+        and n.args[0].id == "autostart_file"
+        for n in ast.walk(fn))
+    check("a Qt clicked() bool cannot be taken for a file name",
+          guarded, "launch_mame is also a clicked() slot")
+    check("the auto-start argument is made an absolute host path",
+          "os.path.abspath(autostart_file" in src)
+    check("no leading-slash stripping (host path, not an image path)",
+          'autostart_file.strip().lstrip("/")' not in src)
+    check("the media switch is chosen per file type, not hard-coded",
+          "mame_autostart_argument" in body)
+    # -hard1 <image> has always been documented as the final argument.
+    check("the file is added BEFORE -hard1, which stays last",
+          src.index("_auto_switch, _auto") < src.index("MAME_HARD_DISK_PARAMETER, mame_image"))
+    check("an unsupported file does not silently vanish",
+          "MAME cannot load {name} directly" in src)
+
+# ---- booting a file that lives on the image must extract it first --------
+ops = open(os.path.join(REPO, "zxnu_sdcard_ops.py"), encoding="utf-8").read()
+check("there is an extract-then-launch step for image files",
+      "def _mame_start_from_image" in ops)
+seg_img = ops[ops.find("def _mame_start_from_image"):]
+seg_img = seg_img[:seg_img.find("def _image_remote_zip")]
+check("it pulls the file out of the image with the hdfmonkey helper",
+      "image_get_paths_to_local" in seg_img)
+check("it launches the EXTRACTED host copy, not the in-image path",
+      "_launch_mame_fn(local)" in seg_img)
+check("a failed extraction does not start MAME",
+      "could not be read from the image" in seg_img)
+check("the temp copy is not deleted out from under a detached MAME",
+      "shutil.rmtree(tmp" in seg_img
+      and seg_img.count("shutil.rmtree(tmp") == 1,
+      "rmtree must only run on the failure path")
+
+# The local action must launch the LOCAL file, never the in-image copy.
+seg_loc = ops[ops.find("def _send_and_start_mame"):]
+seg_loc = seg_loc[:seg_loc.find("menu.addAction")]
+check("the local action starts MAME on the local (host) file",
+      "_launch_mame_fn(_p)" in seg_loc)
+check("the local action never builds an in-image path for MAME",
+      "in_image" not in seg_loc)
+check("a failed transfer does not start MAME",
+      "if not success" in seg_loc)
+check("the local action uploads first, then launches",
+      "on_complete=_after" in seg_loc,
+      "upload must drive the launch through its completion callback")
+
+# ---- both menus are gated on MAME being usable --------------------------
+for label, marker in (
+        ("image explorer", 'ui_tr_now("Start MAME with file {name}")'),
+        ("local explorer",
+         'ui_tr_now("Send to SD Card and start MAME with file {name}"')):
+    at = ops.find(marker)
+    check(f"the {label} action exists", at != -1)
+    if at == -1:
+        continue
+    # The gate is the `if` above the addAction; the local action's handler body
+    # sits in between, so look back far enough to clear it.
+    window = ops[max(0, at - 2600):at]
+    check(f"the {label} action is gated on MAME being usable",
+          "_mame_usable()" in window,
+          "must use _mame_usable() so Flatpak MAME counts too")
+    check(f"the {label} action is gated on a loadable extension",
+          "mame_can_autostart" in window)
+
+# Top of the menu, as asked for, and not at the price of the CSpect entry.
+img_at = ops.find('ui_tr_now("Start MAME with file {name}")')
+newfolder_at = ops.find("new_folder_label = ")
+check("the image-explorer action sits above the rest of that menu",
+      img_at != -1 and newfolder_at != -1 and img_at < newfolder_at,
+      f"mame={img_at} newfolder={newfolder_at}")
+cspect_img_at = ops.find('ui_tr_now("Start CSpect with file {name}")')
+check("the CSpect image action still sits at the top too",
+      cspect_img_at != -1 and cspect_img_at < newfolder_at)
+check("one separator covers both emulator entries",
+      "_emu_entry_added" in ops,
+      "a per-entry separator would leave a stray line when only one is shown")
+
+# ---- every new string is translated -------------------------------------
+from zxnu_i18n import CATALOGS  # noqa: E402
+
+NEW_STRINGS = (
+    "Start MAME with file {name}",
+    "Send to SD Card and start MAME with file {name}",
+    "Extracting {name} from the image, then starting MAME…",
+    "Start MAME: {name} could not be read from the image, MAME was not started.",
+    "Send to SD Card and start MAME: the transfer failed, MAME was not started.",
+    "Sending {name} to the SD card image, then starting MAME…",
+    "MAME cannot load {name} directly; starting MAME without it.",
+)
+missing = [(lg, s) for s in NEW_STRINGS for lg in CATALOGS if not CATALOGS[lg].get(s)]
+check("every new MAME string is translated in all languages",
+      not missing, f"{len(missing)} gap(s): {missing[:3]}")
+broken = []
+for s in NEW_STRINGS:
+    for lg in CATALOGS:
+        try:
+            (CATALOGS[lg].get(s) or s).format(name="beast.nex")
+        except (KeyError, IndexError):
+            broken.append((lg, s))
+check("every translation renders with its placeholder", not broken, str(broken[:3]))
+
+print()
+if FAIL:
+    print(f"{len(FAIL)} FAILURE(S): " + ", ".join(FAIL))
+    sys.exit(1)
+print("all MAME auto-start checks passed")
+sys.exit(0)

--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -31,6 +31,7 @@ Run with: python tests/test_mame_autostart.py
 """
 import ast
 import os
+import re
 import sys
 
 sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -137,10 +138,40 @@ check("it launches the EXTRACTED host copy, not the in-image path",
       "_launch_mame_fn(local)" in seg_img)
 check("a failed extraction does not start MAME",
       "could not be read from the image" in seg_img)
-check("the temp copy is not deleted out from under a detached MAME",
-      "shutil.rmtree(tmp" in seg_img
-      and seg_img.count("shutil.rmtree(tmp") == 1,
-      "rmtree must only run on the failure path")
+# The copy must survive a successful launch (MAME is detached and opens it
+# after we return), so the only cleanup on that path is the failure branch.
+fail_at = seg_img.find("could not be read from the image")
+launch_at = seg_img.find("_launch_mame_fn(local)")
+check("the copy is not deleted out from under a detached MAME",
+      fail_at != -1 and launch_at != -1
+      and "shutil.rmtree(tmp, ignore_errors=True)" in seg_img[fail_at:launch_at],
+      "cleanup must sit on the failure path, before the launch")
+
+# ---- Flatpak MAME cannot see this process's /tmp -------------------------
+# Every Flatpak app gets a private /tmp, and --filesystem=host excludes /tmp
+# outright, so a mkdtemp() copy is invisible to Flatpak MAME. Both manifests
+# (ours and Flathub's org.mamedev.MAME) grant --filesystem=home instead.
+from zxnu_config import mame_autostart_staging_dir  # noqa: E402
+
+stage = mame_autostart_staging_dir()
+home = os.path.expanduser("~")
+check("the Flatpak staging dir lives under the user's home",
+      os.path.commonpath([os.path.abspath(stage), os.path.abspath(home)])
+      == os.path.abspath(home), stage)
+check("the Flatpak staging dir is NOT under /tmp",
+      not os.path.abspath(stage).replace("\\", "/").startswith("/tmp"), stage)
+check("the image extraction switches on the Flatpak setting",
+      "_mame_flatpak_enabled()" in seg_img,
+      "Flatpak MAME must not be handed a /tmp path")
+check("...and only then uses the home staging dir",
+      "mame_autostart_staging_dir()" in seg_img
+      and "tempfile.mkdtemp(prefix=\"zxnu-mame-\")" in seg_img,
+      "the non-Flatpak path should keep using a real temp dir")
+check("the staging dir is cleared so copies do not pile up under ~",
+      "shutil.rmtree(tmp, ignore_errors=True)" in seg_img[:fail_at],
+      "nothing under ~ is cleaned up by the OS")
+check("a staging dir that cannot be created is reported, not ignored",
+      "could not prepare the staging folder" in seg_img)
 
 # The local action must launch the LOCAL file, never the in-image copy.
 seg_loc = ops[ops.find("def _send_and_start_mame"):]
@@ -197,18 +228,25 @@ NEW_STRINGS = (
     "Send to SD Card and start MAME: the transfer failed, MAME was not started.",
     "Sending {name} to the SD card image, then starting MAME…",
     "MAME cannot load {name} directly; starting MAME without it.",
+    "Start MAME: could not prepare the staging folder {path} ({error}).",
 )
 missing = [(lg, s) for s in NEW_STRINGS for lg in CATALOGS if not CATALOGS[lg].get(s)]
 check("every new MAME string is translated in all languages",
       not missing, f"{len(missing)} gap(s): {missing[:3]}")
 broken = []
+sample = {"name": "beast.nex", "path": "/home/u/.cache", "error": "denied"}
 for s in NEW_STRINGS:
     for lg in CATALOGS:
+        translated = CATALOGS[lg].get(s) or s
         try:
-            (CATALOGS[lg].get(s) or s).format(name="beast.nex")
+            translated.format(**sample)
         except (KeyError, IndexError):
             broken.append((lg, s))
-check("every translation renders with its placeholder", not broken, str(broken[:3]))
+        # A translation that quietly drops a placeholder loses the detail the
+        # line exists to carry, which .format() alone would not catch.
+        if set(re.findall(r"\{(\w+)\}", translated)) != set(re.findall(r"\{(\w+)\}", s)):
+            broken.append((lg, s + "  [placeholder set differs]"))
+check("every translation renders with its placeholders", not broken, str(broken[:3]))
 
 print()
 if FAIL:

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -1120,6 +1120,48 @@ def cspect_can_autostart(path):
     return bool(path) and str(path).lower().endswith(CSPECT_AUTOSTART_EXTENSIONS)
 
 
+# File types MAME can load straight from the command line on the Next drivers,
+# grouped by the media switch that takes them. The extension lists come from
+# `mame -listmedia tbblue` (identical for specnext_ks1/ks2/ks3).
+#
+# Contrary to a widespread belief, a raw file needs NO software-list entry and
+# no copy into a software/<system> folder: `mame tbblue -snapshot <host path>`
+# boots an arbitrary .nex. The software-list route (hash/specnext_sd.xml) is
+# for hash-matched SD-card images, which is a different mechanism entirely and
+# cannot describe a file it has never seen. The path must be a HOST path — a
+# path inside the mounted image means nothing to MAME's file loader.
+#
+# MAME also accepts .wav/.flac as cassettes and .raw as a quickload; those are
+# deliberately left out. On an SD card such a name is far more likely to be
+# ordinary audio or generic data than a Spectrum tape, and the point of these
+# tables is to decide when the "start with this file" actions are worth
+# offering — same reason CSPECT_AUTOSTART_EXTENSIONS stops short of .txt.
+MAME_SNAPSHOT_EXTENSIONS = (".nex", ".sna", ".snx", ".snp", ".z80", ".sp",
+                            ".spg", ".zx", ".ach", ".frz", ".sem", ".sit")
+MAME_QUICKLOAD_EXTENSIONS = (".scr",)
+MAME_CASSETTE_EXTENSIONS = (".tap", ".tzx", ".blk")
+
+
+def mame_autostart_argument(path):
+    """The MAME media switch that loads *path* (``-snapshot`` / ``-quickload``
+    / ``-cassette``), or ``""`` when MAME cannot boot that file type."""
+    lowered = str(path or "").lower()
+    if not lowered:
+        return ""
+    if lowered.endswith(MAME_SNAPSHOT_EXTENSIONS):
+        return "-snapshot"
+    if lowered.endswith(MAME_QUICKLOAD_EXTENSIONS):
+        return "-quickload"
+    if lowered.endswith(MAME_CASSETTE_EXTENSIONS):
+        return "-cassette"
+    return ""
+
+
+def mame_can_autostart(path):
+    """True when *path* looks like something MAME can load directly."""
+    return bool(mame_autostart_argument(path))
+
+
 def emulator_option_argument(options, index):
     """The command-line argument for entry *index* of an emulator option tuple
     (any of the ``CSPECT_*`` / ``MAME_*`` ``(label, argument)`` tuples above),

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -1162,6 +1162,28 @@ def mame_can_autostart(path):
     return bool(mame_autostart_argument(path))
 
 
+def mame_autostart_staging_dir():
+    """Where to put a file extracted from the SD image before handing it to
+    FLATPAK MAME.
+
+    The obvious ``tempfile.mkdtemp()`` is wrong here: Flatpak gives every app a
+    private ``/tmp``, and ``--filesystem=host`` deliberately excludes ``/tmp``
+    (it is one of Flatpak's reserved root directories), so a copy left there is
+    invisible to Flatpak MAME no matter what permissions it holds.
+
+    A path under the user's home works from both sides: this app's manifest
+    grants ``--filesystem=home`` (so the directory is written to the real home,
+    not a sandbox-private one) and Flathub's org.mamedev.MAME grants
+    ``--filesystem=home`` too, so it can read the file back.
+
+    One fixed directory, cleared before each use, rather than a fresh temp dir
+    per launch — nothing under ``~`` is cleaned up by the OS, so accumulating
+    copies would just leak disk space.
+    """
+    return os.path.join(os.path.expanduser("~"), ".cache",
+                        "zx-next-unite", "mame-autostart")
+
+
 def emulator_option_argument(options, index):
     """The command-line argument for entry *index* of an emulator option tuple
     (any of the ``CSPECT_*`` / ``MAME_*`` ``(label, argument)`` tuples above),

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -366,7 +366,19 @@ def build_emulator_ops(
             set_all_buttons_enabled()
 
 
-    def launch_mame():
+    def launch_mame(autostart_file=None):
+        """Boot the Next in MAME with the selected image as its hard disk.
+
+        *autostart_file* optionally names a program for MAME to load once the
+        machine is up (see ``mame_autostart_argument`` for the media switch
+        used per file type). It must be a HOST path, NOT a path inside the
+        mounted image: MAME's file loader knows nothing about the emulated
+        SD card's contents.
+
+        The Launch MAME button connects straight to this function, so Qt hands
+        the parameter its ``clicked(checked)`` bool — hence the isinstance()
+        guard below rather than a bare truth test.
+        """
         # Launching MAME boots the Next with the selected HDF as its hard
         # disk and never calls hdfmonkey, so gate on a real image file being
         # selected rather than on right_disk_image_explorer_content (the
@@ -453,6 +465,19 @@ def build_emulator_ops(
                 _rompath = default_mame_flatpak_rompath()
             mame_argv += ["-rompath", _rompath]
 
+        # Autostart file, inserted before -hard1 so the image stays the final
+        # argument. MAME resolves it against its own working directory, which
+        # is its install folder (see mame_cwd below), so it is made absolute.
+        if isinstance(autostart_file, str) and autostart_file.strip():
+            _auto = os.path.abspath(autostart_file.strip().strip('"'))
+            _auto_switch = mame_autostart_argument(_auto)
+            if _auto_switch:
+                mame_argv += [_auto_switch, _auto]
+            else:
+                add_main_log_window(ui_tr_now(
+                    "MAME cannot load {name} directly; starting MAME without "
+                    "it.").format(name=os.path.basename(_auto)))
+
         if mame_image:
             mame_argv += [MAME_HARD_DISK_PARAMETER, mame_image]
 
@@ -538,14 +563,14 @@ def build_emulator_ops(
             # boot-30204.bin) is absent — a manual step the auto-install
             # deliberately leaves to the user. Point them at the guide.
             if getattr(host, "_mame_missing_files", False):
-                add_main_log_window(
+                add_main_log_window(ui_tr_now(
                     "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) "
-                    "is missing. This step is manual — see "
-                    f"{MAME_INSTALL_WIKI_URL} and follow \"Get TBBLUE (the "
-                    "Next 'boot ROM')\". Put the file tbblue.zip into MAME's "
-                    "roms folder (downloads\\mame\\roms) — DON'T extract it — "
-                    "and try again. You must provide a legally acquired, "
-                    "licensed ROM.")
+                    "is missing. This step is manual — see {url} and follow "
+                    "\"Get TBBLUE (the Next 'boot ROM')\". Put the file "
+                    "tbblue.zip into MAME's roms folder (downloads\\mame\\roms) "
+                    "— DON'T extract it — and try again. You must provide a "
+                    "legally acquired, licensed ROM.").format(
+                        url=MAME_INSTALL_WIKI_URL))
                 logging.warning(
                     "MAME launch failed: TBBLUE boot ROM missing. See "
                     f"{MAME_INSTALL_WIKI_URL}")
@@ -895,12 +920,12 @@ def build_emulator_ops(
         add_main_log_window(ui_tr_now(
             "MAME is ready to launch now — no restart needed. Use the "
             "'🕹  Launch Mame' button."))
-        add_main_log_window(
+        add_main_log_window(ui_tr_now(
             "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See "
-            f"{MAME_INSTALL_WIKI_URL} → \"Get TBBLUE (the Next 'boot ROM')\". "
-            f"Put the file tbblue.zip into MAME's roms folder ({roms_dir}) — "
-            "DON'T extract it. You must provide a legally acquired, licensed "
-            "ROM.")
+            "{url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file "
+            "tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. "
+            "You must provide a legally acquired, licensed ROM.").format(
+                url=MAME_INSTALL_WIKI_URL, roms=roms_dir))
         logging.info(f"Successfully installed MAME: {detected}")
         try:
             host._show_toast(
@@ -1361,8 +1386,10 @@ def build_emulator_ops(
             dlg.close()
             if holder["ok"]:
                 add_main_log_window(
-                    f"ZX Next Unite update: downloaded {os.path.basename(dest)} "
-                    f"to {os.path.dirname(dest)}"
+                    ui_tr_now(
+                        "ZX Next Unite update: downloaded {name} to {folder}"
+                    ).format(name=os.path.basename(dest),
+                             folder=os.path.dirname(dest))
                     + (" (SHA-256 verified)." if expected_sha256 else
                        " (no SHA-256 digest published; not verified)."))
                 runnable = holder["runnable"] or dest
@@ -1377,9 +1404,10 @@ def build_emulator_ops(
             elif os.path.isfile(dest):
                 # The package arrived but could not be unpacked — keep it
                 # so the user can extract it by hand.
-                add_main_log_window(
-                    f"ZX Next Unite update: downloaded {dest} but could not "
-                    f"unpack it: {holder['error']}")
+                add_main_log_window(ui_tr_now(
+                    "ZX Next Unite update: downloaded {path} but could not "
+                    "unpack it: {error}").format(
+                        path=dest, error=holder["error"]))
                 QMessageBox.critical(
                     host, "Update could not be unpacked",
                     f"The update was downloaded to:\n{dest}\n\n"
@@ -1408,19 +1436,21 @@ def build_emulator_ops(
         def _attach_notes(box):
             _attach_release_notes(box, notes)
         if not frozen:
-            add_main_log_window(
-                f"ZX Next Unite {tag} is available — running from source, so "
-                "update with 'git pull' instead of the Windows binary.")
+            add_main_log_window(ui_tr_now(
+                "ZX Next Unite {latest} is available — running from source, "
+                "so update with 'git pull' instead of the Windows binary."
+            ).format(latest=tag))
             box = QMessageBox(host)
             box.setIcon(QMessageBox.Information)
             box.setWindowTitle(ui_tr_now("ZX Next Unite update available"))
-            box.setText(
-                f"ZX Next Unite {tag} is available "
-                f"(you are running {ZX_NEXT_UNITE_VERSION}).\n\n"
+            box.setText(ui_tr_now(
+                "ZX Next Unite {latest} is available (you are running "
+                "{installed}).\n\n"
                 "You appear to be running from source (git clone), so the\n"
                 "recommended way to update is:\n\n"
                 "    git pull\n\n"
-                "instead of downloading the Windows binary.")
+                "instead of downloading the Windows binary.").format(
+                    latest=tag, installed=ZX_NEXT_UNITE_VERSION))
             _attach_notes(box)
             openrel = box.addButton(
                 ui_tr_now("Open the releases page"), QMessageBox.AcceptRole)
@@ -1433,9 +1463,10 @@ def build_emulator_ops(
         asset = _zxnu_pick_release_asset(release)
         if not asset:
             add_main_log_window(
-                f"ZX Next Unite {tag} is available, but the release has no "
-                "package for this platform — opening the releases page "
-                "instead.")
+                ui_tr_now(
+                    "ZX Next Unite {latest} is available, but the release has "
+                    "no package for this platform — opening the releases page "
+                    "instead.").format(latest=tag))
             if QMessageBox.question(
                     host, "ZX Next Unite update available",
                     f"{tag} is available but carries no package for this "
@@ -1450,15 +1481,16 @@ def build_emulator_ops(
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
         box.setWindowTitle(ui_tr_now("ZX Next Unite update available"))
-        box.setText(
-            f"ZX Next Unite {tag} is available — download?\n\n"
-            f"Installed: {ZX_NEXT_UNITE_VERSION}\n"
-            f"Latest: {tag}\n"
-            f"Package: {asset_name} (~{size_txt})\n\n"
+        box.setText(ui_tr_now(
+            "ZX Next Unite {latest} is available — download?\n\n"
+            "Installed: {installed}\nLatest: {latest}\n"
+            "Package: {asset} (~{size})\n\n"
             "The new version is saved next to the current one — you choose\n"
-            "when to switch (you'll be offered a restart after the download).")
+            "when to switch (you'll be offered a restart after the download)."
+        ).format(latest=tag, installed=ZX_NEXT_UNITE_VERSION,
+                 asset=asset_name, size=size_txt))
         _attach_notes(box)
-        dl = box.addButton("Download", QMessageBox.AcceptRole)
+        dl = box.addButton(ui_tr_now("Download"), QMessageBox.AcceptRole)
         box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
         box.setDefaultButton(dl)
         box.exec()
@@ -1499,9 +1531,10 @@ def build_emulator_ops(
                 remote = _parse_zxnu_version(tag)
                 local = _parse_zxnu_version(ZX_NEXT_UNITE_VERSION)
                 if not remote or not local:
-                    add_main_log_window(
+                    add_main_log_window(ui_tr_now(
                         "ZX Next Unite update check: could not parse the "
-                        f"versions (latest tag {tag!r}); skipping.")
+                        "versions (latest tag {tag}); skipping.").format(
+                            tag=repr(tag)))
                     return
                 if remote <= local:
                     add_main_log_window(ui_tr_now(
@@ -1546,10 +1579,11 @@ def build_emulator_ops(
         save_configuration_file()
         if not saved:
             return  # first run with this feature: remember, don't nag
-        add_main_log_window(
-            f"NextSync .sync5 dot command updated: v{saved} -> "
-            f"v{ZX_NEXT_UNITE_DOTN_VERSION} — please copy the new build "
-            "to your Next (it cannot be deployed automatically).")
+        add_main_log_window(ui_tr_now(
+            "NextSync .sync5 dot command updated: v{old} -> v{new} — please "
+            "copy the new build to your Next (it cannot be deployed "
+            "automatically).").format(
+                old=saved, new=ZX_NEXT_UNITE_DOTN_VERSION))
         QMessageBox.information(
             host, ".sync5 needs updating on your Next",
             "This ZX Next Unite version ships an updated NextSync dot "
@@ -1596,9 +1630,11 @@ def build_emulator_ops(
         filename = info.get("filename") or ""
         dest_dir = _cspect_update_dest_dir()
 
-        add_main_log_window(
-            f"CSpect update ▸ Starting download + install of {latest_name} "
-            f"({filename or 'archive'}) from itch.io into {dest_dir}.")
+        add_main_log_window(ui_tr_now(
+            "CSpect update ▸ Starting download + install of {name} ({file}) "
+            "from itch.io into {folder}.").format(
+                name=latest_name, file=filename or "archive",
+                folder=dest_dir))
 
         # Marshal worker-thread log lines to the UI thread. Reuses
         # MameInstallSignals (its 'status' str signal); kept on self so the
@@ -1645,9 +1681,9 @@ def build_emulator_ops(
 
         def _ok(extracted):
             host._cspect_update_installing = False
-            add_main_log_window(
-                f"CSpect update ▸ SUCCESS — {latest_name} extracted to: "
-                f"{extracted}")
+            add_main_log_window(ui_tr_now(
+                "CSpect update ▸ SUCCESS — {name} extracted to: {path}"
+            ).format(name=latest_name, path=extracted))
             # Adopt the freshly-installed build: drop the current CSpect path
             # so the rescan re-selects the newest one (find_emulators_in_
             # downloads now prefers the highest version folder). Also re-picks
@@ -1699,11 +1735,11 @@ def build_emulator_ops(
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Question)
         box.setWindowTitle(ui_tr_now("CSpect update available"))
-        box.setText(
+        box.setText(ui_tr_now(
             "A newer version of CSpect is available on itch.io.\n\n"
-            f"Installed: {installed_name}\n"
-            f"Latest: {latest_name}\n\n"
-            "Download and install the newest version now?")
+            "Installed: {installed}\nLatest: {latest}\n\n"
+            "Download and install the newest version now?").format(
+                installed=installed_name, latest=latest_name))
         _attach_release_notes(box, info.get("notes"))
         yes = box.addButton(ui_tr_now("Yes"), QMessageBox.AcceptRole)
         box.addButton(ui_tr_now("Cancel"), QMessageBox.RejectRole)
@@ -2117,19 +2153,20 @@ def build_hdfmonkey_install_ops(
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Warning)
         box.setWindowTitle(ui_tr_now("hdfmonkey download failed"))
-        box.setText(
+        box.setText(ui_tr_now(
             "The automatic hdfmonkey download from specnext.com failed — the "
             "forum may be asking for a login or an anti-robot confirmation "
             "before the download can start (see the log for details).\n\n"
             "You can install it manually instead:\n"
-            f"1. Click 'Open download page' below (or browse to\n"
-            f"    {HDF_MONKEY_JJJS_URL} ).\n"
+            "1. Click 'Open download page' below (or browse to\n"
+            "    {url} ).\n"
             "2. Download the hdfmonkey .zip file.\n"
-            f"3. Drop the downloaded .zip into this EXACT folder — the app "
-            f"has already created it, and the 'Open downloads folder' button "
-            f"below opens it so nothing needs to be typed:\n"
-            f"    {downloads_root}\n"
-            "4. Click \"I've dropped the zip - try again\".")
+            "3. Drop the downloaded .zip into this EXACT folder — the app has "
+            "already created it, and the 'Open downloads folder' button below "
+            "opens it so nothing needs to be typed:\n"
+            "    {folder}\n"
+            "4. Click \"I've dropped the zip - try again\".").format(
+                url=HDF_MONKEY_JJJS_URL, folder=downloads_root))
         open_page_btn = box.addButton(ui_tr_now("Open download page"), QMessageBox.ActionRole)
         open_folder_btn = box.addButton(ui_tr_now("Open downloads folder"), QMessageBox.ActionRole)
         retry_btn = box.addButton(ui_tr_now("I've dropped the zip - try again"),
@@ -2216,14 +2253,14 @@ def build_hdfmonkey_install_ops(
         box = QMessageBox(host)
         box.setIcon(QMessageBox.Information)
         box.setWindowTitle(ui_tr_now("Install hdfmonkey"))
-        box.setText(
+        box.setText(ui_tr_now(
             "TIP: Did you know that if you have purchased CSpect from "
             "itch.io you can do a full end-to-end CSpect install from "
             "there?\n\n"
             "Simply log into your itch.io account in the itch.io tab, "
             "navigate to CSpect and click Install.\n\n"
             "Do you still want to install hdfmonkey only, or abort and then "
-            "make an end-to-end install of CSpect using itch.io?")
+            "make an end-to-end install of CSpect using itch.io?"))
         continue_btn = box.addButton(
             ui_tr_now("Continue hdfmonkey standalone install"),
             QMessageBox.AcceptRole)

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -417,6 +417,39 @@ CATALOGS = {
         "Mouse Off": "Ratón desactivado",
         "Disable ESC Key Off": "Desactivar tecla ESC: no",
         "Disable ESC Key On": "Desactivar tecla ESC: sí",
+        "ZX Next Unite update check: could not parse the versions (latest tag {tag}); skipping.":
+            "Comprobación de ZX Next Unite: no se pudieron interpretar las versiones (última etiqueta {tag}); se omite.",
+        "ZX Next Unite {latest} is available, but the release has no package for this platform — opening the releases page instead.":
+            "ZX Next Unite {latest} está disponible, pero la versión no incluye un paquete para esta plataforma; se abrirá la página de versiones.",
+        # ---- long guidance prompts (final) ----
+        "A newer version of CSpect is available on itch.io.\n\nInstalled: {installed}\nLatest: {latest}\n\nDownload and install the newest version now?":
+            "Hay una versión más reciente de CSpect en itch.io.\n\nInstalada: {installed}\nÚltima: {latest}\n\n¿Descargar e instalar ahora la más reciente?",
+        "CSpect update ▸ SUCCESS — {name} extracted to: {path}":
+            "Actualización de CSpect ▸ CORRECTA — {name} extraído en: {path}",
+        "CSpect update ▸ Starting download + install of {name} ({file}) from itch.io into {folder}.":
+            "Actualización de CSpect ▸ iniciando descarga e instalación de {name} ({file}) desde itch.io en {folder}.",
+        "ERROR: could not build {name}: {error}":
+            "ERROR: no se pudo crear {name}: {error}",
+        "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) is missing. This step is manual — see {url} and follow \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder (downloads\\mame\\roms) — DON'T extract it — and try again. You must provide a legally acquired, licensed ROM.":
+            "MAME no puede arrancar: falta la ROM de arranque del ZX Spectrum Next (TBBLUE). Este paso es manual — consulta {url} y sigue \"Get TBBLUE (the Next 'boot ROM')\". Pon el archivo tbblue.zip en la carpeta roms de MAME (downloads\\mame\\roms) — NO lo extraigas — e inténtalo de nuevo. Debes usar una ROM adquirida legalmente y con licencia.",
+        "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See {url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. You must provide a legally acquired, licensed ROM.":
+            "Instalación de MAME ▸ SIGUIENTE PASO (manual): añade la ROM de arranque TBBLUE. Consulta {url} → \"Get TBBLUE (the Next 'boot ROM')\". Pon el archivo tbblue.zip en la carpeta roms de MAME ({roms}) — NO lo extraigas. Debes usar una ROM adquirida legalmente y con licencia.",
+        "NextSync .sync5 dot command updated: v{old} -> v{new} — please copy the new build to your Next (it cannot be deployed automatically).":
+            "Comando dot .sync5 de NextSync actualizado: v{old} -> v{new} — copia la nueva versión a tu Next (no puede desplegarse automáticamente).",
+        "TIP: Did you know that if you have purchased CSpect from itch.io you can do a full end-to-end CSpect install from there?\n\nSimply log into your itch.io account in the itch.io tab, navigate to CSpect and click Install.\n\nDo you still want to install hdfmonkey only, or abort and then make an end-to-end install of CSpect using itch.io?":
+            "CONSEJO: ¿sabías que si has comprado CSpect en itch.io puedes hacer una instalación completa de CSpect desde allí?\n\nInicia sesión en tu cuenta de itch.io en la pestaña itch.io, ve a CSpect y pulsa Instalar.\n\n¿Aún quieres instalar solo hdfmonkey, o prefieres cancelar y hacer la instalación completa de CSpect con itch.io?",
+        "The automatic hdfmonkey download from specnext.com failed — the forum may be asking for a login or an anti-robot confirmation before the download can start (see the log for details).\n\nYou can install it manually instead:\n1. Click 'Open download page' below (or browse to\n    {url} ).\n2. Download the hdfmonkey .zip file.\n3. Drop the downloaded .zip into this EXACT folder — the app has already created it, and the 'Open downloads folder' button below opens it so nothing needs to be typed:\n    {folder}\n4. Click \"I've dropped the zip - try again\".":
+            "La descarga automática de hdfmonkey desde specnext.com falló — puede que el foro pida iniciar sesión o una confirmación anti-robot antes de permitir la descarga (mira el registro para más detalles).\n\nPuedes instalarlo manualmente:\n1. Pulsa 'Open download page' abajo (o abre\n    {url} ).\n2. Descarga el archivo .zip de hdfmonkey.\n3. Copia el .zip descargado EXACTAMENTE en esta carpeta — la aplicación ya la ha creado, y el botón 'Open downloads folder' de abajo la abre para que no tengas que escribir nada:\n    {folder}\n4. Pulsa \"I've dropped the zip - try again\".",
+        "ZX Next Unite update: downloaded {name} to {folder}":
+            "Actualización de ZX Next Unite: {name} descargado en {folder}",
+        "ZX Next Unite update: downloaded {path} but could not unpack it: {error}":
+            "Actualización de ZX Next Unite: se descargó {path} pero no se pudo descomprimir: {error}",
+        "ZX Next Unite {latest} is available (you are running {installed}).\n\nYou appear to be running from source (git clone), so the\nrecommended way to update is:\n\n    git pull\n\ninstead of downloading the Windows binary.":
+            "ZX Next Unite {latest} está disponible (estás usando {installed}).\n\nParece que lo ejecutas desde el código fuente (git clone), así que la\nforma recomendada de actualizar es:\n\n    git pull\n\nen lugar de descargar el binario de Windows.",
+        "ZX Next Unite {latest} is available — download?\n\nInstalled: {installed}\nLatest: {latest}\nPackage: {asset} (~{size})\n\nThe new version is saved next to the current one — you choose\nwhen to switch (you'll be offered a restart after the download).":
+            "ZX Next Unite {latest} está disponible, ¿descargar?\n\nInstalada: {installed}\nÚltima: {latest}\nPaquete: {asset} (~{size})\n\nLa nueva versión se guarda junto a la actual — tú eliges\ncuándo cambiar (se te ofrecerá reiniciar tras la descarga).",
+        "ZX Next Unite {latest} is available — running from source, so update with 'git pull' instead of the Windows binary.":
+            "ZX Next Unite {latest} está disponible; como se ejecuta desde el código fuente, actualiza con 'git pull' en lugar del binario de Windows.",
         # ---- emulator update prompts (bodies + buttons) ----
         "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
             "Hay una versión más reciente de MAME.\n\nInstalada: 0.{installed}\nÚltima: {latest}  (0.{latest_num})\nPaquete: {asset}\n\n¿Descargar (~{size}) y actualizar tu instalación de MAME ahora?\nLos archivos existentes en la carpeta MAME se sobrescribirán.",
@@ -500,6 +533,20 @@ CATALOGS = {
             "Enviando {name} a la imagen de la tarjeta SD y luego iniciando CSpect…",
         "Start CSpect with file {name}":
             "Iniciar CSpect con el archivo {name}",
+        "Start MAME with file {name}":
+            "Iniciar MAME con el archivo {name}",
+        "Send to SD Card and start MAME with file {name}":
+            "Enviar a la tarjeta SD e iniciar MAME con el archivo {name}",
+        "Extracting {name} from the image, then starting MAME…":
+            "Extrayendo {name} de la imagen y luego iniciando MAME…",
+        "Start MAME: {name} could not be read from the image, MAME was not started.":
+            "Iniciar MAME: no se pudo leer {name} de la imagen; MAME no se ha iniciado.",
+        "Send to SD Card and start MAME: the transfer failed, MAME was not started.":
+            "Enviar a la tarjeta SD e iniciar MAME: la transferencia falló; MAME no se ha iniciado.",
+        "Sending {name} to the SD card image, then starting MAME…":
+            "Enviando {name} a la imagen de la tarjeta SD y luego iniciando MAME…",
+        "MAME cannot load {name} directly; starting MAME without it.":
+            "MAME no puede cargar {name} directamente; se iniciará MAME sin ese archivo.",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Actualización de CSpect disponible",
@@ -1183,6 +1230,39 @@ CATALOGS = {
         "Mouse Off": "Rato desligado",
         "Disable ESC Key Off": "Desativar tecla ESC: não",
         "Disable ESC Key On": "Desativar tecla ESC: sim",
+        "ZX Next Unite update check: could not parse the versions (latest tag {tag}); skipping.":
+            "Verificação do ZX Next Unite: não foi possível interpretar as versões (etiqueta mais recente {tag}); a ignorar.",
+        "ZX Next Unite {latest} is available, but the release has no package for this platform — opening the releases page instead.":
+            "O ZX Next Unite {latest} está disponível, mas a versão não inclui um pacote para esta plataforma; será aberta a página de versões.",
+        # ---- long guidance prompts (final) ----
+        "A newer version of CSpect is available on itch.io.\n\nInstalled: {installed}\nLatest: {latest}\n\nDownload and install the newest version now?":
+            "Existe uma versão mais recente do CSpect no itch.io.\n\nInstalada: {installed}\nMais recente: {latest}\n\nTransferir e instalar agora a mais recente?",
+        "CSpect update ▸ SUCCESS — {name} extracted to: {path}":
+            "Atualização do CSpect ▸ CONCLUÍDA — {name} extraído para: {path}",
+        "CSpect update ▸ Starting download + install of {name} ({file}) from itch.io into {folder}.":
+            "Atualização do CSpect ▸ a iniciar transferência e instalação de {name} ({file}) do itch.io para {folder}.",
+        "ERROR: could not build {name}: {error}":
+            "ERRO: não foi possível criar {name}: {error}",
+        "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) is missing. This step is manual — see {url} and follow \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder (downloads\\mame\\roms) — DON'T extract it — and try again. You must provide a legally acquired, licensed ROM.":
+            "O MAME não consegue arrancar: falta a ROM de arranque do ZX Spectrum Next (TBBLUE). Este passo é manual — consulta {url} e segue \"Get TBBLUE (the Next 'boot ROM')\". Coloca o ficheiro tbblue.zip na pasta roms do MAME (downloads\\mame\\roms) — NÃO o extraias — e tenta de novo. Tens de usar uma ROM adquirida legalmente e licenciada.",
+        "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See {url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. You must provide a legally acquired, licensed ROM.":
+            "Instalação do MAME ▸ PASSO SEGUINTE (manual): adiciona a ROM de arranque TBBLUE. Consulta {url} → \"Get TBBLUE (the Next 'boot ROM')\". Coloca o ficheiro tbblue.zip na pasta roms do MAME ({roms}) — NÃO o extraias. Tens de usar uma ROM adquirida legalmente e licenciada.",
+        "NextSync .sync5 dot command updated: v{old} -> v{new} — please copy the new build to your Next (it cannot be deployed automatically).":
+            "Comando dot .sync5 do NextSync atualizado: v{old} -> v{new} — copia a nova versão para o teu Next (não pode ser implantada automaticamente).",
+        "TIP: Did you know that if you have purchased CSpect from itch.io you can do a full end-to-end CSpect install from there?\n\nSimply log into your itch.io account in the itch.io tab, navigate to CSpect and click Install.\n\nDo you still want to install hdfmonkey only, or abort and then make an end-to-end install of CSpect using itch.io?":
+            "DICA: sabias que se compraste o CSpect no itch.io podes fazer uma instalação completa do CSpect a partir daí?\n\nInicia sessão na tua conta itch.io no separador itch.io, vai a CSpect e clica em Instalar.\n\nAinda queres instalar apenas o hdfmonkey, ou preferes cancelar e fazer a instalação completa do CSpect com o itch.io?",
+        "The automatic hdfmonkey download from specnext.com failed — the forum may be asking for a login or an anti-robot confirmation before the download can start (see the log for details).\n\nYou can install it manually instead:\n1. Click 'Open download page' below (or browse to\n    {url} ).\n2. Download the hdfmonkey .zip file.\n3. Drop the downloaded .zip into this EXACT folder — the app has already created it, and the 'Open downloads folder' button below opens it so nothing needs to be typed:\n    {folder}\n4. Click \"I've dropped the zip - try again\".":
+            "A transferência automática do hdfmonkey a partir de specnext.com falhou — o fórum pode estar a pedir início de sessão ou uma confirmação anti-robô antes de permitir a transferência (vê o registo para detalhes).\n\nPodes instalá-lo manualmente:\n1. Clica em 'Open download page' abaixo (ou abre\n    {url} ).\n2. Transfere o ficheiro .zip do hdfmonkey.\n3. Coloca o .zip transferido EXATAMENTE nesta pasta — a aplicação já a criou, e o botão 'Open downloads folder' abaixo abre-a para não teres de escrever nada:\n    {folder}\n4. Clica em \"I've dropped the zip - try again\".",
+        "ZX Next Unite update: downloaded {name} to {folder}":
+            "Atualização do ZX Next Unite: {name} transferido para {folder}",
+        "ZX Next Unite update: downloaded {path} but could not unpack it: {error}":
+            "Atualização do ZX Next Unite: {path} foi transferido mas não foi possível descompactá-lo: {error}",
+        "ZX Next Unite {latest} is available (you are running {installed}).\n\nYou appear to be running from source (git clone), so the\nrecommended way to update is:\n\n    git pull\n\ninstead of downloading the Windows binary.":
+            "O ZX Next Unite {latest} está disponível (estás a usar {installed}).\n\nParece que o executas a partir do código-fonte (git clone), por isso a\nforma recomendada de atualizar é:\n\n    git pull\n\nem vez de transferir o binário de Windows.",
+        "ZX Next Unite {latest} is available — download?\n\nInstalled: {installed}\nLatest: {latest}\nPackage: {asset} (~{size})\n\nThe new version is saved next to the current one — you choose\nwhen to switch (you'll be offered a restart after the download).":
+            "O ZX Next Unite {latest} está disponível — transferir?\n\nInstalada: {installed}\nMais recente: {latest}\nPacote: {asset} (~{size})\n\nA nova versão é guardada junto da atual — escolhes\nquando mudar (será oferecido um reinício após a transferência).",
+        "ZX Next Unite {latest} is available — running from source, so update with 'git pull' instead of the Windows binary.":
+            "O ZX Next Unite {latest} está disponível; como corre a partir do código-fonte, atualiza com 'git pull' em vez do binário de Windows.",
         # ---- emulator update prompts (bodies + buttons) ----
         "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
             "Existe uma versão mais recente do MAME.\n\nInstalada: 0.{installed}\nMais recente: {latest}  (0.{latest_num})\nPacote: {asset}\n\nTransferir (~{size}) e atualizar a instalação do MAME agora?\nOs ficheiros existentes na pasta MAME serão substituídos.",
@@ -1266,6 +1346,20 @@ CATALOGS = {
             "A enviar {name} para a imagem do cartão SD e depois a iniciar o CSpect…",
         "Start CSpect with file {name}":
             "Iniciar o CSpect com o ficheiro {name}",
+        "Start MAME with file {name}":
+            "Iniciar o MAME com o ficheiro {name}",
+        "Send to SD Card and start MAME with file {name}":
+            "Enviar para o cartão SD e iniciar o MAME com o ficheiro {name}",
+        "Extracting {name} from the image, then starting MAME…":
+            "A extrair {name} da imagem e depois a iniciar o MAME…",
+        "Start MAME: {name} could not be read from the image, MAME was not started.":
+            "Iniciar o MAME: não foi possível ler {name} da imagem; o MAME não foi iniciado.",
+        "Send to SD Card and start MAME: the transfer failed, MAME was not started.":
+            "Enviar para o cartão SD e iniciar o MAME: a transferência falhou; o MAME não foi iniciado.",
+        "Sending {name} to the SD card image, then starting MAME…":
+            "A enviar {name} para a imagem do cartão SD e depois a iniciar o MAME…",
+        "MAME cannot load {name} directly; starting MAME without it.":
+            "O MAME não consegue carregar {name} diretamente; o MAME será iniciado sem esse ficheiro.",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Atualização do CSpect disponível",
@@ -1947,6 +2041,39 @@ CATALOGS = {
         "Mouse Off": "Mysz wyłączona",
         "Disable ESC Key Off": "Blokada klawisza ESC: wył.",
         "Disable ESC Key On": "Blokada klawisza ESC: wł.",
+        "ZX Next Unite update check: could not parse the versions (latest tag {tag}); skipping.":
+            "Sprawdzanie ZX Next Unite: nie udało się odczytać wersji (najnowszy tag {tag}) — pomijanie.",
+        "ZX Next Unite {latest} is available, but the release has no package for this platform — opening the releases page instead.":
+            "Dostępny jest ZX Next Unite {latest}, ale wydanie nie zawiera pakietu dla tej platformy — zostanie otwarta strona wydań.",
+        # ---- long guidance prompts (final) ----
+        "A newer version of CSpect is available on itch.io.\n\nInstalled: {installed}\nLatest: {latest}\n\nDownload and install the newest version now?":
+            "Na itch.io dostępna jest nowsza wersja CSpect.\n\nZainstalowana: {installed}\nNajnowsza: {latest}\n\nPobrać i zainstalować teraz najnowszą?",
+        "CSpect update ▸ SUCCESS — {name} extracted to: {path}":
+            "Aktualizacja CSpect ▸ SUKCES — {name} wypakowano do: {path}",
+        "CSpect update ▸ Starting download + install of {name} ({file}) from itch.io into {folder}.":
+            "Aktualizacja CSpect ▸ rozpoczynanie pobierania i instalacji {name} ({file}) z itch.io do {folder}.",
+        "ERROR: could not build {name}: {error}":
+            "BŁĄD: nie udało się utworzyć {name}: {error}",
+        "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) is missing. This step is manual — see {url} and follow \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder (downloads\\mame\\roms) — DON'T extract it — and try again. You must provide a legally acquired, licensed ROM.":
+            "MAME nie może wystartować: brakuje ROM-u rozruchowego ZX Spectrum Next (TBBLUE). Ten krok jest ręczny — zobacz {url} i wykonaj \"Get TBBLUE (the Next 'boot ROM')\". Umieść plik tbblue.zip w folderze roms MAME (downloads\\mame\\roms) — NIE rozpakowuj go — i spróbuj ponownie. Musisz użyć legalnie nabytego, licencjonowanego ROM-u.",
+        "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See {url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. You must provide a legally acquired, licensed ROM.":
+            "Instalacja MAME ▸ NASTĘPNY KROK (ręczny): dodaj ROM rozruchowy TBBLUE. Zobacz {url} → \"Get TBBLUE (the Next 'boot ROM')\". Umieść plik tbblue.zip w folderze roms MAME ({roms}) — NIE rozpakowuj go. Musisz użyć legalnie nabytego, licencjonowanego ROM-u.",
+        "NextSync .sync5 dot command updated: v{old} -> v{new} — please copy the new build to your Next (it cannot be deployed automatically).":
+            "Polecenie dot .sync5 NextSync zaktualizowane: v{old} -> v{new} — skopiuj nową wersję na swojego Next (nie da się jej wdrożyć automatycznie).",
+        "TIP: Did you know that if you have purchased CSpect from itch.io you can do a full end-to-end CSpect install from there?\n\nSimply log into your itch.io account in the itch.io tab, navigate to CSpect and click Install.\n\nDo you still want to install hdfmonkey only, or abort and then make an end-to-end install of CSpect using itch.io?":
+            "WSKAZÓWKA: czy wiesz, że jeśli kupiłeś CSpect na itch.io, możesz wykonać pełną instalację CSpect właśnie stamtąd?\n\nZaloguj się na swoje konto itch.io w karcie itch.io, przejdź do CSpect i kliknij Zainstaluj.\n\nCzy nadal chcesz zainstalować tylko hdfmonkey, czy przerwać i wykonać pełną instalację CSpect przez itch.io?",
+        "The automatic hdfmonkey download from specnext.com failed — the forum may be asking for a login or an anti-robot confirmation before the download can start (see the log for details).\n\nYou can install it manually instead:\n1. Click 'Open download page' below (or browse to\n    {url} ).\n2. Download the hdfmonkey .zip file.\n3. Drop the downloaded .zip into this EXACT folder — the app has already created it, and the 'Open downloads folder' button below opens it so nothing needs to be typed:\n    {folder}\n4. Click \"I've dropped the zip - try again\".":
+            "Automatyczne pobranie hdfmonkey ze specnext.com nie powiodło się — forum może wymagać zalogowania lub potwierdzenia anty-robot przed rozpoczęciem pobierania (szczegóły w dzienniku).\n\nMożesz zainstalować go ręcznie:\n1. Kliknij 'Open download page' poniżej (albo otwórz\n    {url} ).\n2. Pobierz plik .zip hdfmonkey.\n3. Umieść pobrany .zip DOKŁADNIE w tym folderze — aplikacja już go utworzyła, a przycisk 'Open downloads folder' poniżej otwiera go, więc nic nie trzeba wpisywać:\n    {folder}\n4. Kliknij \"I've dropped the zip - try again\".",
+        "ZX Next Unite update: downloaded {name} to {folder}":
+            "Aktualizacja ZX Next Unite: pobrano {name} do {folder}",
+        "ZX Next Unite update: downloaded {path} but could not unpack it: {error}":
+            "Aktualizacja ZX Next Unite: pobrano {path}, ale nie udało się rozpakować: {error}",
+        "ZX Next Unite {latest} is available (you are running {installed}).\n\nYou appear to be running from source (git clone), so the\nrecommended way to update is:\n\n    git pull\n\ninstead of downloading the Windows binary.":
+            "Dostępny jest ZX Next Unite {latest} (używasz {installed}).\n\nWygląda na to, że uruchamiasz program ze źródeł (git clone), więc\nzalecany sposób aktualizacji to:\n\n    git pull\n\nzamiast pobierania binarium dla Windows.",
+        "ZX Next Unite {latest} is available — download?\n\nInstalled: {installed}\nLatest: {latest}\nPackage: {asset} (~{size})\n\nThe new version is saved next to the current one — you choose\nwhen to switch (you'll be offered a restart after the download).":
+            "Dostępny jest ZX Next Unite {latest} — pobrać?\n\nZainstalowana: {installed}\nNajnowsza: {latest}\nPakiet: {asset} (~{size})\n\nNowa wersja zapisywana jest obok obecnej — sam decydujesz,\nkiedy się przełączyć (po pobraniu zaproponujemy restart).",
+        "ZX Next Unite {latest} is available — running from source, so update with 'git pull' instead of the Windows binary.":
+            "Dostępny jest ZX Next Unite {latest} — program działa ze źródeł, więc zaktualizuj poleceniem 'git pull' zamiast pobierać binarium Windows.",
         # ---- emulator update prompts (bodies + buttons) ----
         "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
             "Dostępna jest nowsza wersja MAME.\n\nZainstalowana: 0.{installed}\nNajnowsza: {latest}  (0.{latest_num})\nPakiet: {asset}\n\nPobrać (~{size}) i zaktualizować instalację MAME teraz?\nIstniejące pliki w folderze MAME zostaną nadpisane.",
@@ -2030,6 +2157,20 @@ CATALOGS = {
             "Wysyłanie {name} do obrazu karty SD, potem uruchomienie CSpect…",
         "Start CSpect with file {name}":
             "Uruchom CSpect z plikiem {name}",
+        "Start MAME with file {name}":
+            "Uruchom MAME z plikiem {name}",
+        "Send to SD Card and start MAME with file {name}":
+            "Wyślij na kartę SD i uruchom MAME z plikiem {name}",
+        "Extracting {name} from the image, then starting MAME…":
+            "Wypakowywanie {name} z obrazu, potem uruchomienie MAME…",
+        "Start MAME: {name} could not be read from the image, MAME was not started.":
+            "Uruchom MAME: nie udało się odczytać {name} z obrazu — MAME nie zostało uruchomione.",
+        "Send to SD Card and start MAME: the transfer failed, MAME was not started.":
+            "Wyślij na kartę SD i uruchom MAME: transfer nie powiódł się — MAME nie zostało uruchomione.",
+        "Sending {name} to the SD card image, then starting MAME…":
+            "Wysyłanie {name} do obrazu karty SD, potem uruchomienie MAME…",
+        "MAME cannot load {name} directly; starting MAME without it.":
+            "MAME nie może załadować {name} bezpośrednio — MAME zostanie uruchomione bez tego pliku.",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Dostępna aktualizacja CSpect",
@@ -2712,6 +2853,39 @@ CATALOGS = {
         "Mouse Off": "Мышь выкл.",
         "Disable ESC Key Off": "Блокировка ESC: выкл.",
         "Disable ESC Key On": "Блокировка ESC: вкл.",
+        "ZX Next Unite update check: could not parse the versions (latest tag {tag}); skipping.":
+            "Проверка ZX Next Unite: не удалось разобрать версии (последний тег {tag}) — пропуск.",
+        "ZX Next Unite {latest} is available, but the release has no package for this platform — opening the releases page instead.":
+            "Доступен ZX Next Unite {latest}, но в релизе нет пакета для этой платформы — откроется страница релизов.",
+        # ---- long guidance prompts (final) ----
+        "A newer version of CSpect is available on itch.io.\n\nInstalled: {installed}\nLatest: {latest}\n\nDownload and install the newest version now?":
+            "На itch.io доступна более новая версия CSpect.\n\nУстановлена: {installed}\nПоследняя: {latest}\n\nСкачать и установить новейшую версию сейчас?",
+        "CSpect update ▸ SUCCESS — {name} extracted to: {path}":
+            "Обновление CSpect ▸ УСПЕШНО — {name} распакован в: {path}",
+        "CSpect update ▸ Starting download + install of {name} ({file}) from itch.io into {folder}.":
+            "Обновление CSpect ▸ начало загрузки и установки {name} ({file}) с itch.io в {folder}.",
+        "ERROR: could not build {name}: {error}":
+            "ОШИБКА: не удалось создать {name}: {error}",
+        "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) is missing. This step is manual — see {url} and follow \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder (downloads\\mame\\roms) — DON'T extract it — and try again. You must provide a legally acquired, licensed ROM.":
+            "MAME не может запуститься: отсутствует загрузочная ROM ZX Spectrum Next (TBBLUE). Этот шаг выполняется вручную — см. {url} и раздел \"Get TBBLUE (the Next 'boot ROM')\". Поместите файл tbblue.zip в папку roms MAME (downloads\\mame\\roms) — НЕ распаковывайте его — и повторите попытку. Используйте только легально приобретённую лицензионную ROM.",
+        "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See {url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. You must provide a legally acquired, licensed ROM.":
+            "Установка MAME ▸ СЛЕДУЮЩИЙ ШАГ (вручную): добавьте загрузочную ROM TBBLUE. См. {url} → \"Get TBBLUE (the Next 'boot ROM')\". Поместите файл tbblue.zip в папку roms MAME ({roms}) — НЕ распаковывайте его. Используйте только легально приобретённую лицензионную ROM.",
+        "NextSync .sync5 dot command updated: v{old} -> v{new} — please copy the new build to your Next (it cannot be deployed automatically).":
+            "Dot-команда NextSync .sync5 обновлена: v{old} -> v{new} — скопируйте новую сборку на Next (автоматическое развёртывание невозможно).",
+        "TIP: Did you know that if you have purchased CSpect from itch.io you can do a full end-to-end CSpect install from there?\n\nSimply log into your itch.io account in the itch.io tab, navigate to CSpect and click Install.\n\nDo you still want to install hdfmonkey only, or abort and then make an end-to-end install of CSpect using itch.io?":
+            "СОВЕТ: знали ли вы, что если CSpect куплен на itch.io, можно выполнить полную установку CSpect прямо оттуда?\n\nВойдите в свою учётную запись itch.io на вкладке itch.io, найдите CSpect и нажмите «Установить».\n\nВсё ещё установить только hdfmonkey или прервать и выполнить полную установку CSpect через itch.io?",
+        "The automatic hdfmonkey download from specnext.com failed — the forum may be asking for a login or an anti-robot confirmation before the download can start (see the log for details).\n\nYou can install it manually instead:\n1. Click 'Open download page' below (or browse to\n    {url} ).\n2. Download the hdfmonkey .zip file.\n3. Drop the downloaded .zip into this EXACT folder — the app has already created it, and the 'Open downloads folder' button below opens it so nothing needs to be typed:\n    {folder}\n4. Click \"I've dropped the zip - try again\".":
+            "Автоматическая загрузка hdfmonkey с specnext.com не удалась — форум может требовать входа или анти-робот подтверждения перед началом загрузки (подробности в журнале).\n\nМожно установить вручную:\n1. Нажмите 'Open download page' ниже (или откройте\n    {url} ).\n2. Скачайте .zip-файл hdfmonkey.\n3. Положите скачанный .zip ИМЕННО в эту папку — приложение уже создало её, а кнопка 'Open downloads folder' ниже открывает её, так что вводить ничего не нужно:\n    {folder}\n4. Нажмите \"I've dropped the zip - try again\".",
+        "ZX Next Unite update: downloaded {name} to {folder}":
+            "Обновление ZX Next Unite: {name} загружен в {folder}",
+        "ZX Next Unite update: downloaded {path} but could not unpack it: {error}":
+            "Обновление ZX Next Unite: {path} загружен, но распаковать не удалось: {error}",
+        "ZX Next Unite {latest} is available (you are running {installed}).\n\nYou appear to be running from source (git clone), so the\nrecommended way to update is:\n\n    git pull\n\ninstead of downloading the Windows binary.":
+            "Доступен ZX Next Unite {latest} (у вас {installed}).\n\nПохоже, вы запускаете программу из исходников (git clone), поэтому\nрекомендуемый способ обновления:\n\n    git pull\n\nвместо загрузки бинарника для Windows.",
+        "ZX Next Unite {latest} is available — download?\n\nInstalled: {installed}\nLatest: {latest}\nPackage: {asset} (~{size})\n\nThe new version is saved next to the current one — you choose\nwhen to switch (you'll be offered a restart after the download).":
+            "Доступен ZX Next Unite {latest} — скачать?\n\nУстановлена: {installed}\nПоследняя: {latest}\nПакет: {asset} (~{size})\n\nНовая версия сохраняется рядом с текущей — вы сами решаете,\nкогда переключиться (после загрузки будет предложен перезапуск).",
+        "ZX Next Unite {latest} is available — running from source, so update with 'git pull' instead of the Windows binary.":
+            "Доступен ZX Next Unite {latest} — запуск из исходников, поэтому обновляйтесь через 'git pull', а не бинарником для Windows.",
         # ---- emulator update prompts (bodies + buttons) ----
         "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
             "Доступна более новая версия MAME.\n\nУстановлена: 0.{installed}\nПоследняя: {latest}  (0.{latest_num})\nПакет: {asset}\n\nСкачать (~{size}) и обновить установку MAME сейчас?\nСуществующие файлы в папке MAME будут перезаписаны.",
@@ -2795,6 +2969,20 @@ CATALOGS = {
             "Отправка {name} в образ SD-карты, затем запуск CSpect…",
         "Start CSpect with file {name}":
             "Запустить CSpect с файлом {name}",
+        "Start MAME with file {name}":
+            "Запустить MAME с файлом {name}",
+        "Send to SD Card and start MAME with file {name}":
+            "Отправить на SD-карту и запустить MAME с файлом {name}",
+        "Extracting {name} from the image, then starting MAME…":
+            "Извлечение {name} из образа, затем запуск MAME…",
+        "Start MAME: {name} could not be read from the image, MAME was not started.":
+            "Запуск MAME: не удалось прочитать {name} из образа — MAME не запущен.",
+        "Send to SD Card and start MAME: the transfer failed, MAME was not started.":
+            "Отправка на SD-карту и запуск MAME: передача не удалась — MAME не запущен.",
+        "Sending {name} to the SD card image, then starting MAME…":
+            "Отправка {name} в образ SD-карты, затем запуск MAME…",
+        "MAME cannot load {name} directly; starting MAME without it.":
+            "MAME не может загрузить {name} напрямую — MAME будет запущен без этого файла.",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Доступно обновление CSpect",
@@ -3476,6 +3664,39 @@ CATALOGS = {
         "Mouse Off": "Myš vypnuta",
         "Disable ESC Key Off": "Blokovat klávesu ESC: ne",
         "Disable ESC Key On": "Blokovat klávesu ESC: ano",
+        "ZX Next Unite update check: could not parse the versions (latest tag {tag}); skipping.":
+            "Kontrola ZX Next Unite: nepodařilo se rozpoznat verze (nejnovější značka {tag}) — přeskakuje se.",
+        "ZX Next Unite {latest} is available, but the release has no package for this platform — opening the releases page instead.":
+            "Je dostupný ZX Next Unite {latest}, ale vydání neobsahuje balíček pro tuto platformu — otevře se stránka vydání.",
+        # ---- long guidance prompts (final) ----
+        "A newer version of CSpect is available on itch.io.\n\nInstalled: {installed}\nLatest: {latest}\n\nDownload and install the newest version now?":
+            "Na itch.io je dostupná novější verze CSpectu.\n\nNainstalovaná: {installed}\nNejnovější: {latest}\n\nStáhnout a nainstalovat nejnovější verzi nyní?",
+        "CSpect update ▸ SUCCESS — {name} extracted to: {path}":
+            "Aktualizace CSpectu ▸ ÚSPĚCH — {name} rozbaleno do: {path}",
+        "CSpect update ▸ Starting download + install of {name} ({file}) from itch.io into {folder}.":
+            "Aktualizace CSpectu ▸ zahájení stažení a instalace {name} ({file}) z itch.io do {folder}.",
+        "ERROR: could not build {name}: {error}":
+            "CHYBA: nepodařilo se vytvořit {name}: {error}",
+        "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) is missing. This step is manual — see {url} and follow \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder (downloads\\mame\\roms) — DON'T extract it — and try again. You must provide a legally acquired, licensed ROM.":
+            "MAME nemůže nastartovat: chybí zaváděcí ROM ZX Spectrum Next (TBBLUE). Tento krok je ruční — viz {url} a postup \"Get TBBLUE (the Next 'boot ROM')\". Vložte soubor tbblue.zip do složky roms MAME (downloads\\mame\\roms) — NEROZBALUJTE jej — a zkuste to znovu. Musíte použít legálně pořízenou licencovanou ROM.",
+        "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See {url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. You must provide a legally acquired, licensed ROM.":
+            "Instalace MAME ▸ DALŠÍ KROK (ruční): přidejte zaváděcí ROM TBBLUE. Viz {url} → \"Get TBBLUE (the Next 'boot ROM')\". Vložte soubor tbblue.zip do složky roms MAME ({roms}) — NEROZBALUJTE jej. Musíte použít legálně pořízenou licencovanou ROM.",
+        "NextSync .sync5 dot command updated: v{old} -> v{new} — please copy the new build to your Next (it cannot be deployed automatically).":
+            "Dot příkaz NextSync .sync5 aktualizován: v{old} -> v{new} — zkopírujte novou verzi na svůj Next (nelze ji nasadit automaticky).",
+        "TIP: Did you know that if you have purchased CSpect from itch.io you can do a full end-to-end CSpect install from there?\n\nSimply log into your itch.io account in the itch.io tab, navigate to CSpect and click Install.\n\nDo you still want to install hdfmonkey only, or abort and then make an end-to-end install of CSpect using itch.io?":
+            "TIP: věděli jste, že pokud máte CSpect zakoupený na itch.io, můžete odtud provést kompletní instalaci CSpectu?\n\nPřihlaste se ke svému účtu itch.io na kartě itch.io, přejděte na CSpect a klikněte na Instalovat.\n\nChcete přesto nainstalovat pouze hdfmonkey, nebo akci přerušit a provést kompletní instalaci CSpectu přes itch.io?",
+        "The automatic hdfmonkey download from specnext.com failed — the forum may be asking for a login or an anti-robot confirmation before the download can start (see the log for details).\n\nYou can install it manually instead:\n1. Click 'Open download page' below (or browse to\n    {url} ).\n2. Download the hdfmonkey .zip file.\n3. Drop the downloaded .zip into this EXACT folder — the app has already created it, and the 'Open downloads folder' button below opens it so nothing needs to be typed:\n    {folder}\n4. Click \"I've dropped the zip - try again\".":
+            "Automatické stažení hdfmonkey ze specnext.com selhalo — fórum může před zahájením stahování vyžadovat přihlášení nebo potvrzení proti robotům (podrobnosti v logu).\n\nMůžete jej nainstalovat ručně:\n1. Klikněte na 'Open download page' níže (nebo otevřete\n    {url} ).\n2. Stáhněte soubor .zip s hdfmonkey.\n3. Vložte stažený .zip PŘESNĚ do této složky — aplikace ji už vytvořila a tlačítko 'Open downloads folder' níže ji otevře, takže nic nemusíte psát:\n    {folder}\n4. Klikněte na \"I've dropped the zip - try again\".",
+        "ZX Next Unite update: downloaded {name} to {folder}":
+            "Aktualizace ZX Next Unite: {name} staženo do {folder}",
+        "ZX Next Unite update: downloaded {path} but could not unpack it: {error}":
+            "Aktualizace ZX Next Unite: {path} staženo, ale nepodařilo se rozbalit: {error}",
+        "ZX Next Unite {latest} is available (you are running {installed}).\n\nYou appear to be running from source (git clone), so the\nrecommended way to update is:\n\n    git pull\n\ninstead of downloading the Windows binary.":
+            "Je dostupný ZX Next Unite {latest} (používáte {installed}).\n\nZdá se, že program spouštíte ze zdrojů (git clone), takže\ndoporučený způsob aktualizace je:\n\n    git pull\n\nmísto stahování binárky pro Windows.",
+        "ZX Next Unite {latest} is available — download?\n\nInstalled: {installed}\nLatest: {latest}\nPackage: {asset} (~{size})\n\nThe new version is saved next to the current one — you choose\nwhen to switch (you'll be offered a restart after the download).":
+            "Je dostupný ZX Next Unite {latest} — stáhnout?\n\nNainstalovaná: {installed}\nNejnovější: {latest}\nBalíček: {asset} (~{size})\n\nNová verze se uloží vedle stávající — sami zvolíte,\nkdy přepnout (po stažení bude nabídnut restart).",
+        "ZX Next Unite {latest} is available — running from source, so update with 'git pull' instead of the Windows binary.":
+            "Je dostupný ZX Next Unite {latest} — běží ze zdrojů, takže aktualizujte příkazem 'git pull' místo stahování binárky pro Windows.",
         # ---- emulator update prompts (bodies + buttons) ----
         "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
             "Je dostupná novější verze MAME.\n\nNainstalovaná: 0.{installed}\nNejnovější: {latest}  (0.{latest_num})\nBalíček: {asset}\n\nStáhnout (~{size}) a aktualizovat instalaci MAME nyní?\nStávající soubory ve složce MAME budou přepsány.",
@@ -3559,6 +3780,20 @@ CATALOGS = {
             "Odesílání {name} do obrazu SD karty, poté spuštění CSpectu…",
         "Start CSpect with file {name}":
             "Spustit CSpect se souborem {name}",
+        "Start MAME with file {name}":
+            "Spustit MAME se souborem {name}",
+        "Send to SD Card and start MAME with file {name}":
+            "Odeslat na SD kartu a spustit MAME se souborem {name}",
+        "Extracting {name} from the image, then starting MAME…":
+            "Rozbaluje se {name} z obrazu, poté se spustí MAME…",
+        "Start MAME: {name} could not be read from the image, MAME was not started.":
+            "Spustit MAME: {name} se nepodařilo načíst z obrazu — MAME nebyl spuštěn.",
+        "Send to SD Card and start MAME: the transfer failed, MAME was not started.":
+            "Odeslat na SD kartu a spustit MAME: přenos selhal — MAME nebyl spuštěn.",
+        "Sending {name} to the SD card image, then starting MAME…":
+            "Odesílání {name} do obrazu SD karty, poté spuštění MAME…",
+        "MAME cannot load {name} directly; starting MAME without it.":
+            "MAME nemůže {name} načíst přímo — MAME bude spuštěn bez tohoto souboru.",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "K dispozici je aktualizace CSpectu",
@@ -4243,6 +4478,39 @@ CATALOGS = {
         "Mouse Off": "Souris désactivée",
         "Disable ESC Key Off": "Désactiver la touche ÉCHAP : non",
         "Disable ESC Key On": "Désactiver la touche ÉCHAP : oui",
+        "ZX Next Unite update check: could not parse the versions (latest tag {tag}); skipping.":
+            "Vérification de ZX Next Unite : impossible d'analyser les versions (dernière étiquette {tag}) ; ignorée.",
+        "ZX Next Unite {latest} is available, but the release has no package for this platform — opening the releases page instead.":
+            "ZX Next Unite {latest} est disponible, mais la version ne contient aucun paquet pour cette plateforme — la page des versions va s'ouvrir.",
+        # ---- long guidance prompts (final) ----
+        "A newer version of CSpect is available on itch.io.\n\nInstalled: {installed}\nLatest: {latest}\n\nDownload and install the newest version now?":
+            "Une version plus récente de CSpect est disponible sur itch.io.\n\nInstallée : {installed}\nDernière : {latest}\n\nTélécharger et installer la plus récente maintenant ?",
+        "CSpect update ▸ SUCCESS — {name} extracted to: {path}":
+            "Mise à jour de CSpect ▸ RÉUSSIE — {name} extrait dans : {path}",
+        "CSpect update ▸ Starting download + install of {name} ({file}) from itch.io into {folder}.":
+            "Mise à jour de CSpect ▸ démarrage du téléchargement et de l'installation de {name} ({file}) depuis itch.io vers {folder}.",
+        "ERROR: could not build {name}: {error}":
+            "ERREUR : impossible de créer {name} : {error}",
+        "MAME can't start: the ZX Spectrum Next boot ROM (TBBLUE) is missing. This step is manual — see {url} and follow \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder (downloads\\mame\\roms) — DON'T extract it — and try again. You must provide a legally acquired, licensed ROM.":
+            "MAME ne peut pas démarrer : la ROM de démarrage du ZX Spectrum Next (TBBLUE) est absente. Cette étape est manuelle — voir {url} et suivre \"Get TBBLUE (the Next 'boot ROM')\". Placez le fichier tbblue.zip dans le dossier roms de MAME (downloads\\mame\\roms) — NE l'extrayez PAS — puis réessayez. Vous devez fournir une ROM acquise légalement et sous licence.",
+        "MAME install ▸ NEXT STEP (manual): add the TBBLUE boot ROM. See {url} → \"Get TBBLUE (the Next 'boot ROM')\". Put the file tbblue.zip into MAME's roms folder ({roms}) — DON'T extract it. You must provide a legally acquired, licensed ROM.":
+            "Installation de MAME ▸ ÉTAPE SUIVANTE (manuelle) : ajoutez la ROM de démarrage TBBLUE. Voir {url} → \"Get TBBLUE (the Next 'boot ROM')\". Placez le fichier tbblue.zip dans le dossier roms de MAME ({roms}) — NE l'extrayez PAS. Vous devez fournir une ROM acquise légalement et sous licence.",
+        "NextSync .sync5 dot command updated: v{old} -> v{new} — please copy the new build to your Next (it cannot be deployed automatically).":
+            "Commande dot .sync5 de NextSync mise à jour : v{old} -> v{new} — copiez la nouvelle version sur votre Next (le déploiement automatique est impossible).",
+        "TIP: Did you know that if you have purchased CSpect from itch.io you can do a full end-to-end CSpect install from there?\n\nSimply log into your itch.io account in the itch.io tab, navigate to CSpect and click Install.\n\nDo you still want to install hdfmonkey only, or abort and then make an end-to-end install of CSpect using itch.io?":
+            "ASTUCE : saviez-vous que si vous avez acheté CSpect sur itch.io, vous pouvez y faire une installation complète de CSpect ?\n\nConnectez-vous à votre compte itch.io dans l'onglet itch.io, allez sur CSpect et cliquez sur Installer.\n\nVoulez-vous quand même installer uniquement hdfmonkey, ou annuler et faire l'installation complète de CSpect via itch.io ?",
+        "The automatic hdfmonkey download from specnext.com failed — the forum may be asking for a login or an anti-robot confirmation before the download can start (see the log for details).\n\nYou can install it manually instead:\n1. Click 'Open download page' below (or browse to\n    {url} ).\n2. Download the hdfmonkey .zip file.\n3. Drop the downloaded .zip into this EXACT folder — the app has already created it, and the 'Open downloads folder' button below opens it so nothing needs to be typed:\n    {folder}\n4. Click \"I've dropped the zip - try again\".":
+            "Le téléchargement automatique de hdfmonkey depuis specnext.com a échoué — le forum demande peut-être une connexion ou une confirmation anti-robot avant de lancer le téléchargement (voir le journal pour les détails).\n\nVous pouvez l'installer manuellement :\n1. Cliquez sur 'Open download page' ci-dessous (ou ouvrez\n    {url} ).\n2. Téléchargez le fichier .zip de hdfmonkey.\n3. Déposez le .zip téléchargé EXACTEMENT dans ce dossier — l'application l'a déjà créé, et le bouton 'Open downloads folder' ci-dessous l'ouvre pour éviter toute saisie :\n    {folder}\n4. Cliquez sur \"I've dropped the zip - try again\".",
+        "ZX Next Unite update: downloaded {name} to {folder}":
+            "Mise à jour de ZX Next Unite : {name} téléchargé dans {folder}",
+        "ZX Next Unite update: downloaded {path} but could not unpack it: {error}":
+            "Mise à jour de ZX Next Unite : {path} téléchargé mais impossible à décompresser : {error}",
+        "ZX Next Unite {latest} is available (you are running {installed}).\n\nYou appear to be running from source (git clone), so the\nrecommended way to update is:\n\n    git pull\n\ninstead of downloading the Windows binary.":
+            "ZX Next Unite {latest} est disponible (vous utilisez {installed}).\n\nVous semblez l'exécuter depuis les sources (git clone), la\nméthode de mise à jour recommandée est donc :\n\n    git pull\n\nplutôt que de télécharger le binaire Windows.",
+        "ZX Next Unite {latest} is available — download?\n\nInstalled: {installed}\nLatest: {latest}\nPackage: {asset} (~{size})\n\nThe new version is saved next to the current one — you choose\nwhen to switch (you'll be offered a restart after the download).":
+            "ZX Next Unite {latest} est disponible — télécharger ?\n\nInstallée : {installed}\nDernière : {latest}\nPaquet : {asset} (~{size})\n\nLa nouvelle version est enregistrée à côté de l'actuelle — vous choisissez\nquand basculer (un redémarrage vous sera proposé après le téléchargement).",
+        "ZX Next Unite {latest} is available — running from source, so update with 'git pull' instead of the Windows binary.":
+            "ZX Next Unite {latest} est disponible — exécution depuis les sources, mettez à jour avec 'git pull' plutôt que le binaire Windows.",
         # ---- emulator update prompts (bodies + buttons) ----
         "A newer version of MAME is available.\n\nInstalled: 0.{installed}\nLatest: {latest}  (0.{latest_num})\nPackage: {asset}\n\nDownload (~{size}) and update your MAME install now?\nThe existing files in the downloads MAME folder will be overwritten.":
             "Une version plus récente de MAME est disponible.\n\nInstallée : 0.{installed}\nDernière : {latest}  (0.{latest_num})\nPaquet : {asset}\n\nTélécharger (~{size}) et mettre à jour votre installation MAME maintenant ?\nLes fichiers existants du dossier MAME seront écrasés.",
@@ -4326,6 +4594,20 @@ CATALOGS = {
             "Envoi de {name} vers l'image de la carte SD, puis lancement de CSpect…",
         "Start CSpect with file {name}":
             "Lancer CSpect avec le fichier {name}",
+        "Start MAME with file {name}":
+            "Lancer MAME avec le fichier {name}",
+        "Send to SD Card and start MAME with file {name}":
+            "Envoyer vers la carte SD et lancer MAME avec le fichier {name}",
+        "Extracting {name} from the image, then starting MAME…":
+            "Extraction de {name} depuis l'image, puis lancement de MAME…",
+        "Start MAME: {name} could not be read from the image, MAME was not started.":
+            "Lancer MAME : impossible de lire {name} depuis l'image, MAME n'a pas été lancé.",
+        "Send to SD Card and start MAME: the transfer failed, MAME was not started.":
+            "Envoyer vers la carte SD et lancer MAME : le transfert a échoué, MAME n'a pas été lancé.",
+        "Sending {name} to the SD card image, then starting MAME…":
+            "Envoi de {name} vers l'image de la carte SD, puis lancement de MAME…",
+        "MAME cannot load {name} directly; starting MAME without it.":
+            "MAME ne peut pas charger {name} directement ; MAME sera lancé sans ce fichier.",
         # ---- dialogs (message boxes) ----
         "CSpect update available":
             "Mise à jour de CSpect disponible",

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -535,6 +535,8 @@ CATALOGS = {
             "Iniciar CSpect con el archivo {name}",
         "Start MAME with file {name}":
             "Iniciar MAME con el archivo {name}",
+        "Start MAME: could not prepare the staging folder {path} ({error}).":
+            "Iniciar MAME: no se pudo preparar la carpeta temporal {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
             "Enviar a la tarjeta SD e iniciar MAME con el archivo {name}",
         "Extracting {name} from the image, then starting MAME…":
@@ -1348,6 +1350,8 @@ CATALOGS = {
             "Iniciar o CSpect com o ficheiro {name}",
         "Start MAME with file {name}":
             "Iniciar o MAME com o ficheiro {name}",
+        "Start MAME: could not prepare the staging folder {path} ({error}).":
+            "Iniciar o MAME: não foi possível preparar a pasta temporária {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
             "Enviar para o cartão SD e iniciar o MAME com o ficheiro {name}",
         "Extracting {name} from the image, then starting MAME…":
@@ -2159,6 +2163,8 @@ CATALOGS = {
             "Uruchom CSpect z plikiem {name}",
         "Start MAME with file {name}":
             "Uruchom MAME z plikiem {name}",
+        "Start MAME: could not prepare the staging folder {path} ({error}).":
+            "Uruchom MAME: nie udało się przygotować folderu tymczasowego {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
             "Wyślij na kartę SD i uruchom MAME z plikiem {name}",
         "Extracting {name} from the image, then starting MAME…":
@@ -2971,6 +2977,8 @@ CATALOGS = {
             "Запустить CSpect с файлом {name}",
         "Start MAME with file {name}":
             "Запустить MAME с файлом {name}",
+        "Start MAME: could not prepare the staging folder {path} ({error}).":
+            "Запуск MAME: не удалось подготовить временную папку {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
             "Отправить на SD-карту и запустить MAME с файлом {name}",
         "Extracting {name} from the image, then starting MAME…":
@@ -3782,6 +3790,8 @@ CATALOGS = {
             "Spustit CSpect se souborem {name}",
         "Start MAME with file {name}":
             "Spustit MAME se souborem {name}",
+        "Start MAME: could not prepare the staging folder {path} ({error}).":
+            "Spustit MAME: nepodařilo se připravit dočasnou složku {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
             "Odeslat na SD kartu a spustit MAME se souborem {name}",
         "Extracting {name} from the image, then starting MAME…":
@@ -4596,6 +4606,8 @@ CATALOGS = {
             "Lancer CSpect avec le fichier {name}",
         "Start MAME with file {name}":
             "Lancer MAME avec le fichier {name}",
+        "Start MAME: could not prepare the staging folder {path} ({error}).":
+            "Lancer MAME : impossible de préparer le dossier temporaire {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
             "Envoyer vers la carte SD et lancer MAME avec le fichier {name}",
         "Extracting {name} from the image, then starting MAME…":

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -2880,12 +2880,26 @@ def build_transfer_clipboard_ops(
         image still attached as -hard1, so anything the program loads from the
         SD card resolves as usual.
 
-        The temp copy is deliberately NOT deleted: MAME is launched detached
-        and opens the file after we return."""
+        The extracted copy is deliberately NOT deleted on success: MAME is
+        launched detached and opens the file after we return."""
         if not _right_disk_content() or not image_path:
             return
         name = os.path.basename(image_path)
-        tmp = tempfile.mkdtemp(prefix="zxnu-mame-")
+        if host._mame_flatpak_enabled():
+            # Flatpak MAME cannot see this process's /tmp, so stage the copy
+            # under the user's home instead — see mame_autostart_staging_dir().
+            tmp = mame_autostart_staging_dir()
+            shutil.rmtree(tmp, ignore_errors=True)
+            try:
+                os.makedirs(tmp, exist_ok=True)
+            except OSError as exc:
+                logging.exception("MAME auto-start staging dir unusable")
+                add_main_log_window(ui_tr_now(
+                    "Start MAME: could not prepare the staging folder {path} "
+                    "({error}).").format(path=tmp, error=exc))
+                return
+        else:
+            tmp = tempfile.mkdtemp(prefix="zxnu-mame-")
 
         def _go(ok):
             local = os.path.join(tmp, name)

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -1630,6 +1630,35 @@ def build_local_explorer_ops(
                 lambda: QTimer.singleShot(0, _send_and_start))
             menu.addSeparator()
 
+        # The MAME twin of the action above. Same shape, same reason for
+        # starting on the LOCAL file rather than the copy just written into
+        # the image: MAME cannot read a path inside the mounted image.
+        if (not is_dir and mame_can_autostart(file_path)
+                and _right_disk_content()
+                and host._mame_usable()
+                and getattr(host, "_launch_mame_fn", None)
+                and getattr(host, "image_upload_external_paths", None)):
+            def _send_and_start_mame(_p=file_path):
+                target = (host.diskimageexplorerpathinput.text() or "/").strip()
+                target = ("/" + target.strip("/")) if target.strip("/") else "/"
+
+                def _after(success):
+                    if not success:
+                        add_main_log_window(ui_tr_now(
+                            "Send to SD Card and start MAME: the transfer "
+                            "failed, MAME was not started."))
+                        return
+                    host._launch_mame_fn(_p)
+                add_main_log_window(ui_tr_now(
+                    "Sending {name} to the SD card image, then starting "
+                    "MAME…").format(name=os.path.basename(_p)))
+                host.image_upload_external_paths([_p], target, on_complete=_after)
+            menu.addAction(
+                ui_tr_now("Send to SD Card and start MAME with file {name}"
+                          ).format(name=name),
+                lambda: QTimer.singleShot(0, _send_and_start_mame))
+            menu.addSeparator()
+
         menu.addAction(action_copy_text)
         menu.addAction(action_copy_path)
         menu.addSeparator()
@@ -2841,6 +2870,40 @@ def build_transfer_clipboard_ops(
             [(image_path, False)], tmp, refresh_fn=lambda: None,
             on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
 
+    def _mame_start_from_image(image_path):
+        """Boot a file that lives INSIDE the mounted image with MAME.
+
+        Same constraint as the CSpect twin above: MAME loads the file through
+        its own file system, so an in-image path is meaningless to it and the
+        file has to exist on the host first. Extract it (and nothing else) to
+        a temp folder with hdfmonkey, then start MAME on that copy with the
+        image still attached as -hard1, so anything the program loads from the
+        SD card resolves as usual.
+
+        The temp copy is deliberately NOT deleted: MAME is launched detached
+        and opens the file after we return."""
+        if not _right_disk_content() or not image_path:
+            return
+        name = os.path.basename(image_path)
+        tmp = tempfile.mkdtemp(prefix="zxnu-mame-")
+
+        def _go(ok):
+            local = os.path.join(tmp, name)
+            if not ok or not os.path.isfile(local):
+                add_main_log_window(ui_tr_now(
+                    "Start MAME: {name} could not be read from the image, "
+                    "MAME was not started.").format(name=name))
+                shutil.rmtree(tmp, ignore_errors=True)
+                return
+            host._launch_mame_fn(local)
+
+        add_main_log_window(ui_tr_now(
+            "Extracting {name} from the image, then starting MAME…").format(
+                name=name))
+        image_get_paths_to_local(
+            [(image_path, False)], tmp, refresh_fn=lambda: None,
+            on_complete=lambda okd: QTimer.singleShot(0, lambda: _go(okd)))
+
     def _image_remote_zip(items):
         """'Remote Zip' on the image selection: get the items to a temp
         dir, zip them on the PC, upload <first item>.zip back into the
@@ -2881,8 +2944,9 @@ def build_transfer_clipboard_ops(
                     add_main_log_window(ui_tr_now(
                         "Remote zip cancelled — no zip was created."))
                 else:
-                    add_main_log_window(f"ERROR: could not build "
-                                        f"{zip_name}: {res['error']}")
+                    add_main_log_window(ui_tr_now(
+                        "ERROR: could not build {name}: {error}").format(
+                            name=zip_name, error=res["error"]))
                 return
             size = os.path.getsize(zip_local)
 
@@ -2929,13 +2993,14 @@ def build_transfer_clipboard_ops(
 
             selected_count = len(host.image_selected_paths)
 
-            # "Start CSpect with <file>" — top of the menu, and only when
-            # CSpect is actually installed and the row is a file CSpect can
-            # boot. CSpect takes the in-image path as its trailing argument,
-            # resolved against the -mmc root, so the file must already live on
-            # the mounted image (which it does: this is the image explorer).
+            # "Start <emulator> with <file>" — top of the menu, and only when
+            # that emulator is actually installed and the row is a file it can
+            # boot. Neither emulator can read the file from the image itself,
+            # so both helpers extract it to a temp folder on the host first
+            # and start the emulator on that copy.
             item_path = (name_item.data(IMG_PATH_ROLE) or "") \
                 if name_item is not None else ""
+            _emu_entry_added = False
             if (not is_dir and cspect_can_autostart(item_path)
                     and getattr(host, "_cspect_executable_path", None)
                     and getattr(host, "_launch_cspect_fn", None)):
@@ -2944,6 +3009,17 @@ def build_transfer_clipboard_ops(
                         name=os.path.basename(item_path)),
                     lambda p=item_path: QTimer.singleShot(
                         0, lambda: _cspect_start_from_image(p)))
+                _emu_entry_added = True
+            if (not is_dir and mame_can_autostart(item_path)
+                    and host._mame_usable()
+                    and getattr(host, "_launch_mame_fn", None)):
+                menu.addAction(
+                    ui_tr_now("Start MAME with file {name}").format(
+                        name=os.path.basename(item_path)),
+                    lambda p=item_path: QTimer.singleShot(
+                        0, lambda: _mame_start_from_image(p)))
+                _emu_entry_added = True
+            if _emu_entry_added:
                 menu.addSeparator()
 
             new_folder_label = "New Folder Here…" if is_dir else "New Folder…"


### PR DESCRIPTION
## MAME auto-start (mirrors the CSpect actions)

When MAME is usable the SD Card tab now offers, at the top of each menu:

- **image explorer** → `Start MAME with file X`
- **local explorer** → `Send to SD Card and start MAME with file X`

Both emulator entries share one separator, so showing only one of them leaves no stray line.

### The mechanism is simpler than the usual advice

The common guidance is that a `.nex` needs a software-list entry and a copy into `software/specnext`. That is **not** the case, and it would not have worked: `hash/specnext_sd.xml` describes *hash-matched SD-card images*, so it cannot describe a file it has never seen.

`mame -listmedia tbblue` reports `.nex` among the **snapshot** extensions, and this boots it directly:

```
mame tbblue -snapshot <host path>.nex -hard1 <image>
```

Verified against MAME 0.288: it runs, it runs alongside `-hard1`, it runs with the app's own default option set, and it fails loudly (`Fatal error: Device Snapshot load … failed`) on a bogus path — so the argument is genuinely honoured rather than ignored. Extensions are grouped by the switch that takes them (`-snapshot` / `-quickload` / `-cassette`).

### Host paths, not image paths

MAME's loader knows nothing about the emulated SD card, so a file living on the image is extracted with hdfmonkey first and MAME is started on that copy, with the image still attached as `-hard1`. This is the same trap the CSpect feature shipped with; the stale comment and test docstring still asserting the old (wrong) "resolved against the `-mmc` root" reasoning are corrected here too.

`.wav` / `.flac` / `.raw` are deliberately left out of the gate. MAME accepts them, but on an SD card such a name is far more likely to be ordinary audio or generic data than a Spectrum tape — the same reason the CSpect gate stops short of `.txt`.

`launch_mame` keeps an `isinstance()` guard because `button_start_mame.clicked` connects straight to it, so Qt hands the new parameter its `checked` bool.

## Localization

The last batch of console and dialog strings in the emulator/hdfmonkey chains now goes through `ui_tr_now`, plus the seven new MAME strings across all six languages: **347 runtime literals, 0 catalog gaps, 0 render failures.** What stays English is the 31 diagnostics and the pure-interpolation lines (`ERROR: {}`, `MAME: {}`).

## Tests

`tests/test_mame_autostart.py` (39 checks) pins the media mapping, the argv order (`-hard1` stays last), the extract-first contract, both gates, and the translation coverage.

Its assertions were **mutation-checked, not assumed** — each was confirmed to fail when the corresponding behaviour is broken:

| Mutation | Caught |
|---|---|
| launch on the in-image path instead of the extracted copy | yes |
| `isinstance` guard removed from `launch_mame` | yes |
| autostart file moved after `-hard1` | yes |

That exercise found one hollow assertion (`"isinstance" in ast.dump(fn)`, satisfiable by any unrelated `isinstance`), now an exact AST match on `isinstance(autostart_file, …)`.

Full suite green (19/19).