### PR TITLE
NextSync tab: same "start this file in an emulator" entries as the SD Card tab

### DIFF
--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -37,6 +37,7 @@ SUITES = [
     ("test_startup_tab_activation.py", 120, None),
     ("test_cspect_autostart.py",  120, None),
     ("test_mame_autostart.py",   120, None),
+    ("test_nextsync_autostart.py", 120, None),
     ("test_pane_imports.py",    120, None),
     ("test_hdf_workers.py",     120, None),
     ("test_classic_sync.py",    180, None),

--- a/tests/test_nextsync_autostart.py
+++ b/tests/test_nextsync_autostart.py
@@ -1,0 +1,234 @@
+"""Emulator auto-start across the NextSync tab.
+
+The SD Card tab's "Start <emulator> with <file>" actions are mirrored on all
+three NextSync explorers, so the same entries appear everywhere a bootable file
+can be seen:
+
+  * Classic Sync, local explorer      -> launch the local path as-is
+  * Remote Explorer, local pane       -> launch the local path as-is
+  * Remote Explorer, Next pane        -> DOWNLOAD first, then launch the copy
+
+All five explorers (these three plus the SD Card tab's two) build their entries
+from one helper, zxnu_workers.emulator_autostart_entries, so an emulator cannot
+end up offered in one pane and missing in another. This file tests that helper
+behaviourally and pins the three NextSync call sites.
+
+The Next pane's download-then-launch path is driven end-to-end against a real
+widget in test_remote_explorer_widget.py::test_emulator_start_from_next.
+
+Run with: python tests/test_nextsync_autostart.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+REPO = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+sys.path.insert(0, REPO)
+
+import zxnu_workers  # noqa: E402
+from zxnu_workers import emulator_autostart_entries  # noqa: E402
+
+FAIL = []
+
+
+def check(label, cond, detail=""):
+    print(("PASS  " if cond else "FAIL  ") + label
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+class Host:
+    """A stand-in MainWindow exposing only what the helper reads."""
+
+    def __init__(self, cspect=True, mame=True, flatpak=False):
+        self._cspect_executable_path = "/opt/CSpect/CSpect.exe" if cspect else None
+        self._launch_cspect_fn = lambda p: ("cspect", p)
+        self._launch_mame_fn = lambda p: ("mame", p)
+        self._mame = mame
+        self._flatpak = flatpak
+
+    def _mame_usable(self):
+        return self._mame
+
+    def _mame_flatpak_enabled(self):
+        return self._flatpak
+
+
+def names(host, path, is_dir=False):
+    return [e.name for e in emulator_autostart_entries(host, path, is_dir)]
+
+
+# ---- which emulators are offered -----------------------------------------
+both = Host()
+check("a .nex offers both emulators when both are available",
+      names(both, "/games/beast.nex") == ["CSpect", "MAME"])
+check("the order is stable (CSpect, then MAME) in every explorer",
+      names(both, "/a.nex") == names(both, "C:\\b.nex") == ["CSpect", "MAME"])
+check("no CSpect installed -> only MAME",
+      names(Host(cspect=False), "/a.nex") == ["MAME"])
+check("no usable MAME -> only CSpect",
+      names(Host(mame=False), "/a.nex") == ["CSpect"])
+check("neither available -> no entries at all",
+      names(Host(cspect=False, mame=False), "/a.nex") == [])
+check("a directory is never offered", names(both, "/games", True) == [])
+check("a readme is never offered", names(both, "/docs/readme.txt") == [])
+check("empty / None are safe",
+      names(both, "") == [] and names(both, None) == [])
+# The two emulators genuinely take different media, and the helper must respect
+# that rather than assuming what one can boot the other can too.
+check("a .dsk is offered for CSpect only (MAME's Next drivers take no disks)",
+      names(both, "/games/disk.dsk") == ["CSpect"])
+check("a .scr is offered for MAME only (CSpect does not boot screens)",
+      names(both, "/loading.scr") == ["MAME"])
+check("a .tap is offered for both", names(both, "/tape.tap") == ["CSpect", "MAME"])
+
+# ---- the entries are usable as menu items --------------------------------
+entries = emulator_autostart_entries(both, "/games/beast.nex")
+check("each entry carries a ready-to-use label naming the file",
+      all("beast.nex" in e.label for e in entries),
+      str([e.label for e in entries]))
+check("the label names its emulator",
+      entries[0].label.startswith("Start CSpect")
+      and entries[1].label.startswith("Start MAME"),
+      str([e.label for e in entries]))
+check("launching passes the host path straight through",
+      entries[0].launch("/tmp/x.nex") == ("cspect", "/tmp/x.nex"))
+check("a Windows path is labelled by base name, not the whole path",
+      "C:\\" not in emulator_autostart_entries(
+          both, "C:\\games\\beast.nex")[0].label)
+
+# ---- staging directories --------------------------------------------------
+# Only callers that must FETCH the file first use these (the SD image and the
+# Next). They differ per emulator because Flatpak MAME cannot see our /tmp.
+sysroot = os.path.realpath(tempfile.gettempdir())
+cspect_dir = entries[0].staging_dir()
+check("CSpect stages into a fresh temp directory",
+      os.path.isdir(cspect_dir)
+      and os.path.realpath(cspect_dir).startswith(sysroot), cspect_dir)
+mame_dir = entries[1].staging_dir()
+check("MAME stages into a fresh temp directory when not on Flatpak",
+      os.path.isdir(mame_dir)
+      and os.path.realpath(mame_dir).startswith(sysroot), mame_dir)
+check("each call gets its own directory (two launches cannot collide)",
+      entries[0].staging_dir() != cspect_dir)
+shutil.rmtree(cspect_dir, ignore_errors=True)
+shutil.rmtree(mame_dir, ignore_errors=True)
+
+# Flatpak MAME: a fixed directory under the user's home, cleared each time.
+fake_home = tempfile.mkdtemp(prefix="zxnu-fakehome-")
+staged = os.path.join(fake_home, ".cache", "zx-next-unite", "mame-autostart")
+_real = zxnu_workers.mame_autostart_staging_dir
+zxnu_workers.mame_autostart_staging_dir = lambda: staged
+try:
+    fp = emulator_autostart_entries(Host(flatpak=True), "/a.nex")
+    got = fp[-1].staging_dir()
+    # The property that distinguishes it from the mkdtemp path: one fixed
+    # directory, not a fresh one per launch. (That this location is outside
+    # /tmp is a property of mame_autostart_staging_dir itself and is tested
+    # against the real function in test_mame_autostart.py — the fake home
+    # used here necessarily lives under the temp dir.)
+    check("Flatpak MAME does NOT get a fresh per-launch temp directory",
+          fp[-1].name == "MAME"
+          and os.path.realpath(fp[-1].staging_dir()) == os.path.realpath(got))
+    check("...it uses the home staging directory",
+          os.path.realpath(got) == os.path.realpath(staged), got)
+    # Nothing under ~ is reaped by the OS, so the directory is reused and
+    # emptied rather than accumulating one copy per launch.
+    open(os.path.join(got, "stale.nex"), "wb").write(b"x")
+    again = fp[-1].staging_dir()
+    check("...and is cleared before each use, so copies do not pile up",
+          os.path.realpath(again) == os.path.realpath(staged)
+          and os.listdir(again) == [], str(os.listdir(again)))
+    check("Flatpak MAME staging is reached through the shared helper only",
+          "mame_autostart_staging_dir" in open(
+              os.path.join(REPO, "zxnu_workers.py"), encoding="utf-8").read())
+finally:
+    zxnu_workers.mame_autostart_staging_dir = _real
+    shutil.rmtree(fake_home, ignore_errors=True)
+
+# ---- the three NextSync call sites ---------------------------------------
+ops = open(os.path.join(REPO, "zxnu_nextsync_ops.py"), encoding="utf-8").read()
+check("the classic explorer builds its entries from the shared helper",
+      "emulator_autostart_entries(host, file_path, is_dir)" in ops)
+check("the classic explorer launches the local path directly (no fetch)",
+      "_e.launch(file_path)" in ops,
+      "these files are already on the PC")
+# Top of the menu, as on the SD Card tab.
+emu_at = ops.find("emulator_autostart_entries(host, file_path, is_dir)")
+first_at = ops.find("menu.addAction(action_copy_text)")
+check("the classic explorer's entries sit at the top of its menu",
+      emu_at != -1 and first_at != -1 and emu_at < first_at,
+      f"emu={emu_at} first={first_at}")
+
+rex = open(os.path.join(REPO, "zxnu_remote_explorer.py"), encoding="utf-8").read()
+check("the Remote Explorer takes the emulators as an injected hook",
+      "emulator_entries=None" in rex,
+      "the widget must not import the emulator ops layer")
+check("...and offers nothing when the hook is absent",
+      "self._emulator_entries = emulator_entries or (lambda path: [])" in rex)
+check("the local pane launches its path directly (no fetch)",
+      "e.launch(p)" in rex)
+check("the Next pane routes through the download-first path",
+      "self._emulator_start_from_next(_sel_now[0][0], entry)" in rex)
+seg = rex[rex.find("def _emulator_start_from_next"):]
+seg = seg[:seg.find("def _remote_unzip")]
+check("the Next pane downloads with the same 'get' op as Download",
+      '("get", remote_path, tmp)' in seg)
+check("...into the emulator's own staging directory",
+      "entry.staging_dir()" in seg,
+      "a plain mkdtemp would break Flatpak MAME")
+check("...and launches the DOWNLOADED copy, never the Next path",
+      "entry.launch(local)" in seg and "entry.launch(remote_path)" not in seg)
+check("a failed download starts nothing and cleans up",
+      "shutil.rmtree(tmp, ignore_errors=True)" in seg
+      and "could not be downloaded from " in seg)
+# Both panes act on exactly one selected FILE — a folder or a multi-selection
+# has no single file to boot.
+check("the Next pane only offers the entries for a single selected file",
+      "len(_sel_now) == 1 and not _sel_now[0][1]" in rex)
+check("the local pane only offers the entries for a single selected file",
+      "len(sel) == 1 and os.path.isfile(sel[0])" in rex)
+
+pane = open(os.path.join(REPO, "zxnu_nextsync_pane.py"), encoding="utf-8").read()
+check("the Remote Explorer is actually given the hook at construction",
+      "emulator_entries=lambda path: emulator_autostart_entries(host, path)" in pane,
+      "without this the panes silently offer nothing")
+
+# ---- every new string is translated --------------------------------------
+from zxnu_i18n import CATALOGS  # noqa: E402
+
+NEW_STRINGS = (
+    "Could not start {emulator}",
+    "Could not prepare a folder for {name}: {error}",
+    "Start {emulator}: {name} could not be downloaded from the Next, "
+    "{emulator} was not started.",
+    "Downloading {name} from the Next, then starting {emulator}…",
+    "Downloading {name}…",
+)
+missing = [(lg, s) for s in NEW_STRINGS for lg in CATALOGS if not CATALOGS[lg].get(s)]
+check("every new string is translated in all languages",
+      not missing, f"{len(missing)} gap(s): {missing[:2]}")
+sample = {"name": "beast.nex", "emulator": "MAME", "error": "denied"}
+broken = []
+for s in NEW_STRINGS:
+    for lg in CATALOGS:
+        t = CATALOGS[lg].get(s) or s
+        try:
+            t.format(**sample)
+        except (KeyError, IndexError):
+            broken.append((lg, s))
+check("every translation renders with its placeholders", not broken, str(broken[:2]))
+# The emulator name is interpolated, never translated — "MAME" must survive.
+check("the emulator name is never translated away",
+      all("MAME" in (CATALOGS[lg].get(NEW_STRINGS[2]) or "").format(**sample)
+          for lg in CATALOGS))
+
+print()
+if FAIL:
+    print(f"{len(FAIL)} FAILURE(S): " + ", ".join(FAIL))
+    sys.exit(1)
+print("all NextSync emulator auto-start checks passed")
+sys.exit(0)

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -119,7 +119,8 @@ def make_widget(**kw):
         on_sort_changed=lambda which, v: calls["sorts"].append((which, v)),
         on_toast=lambda t, m, variant="red": calls["toasts"].append((t, m, variant)),
         extra_drives=kw.get("extra_drives"),
-        on_extra_drives_changed=calls["extra_drives"].append)
+        on_extra_drives_changed=calls["extra_drives"].append,
+        emulator_entries=kw.get("emulator_entries"))
     return w, calls
 
 
@@ -1154,6 +1155,73 @@ def test_compact_buttons_fit_translated_labels():
     w.deleteLater()
 
 
+def test_emulator_start_from_next():
+    """'Start <emulator> with <file>' on the NEXT pane.
+
+    The emulator runs on the PC and cannot read the Next's storage, so the file
+    must be downloaded first and the emulator started on THAT copy — the Next
+    pane's counterpart to the SD Card tab extracting from the image. Driven
+    through the real widget: the download is a normal queued 'get' op, so the
+    recorded queue and on_op_done() are enough to exercise the whole path.
+    """
+    print("\n== emulator auto-start from the Next pane ==")
+    from zxnu_workers import EmulatorAutostart
+
+    launched, staged = [], []
+    stage_root = tempfile.mkdtemp(dir=TMP)
+
+    def make_stage():
+        staged.append(stage_root)
+        return stage_root
+
+    entry = EmulatorAutostart("CSpect", "Start CSpect with file beast.nex",
+                              launched.append, make_stage)
+    w, calls = make_widget(emulator_entries=lambda p: [entry])
+    connect_widget(w, calls, listing=[(False, 4096, "beast.nex")])
+
+    # The download is queued against the emulator's own staging directory.
+    w._emulator_start_from_next("/beast.nex", entry)
+    q = list(calls["q"])
+    check("the Next-pane action queues a download",
+          any(c[0] == "get" and c[1] == "/beast.nex" for c in q), str(q))
+    check("...into the directory the emulator asked for",
+          staged == [stage_root] and any(len(c) > 2 and c[2] == stage_root
+                                         for c in q), str(q))
+    check("nothing is launched before the download finishes", launched == [])
+
+    # Finish the download with the file actually present, as the worker would.
+    open(os.path.join(stage_root, "beast.nex"), "wb").write(b"\x00" * 8)
+    w.on_op_done(True, "get", "/beast.nex")
+    QApplication.processEvents()          # the launch is deferred by one tick
+    check("the emulator is started once the file has arrived",
+          launched == [os.path.join(stage_root, "beast.nex")], str(launched))
+    check("it is started on the DOWNLOADED copy, not the Next path",
+          launched and not launched[0].startswith("/beast"), str(launched))
+    check("the copy survives the launch (the emulator is detached)",
+          os.path.isfile(os.path.join(stage_root, "beast.nex")))
+
+    # A failed download must not start anything and must clean up after itself.
+    launched.clear()
+    stage2 = tempfile.mkdtemp(dir=TMP)
+    entry2 = EmulatorAutostart("MAME", "Start MAME with file x.nex",
+                               launched.append, lambda: stage2)
+    w2, calls2 = make_widget(emulator_entries=lambda p: [entry2])
+    connect_widget(w2, calls2, listing=[(False, 10, "x.nex")])
+    w2._emulator_start_from_next("/x.nex", entry2)
+    w2.on_op_done(False, "get", "/x.nex")   # download failed
+    QApplication.processEvents()
+    check("a failed download starts nothing", launched == [], str(launched))
+    check("...and removes the staging directory", not os.path.isdir(stage2))
+    check("...and says so in the log",
+          any("could not be downloaded" in str(s) or "not started" in str(s)
+              for s in calls2["log"]), str(calls2["log"][-3:]))
+
+    # Without the host hook the widget must simply offer nothing, never crash.
+    w3, _ = make_widget()
+    check("no hook -> no entries (the widget knows no emulators itself)",
+          w3._emulator_entries("/anything.nex") == [])
+
+
 def main():
     logging.disable(logging.CRITICAL)
     app = QApplication(sys.argv)  # noqa: F841 — QWidget construction needs it
@@ -1180,6 +1248,7 @@ def main():
         test_idle_status_provider()
         test_idle_details_provider()
         test_compact_buttons_fit_translated_labels()
+        test_emulator_start_from_next()
     finally:
         shutil.rmtree(TMP, ignore_errors=True)
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -535,6 +535,18 @@ CATALOGS = {
             "Iniciar CSpect con el archivo {name}",
         "Start MAME with file {name}":
             "Iniciar MAME con el archivo {name}",
+        "Could not start {emulator}":
+            "No se pudo iniciar {emulator}",
+        "Could not prepare a folder for {name}: {error}":
+            "No se pudo preparar una carpeta para {name}: {error}",
+        "Start {emulator}: {name} could not be downloaded from the Next, "
+        "{emulator} was not started.":
+            "Iniciar {emulator}: no se pudo descargar {name} del Next; "
+            "{emulator} no se ha iniciado.",
+        "Downloading {name} from the Next, then starting {emulator}…":
+            "Descargando {name} del Next y luego iniciando {emulator}…",
+        "Downloading {name}…":
+            "Descargando {name}…",
         "Start MAME: could not prepare the staging folder {path} ({error}).":
             "Iniciar MAME: no se pudo preparar la carpeta temporal {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
@@ -1350,6 +1362,18 @@ CATALOGS = {
             "Iniciar o CSpect com o ficheiro {name}",
         "Start MAME with file {name}":
             "Iniciar o MAME com o ficheiro {name}",
+        "Could not start {emulator}":
+            "Não foi possível iniciar o {emulator}",
+        "Could not prepare a folder for {name}: {error}":
+            "Não foi possível preparar uma pasta para {name}: {error}",
+        "Start {emulator}: {name} could not be downloaded from the Next, "
+        "{emulator} was not started.":
+            "Iniciar o {emulator}: não foi possível transferir {name} do Next; "
+            "o {emulator} não foi iniciado.",
+        "Downloading {name} from the Next, then starting {emulator}…":
+            "A transferir {name} do Next e depois a iniciar o {emulator}…",
+        "Downloading {name}…":
+            "A transferir {name}…",
         "Start MAME: could not prepare the staging folder {path} ({error}).":
             "Iniciar o MAME: não foi possível preparar a pasta temporária {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
@@ -2163,6 +2187,18 @@ CATALOGS = {
             "Uruchom CSpect z plikiem {name}",
         "Start MAME with file {name}":
             "Uruchom MAME z plikiem {name}",
+        "Could not start {emulator}":
+            "Nie udało się uruchomić {emulator}",
+        "Could not prepare a folder for {name}: {error}":
+            "Nie udało się przygotować folderu dla {name}: {error}",
+        "Start {emulator}: {name} could not be downloaded from the Next, "
+        "{emulator} was not started.":
+            "Uruchom {emulator}: nie udało się pobrać {name} z Nexta — "
+            "{emulator} nie został uruchomiony.",
+        "Downloading {name} from the Next, then starting {emulator}…":
+            "Pobieranie {name} z Nexta, potem uruchomienie {emulator}…",
+        "Downloading {name}…":
+            "Pobieranie {name}…",
         "Start MAME: could not prepare the staging folder {path} ({error}).":
             "Uruchom MAME: nie udało się przygotować folderu tymczasowego {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
@@ -2977,6 +3013,18 @@ CATALOGS = {
             "Запустить CSpect с файлом {name}",
         "Start MAME with file {name}":
             "Запустить MAME с файлом {name}",
+        "Could not start {emulator}":
+            "Не удалось запустить {emulator}",
+        "Could not prepare a folder for {name}: {error}":
+            "Не удалось подготовить папку для {name}: {error}",
+        "Start {emulator}: {name} could not be downloaded from the Next, "
+        "{emulator} was not started.":
+            "Запуск {emulator}: не удалось скачать {name} с Next — {emulator} "
+            "не запущен.",
+        "Downloading {name} from the Next, then starting {emulator}…":
+            "Загрузка {name} с Next, затем запуск {emulator}…",
+        "Downloading {name}…":
+            "Загрузка {name}…",
         "Start MAME: could not prepare the staging folder {path} ({error}).":
             "Запуск MAME: не удалось подготовить временную папку {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
@@ -3790,6 +3838,18 @@ CATALOGS = {
             "Spustit CSpect se souborem {name}",
         "Start MAME with file {name}":
             "Spustit MAME se souborem {name}",
+        "Could not start {emulator}":
+            "Nepodařilo se spustit {emulator}",
+        "Could not prepare a folder for {name}: {error}":
+            "Nepodařilo se připravit složku pro {name}: {error}",
+        "Start {emulator}: {name} could not be downloaded from the Next, "
+        "{emulator} was not started.":
+            "Spustit {emulator}: {name} se nepodařilo stáhnout z Nextu — "
+            "{emulator} nebyl spuštěn.",
+        "Downloading {name} from the Next, then starting {emulator}…":
+            "Stahuje se {name} z Nextu, poté se spustí {emulator}…",
+        "Downloading {name}…":
+            "Stahuje se {name}…",
         "Start MAME: could not prepare the staging folder {path} ({error}).":
             "Spustit MAME: nepodařilo se připravit dočasnou složku {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":
@@ -4606,6 +4666,19 @@ CATALOGS = {
             "Lancer CSpect avec le fichier {name}",
         "Start MAME with file {name}":
             "Lancer MAME avec le fichier {name}",
+        "Could not start {emulator}":
+            "Impossible de lancer {emulator}",
+        "Could not prepare a folder for {name}: {error}":
+            "Impossible de préparer un dossier pour {name} : {error}",
+        "Start {emulator}: {name} could not be downloaded from the Next, "
+        "{emulator} was not started.":
+            "Lancer {emulator} : impossible de télécharger {name} depuis le "
+            "Next, {emulator} n'a pas été lancé.",
+        "Downloading {name} from the Next, then starting {emulator}…":
+            "Téléchargement de {name} depuis le Next, puis lancement de "
+            "{emulator}…",
+        "Downloading {name}…":
+            "Téléchargement de {name}…",
         "Start MAME: could not prepare the staging folder {path} ({error}).":
             "Lancer MAME : impossible de préparer le dossier temporaire {path} ({error}).",
         "Send to SD Card and start MAME with file {name}":

--- a/zxnu_nextsync_ops.py
+++ b/zxnu_nextsync_ops.py
@@ -295,6 +295,18 @@ def build_nextsync_explorer_ops(
         action_paste.triggered.connect(lambda: QTimer.singleShot(0, lambda: nextsync_paste_explorer_item(paste_dir)))
         action_rename.triggered.connect(lambda: QTimer.singleShot(0, lambda: nextsync_rename_explorer_item(file_path, name, is_dir)))
         action_delete.triggered.connect(lambda: QTimer.singleShot(0, lambda: nextsync_delete_explorer_item(file_path, name, is_dir)))
+        # "Start <emulator> with <file>" at the top, same as the SD Card tab
+        # and the Remote Explorer. These files are already on the PC, so there
+        # is nothing to fetch first — the launcher takes the path as it is.
+        _emu = emulator_autostart_entries(host, file_path, is_dir)
+        for _entry in _emu:
+            menu.addAction(
+                _entry.label,
+                lambda _e=_entry: QTimer.singleShot(
+                    0, lambda: _e.launch(file_path)))
+        if _emu:
+            menu.addSeparator()
+
         menu.addAction(action_copy_text)
         menu.addAction(action_copy_path)
         menu.addSeparator()

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -772,6 +772,10 @@ def build_nextsync_pane(
             on_sort_changed=_re_on_sort_changed,
             extra_drives=extra_drives,
             on_extra_drives_changed=_re_on_extra_drives_changed,
+            # Same "Start <emulator> with <file>" entries as the SD Card tab and
+            # the classic explorer; the widget itself knows nothing about which
+            # emulators are installed.
+            emulator_entries=lambda path: emulator_autostart_entries(host, path),
             on_toast=lambda title, msg, variant="red": host._show_toast(
                 title, msg, variant=variant, duration_ms=9000))
         host._re_widget = widget

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -11,6 +11,7 @@ through RemoteExplorerSignals and are applied here on the UI thread.
 """
 
 import html
+import logging
 import os
 import posixpath
 import shutil
@@ -244,11 +245,17 @@ class RemoteExplorerWidget(QWidget):
                  drain=None, on_sync_root_changed=None, remote_start_dir=None,
                  on_remote_cwd_changed=None, local_sort=None, next_sort=None,
                  on_sort_changed=None, on_toast=None, extra_drives=None,
-                 on_extra_drives_changed=None):
+                 on_extra_drives_changed=None, emulator_entries=None):
         super().__init__(parent)
         self._enqueue_raw = enqueue          # host closure: put one command
         self._drain_raw = drain              # host closure: empty the queue, -> count
         self._log = log or (lambda s: None)
+        # host closure: path -> [EmulatorAutostart] for the emulators that are
+        # installed and can boot that file, so both panes can offer the same
+        # "Start <emulator> with <file>" entries as the SD Card tab. The widget
+        # deliberately does not know which emulators exist; without the hook it
+        # simply offers nothing.
+        self._emulator_entries = emulator_entries or (lambda path: [])
         self._on_sync_root_changed = on_sync_root_changed or (lambda p: None)
         # Surface Next-side failures ('F' replies / abandoned transfers) to the
         # user: on_toast(title, message, variant) pops a host toast.
@@ -1601,6 +1608,17 @@ class RemoteExplorerWidget(QWidget):
         if not self._connected:
             return
         menu = QMenu(self)
+        # "Start <emulator> with <file>" at the top, mirroring the SD Card tab's
+        # image pane: the file lives on the Next, so it is downloaded to the PC
+        # first and the emulator started on that copy (see
+        # _emulator_start_from_next). Offered for a single selected file only.
+        emu_next = []
+        _sel_now = self._selected_next_entries()
+        if len(_sel_now) == 1 and not _sel_now[0][1]:
+            for entry in self._emulator_entries(_sel_now[0][0]):
+                emu_next.append((menu.addAction(entry.label), entry))
+            if emu_next:
+                menu.addSeparator()
         act_new = menu.addAction(ui_tr_now("New Folder…"))
         act_get = menu.addAction(ui_tr_now("Download (:<-)"))
         act_size = menu.addAction(ui_tr_now("Get size"))
@@ -1629,6 +1647,10 @@ class RemoteExplorerWidget(QWidget):
         # duplicated ON the Next itself via the dot's rcpy (v5.2+).
         act_paste.setEnabled(bool(self._clip))
         chosen = menu.exec(self.next_view.viewport().mapToGlobal(pos))
+        for act, entry in emu_next:
+            if chosen == act:
+                self._emulator_start_from_next(_sel_now[0][0], entry)
+                return
         if chosen == act_new:
             self._new_folder()
         elif chosen == act_get:
@@ -2214,6 +2236,51 @@ class RemoteExplorerWidget(QWidget):
         return self._cwd if self._cwd.endswith("/") else self._cwd + "/"
 
     # ---- Remote Unzip file -------------------------------------------
+    def _emulator_start_from_next(self, remote_path, entry):
+        """Boot a file that lives ON THE NEXT in an emulator.
+
+        The emulator runs on the PC and knows nothing about the Next's storage,
+        so the file is downloaded first (same 'get' op as the Download action)
+        and the emulator started on that copy — the Next pane's counterpart to
+        the SD Card tab extracting from the image with hdfmonkey.
+
+        The copy is deliberately NOT deleted on success: the emulator is
+        launched detached and opens the file after we return. Which directory
+        it goes to is the emulator's business (entry.staging_dir), because
+        Flatpak MAME cannot see this process's /tmp.
+        """
+        if not self._connected or self._op_active:
+            return
+        name = posixpath.basename(remote_path.rstrip("/")) or remote_path
+        try:
+            tmp = entry.staging_dir()
+        except OSError as exc:
+            logging.exception("emulator staging dir unusable")
+            self._on_toast(
+                ui_tr_now("Could not start {emulator}").format(emulator=entry.name),
+                ui_tr_now("Could not prepare a folder for {name}: {error}")
+                .format(name=name, error=exc), "red")
+            return
+
+        def _started(ok, _fails):
+            local = os.path.join(tmp, name)
+            if not ok or not os.path.isfile(local):
+                shutil.rmtree(tmp, ignore_errors=True)
+                self._log(ui_tr_now(
+                    "Start {emulator}: {name} could not be downloaded from "
+                    "the Next, {emulator} was not started.").format(
+                        emulator=entry.name, name=name))
+                return
+            # Deferred so _end_operation fully unwinds before the launch.
+            QTimer.singleShot(0, lambda: entry.launch(local))
+
+        self._log(ui_tr_now(
+            "Downloading {name} from the Next, then starting {emulator}…")
+            .format(name=name, emulator=entry.name))
+        self._run_op(ui_tr_now("Downloading {name}…").format(name=name),
+                     lambda: self._enqueue(("get", remote_path, tmp)),
+                     on_done=_started)
+
     def _remote_unzip(self, zip_path):
         """Context menu 'Remote Unzip file' (a single selected remote .zip):
         stage 1 downloads the zip to a temp dir (normal cancellable op),
@@ -2601,6 +2668,15 @@ class RemoteExplorerWidget(QWidget):
         sel = [p for p in self._selected_local_paths() if p]
         has_sel = len(sel) > 0
         menu = QMenu(self)
+        # "Start <emulator> with <file>" at the top, for a single selected file
+        # the emulator can boot. These paths are already local, so they go
+        # straight to the launcher.
+        emu_local = []
+        if len(sel) == 1 and os.path.isfile(sel[0]):
+            for entry in self._emulator_entries(sel[0]):
+                emu_local.append((menu.addAction(entry.label), entry))
+            if emu_local:
+                menu.addSeparator()
         act_new = menu.addAction(ui_tr_now("New Folder…"))
         act_unzip = menu.addAction(ui_tr_now("Unzip file"))
         act_zip = menu.addAction(ui_tr_now("Zip"))
@@ -2626,6 +2702,10 @@ class RemoteExplorerWidget(QWidget):
         # copies/moves copied/cut LOCAL items into it.
         act_paste.setEnabled(bool(self._clip))
         chosen = menu.exec(self.local_view.viewport().mapToGlobal(pos))
+        for act, entry in emu_local:
+            if chosen == act:
+                QTimer.singleShot(0, lambda e=entry, p=sel[0]: e.launch(p))
+                return
         if chosen == act_new:
             self._local_new_folder()
         elif chosen == act_unzip:

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -10,14 +10,17 @@ import fnmatch
 import glob
 import logging
 import platform
+import shutil
 import socket
 import struct
+import tempfile
 import threading
 import time
-from collections import deque
+from collections import deque, namedtuple
 from zxnu_config import (IGNOREFILE, MAX_PAYLOAD, PORT, SYNCPOINT,
                          UP_DIRECTORY, VERSION3, VERSION4,
-                         is_filetype_a_directory)
+                         cspect_can_autostart, is_filetype_a_directory,
+                         mame_autostart_staging_dir, mame_can_autostart)
 from PySide6.QtCore import (
     QEvent, QObject, QPoint, QRect, QRunnable, QSize, QSortFilterProxyModel,
     QTimer, Qt, Signal, Slot,
@@ -71,6 +74,67 @@ class CompactButton(QPushButton):
     def _fit_to_text(self):
         needed = self.fontMetrics().horizontalAdvance(self.text()) + self._fit_padding
         self.setMaximumWidth(max(self._fit_floor, needed))
+
+
+# One emulator's "start this file" context-menu entry.
+#   name        "CSpect" / "MAME" — for composing messages about it
+#   label       the ready-to-use, already-translated menu label
+#   launch      call with a HOST path to boot the file
+#   staging_dir call to create and return a directory to put a host copy in,
+#               when the file is not already on the PC
+EmulatorAutostart = namedtuple("EmulatorAutostart",
+                               "name label launch staging_dir")
+
+
+def emulator_autostart_entries(host, path, is_dir=False):
+    """The "start <file> in an emulator" entries to offer for *path*.
+
+    One list, used by all five explorers that can hold a bootable file (the SD
+    Card tab's local and image panes, the NextSync tab's classic explorer, and
+    the Remote Explorer's local and Next panes) so they offer the same entries,
+    in the same order, under the same conditions. An emulator appears only when
+    it is actually available AND can boot that file type.
+
+    ``staging_dir`` is per-emulator rather than a plain ``mkdtemp()`` because
+    Flatpak MAME cannot see this process's /tmp — see the long explanation on
+    ``mame_autostart_staging_dir``. Callers that already hold a host path (a
+    local explorer) never need it; callers that must first fetch the file (from
+    the SD image, or from the Next) do.
+    """
+    entries = []
+    if is_dir or not path:
+        return entries
+    name = os.path.basename(str(path).rstrip("/\\")) or str(path)
+
+    def _tmp(prefix):
+        return lambda: tempfile.mkdtemp(prefix=prefix)
+
+    if (cspect_can_autostart(path)
+            and getattr(host, "_cspect_executable_path", None)
+            and getattr(host, "_launch_cspect_fn", None)):
+        entries.append(EmulatorAutostart(
+            "CSpect",
+            ui_tr_now("Start CSpect with file {name}").format(name=name),
+            host._launch_cspect_fn, _tmp("zxnu-cspect-")))
+
+    _mame_usable = getattr(host, "_mame_usable", None)
+    if (mame_can_autostart(path) and _mame_usable and _mame_usable()
+            and getattr(host, "_launch_mame_fn", None)):
+        def _mame_staging_dir():
+            _flatpak = getattr(host, "_mame_flatpak_enabled", None)
+            if not (_flatpak and _flatpak()):
+                return tempfile.mkdtemp(prefix="zxnu-mame-")
+            # Fixed directory under ~, cleared each time: nothing there is
+            # reaped by the OS, so a fresh one per launch would leak disk.
+            staged = mame_autostart_staging_dir()
+            shutil.rmtree(staged, ignore_errors=True)
+            os.makedirs(staged, exist_ok=True)
+            return staged
+        entries.append(EmulatorAutostart(
+            "MAME",
+            ui_tr_now("Start MAME with file {name}").format(name=name),
+            host._launch_mame_fn, _mame_staging_dir))
+    return entries
 
 
 class FlowLayout(QLayout):


### PR DESCRIPTION
Mirrors the CSpect/MAME auto-start actions across the whole NextSync tab, so a bootable file offers the same entries wherever it is seen.

| Explorer | Behaviour |
|---|---|
| Classic Sync — local explorer | launch the local path as-is |
| Remote Explorer — local pane | launch the local path as-is |
| Remote Explorer — **Next pane** | **download first**, then launch the copy |

The Next pane needs the download for exactly the reason the SD Card tab's image pane needs hdfmonkey: the emulator runs on the PC and cannot read the Next's storage. It reuses the existing `get` op, so it is cancellable and reports through the normal operation lifecycle. A failed or cancelled download starts nothing and removes the staging directory.

## One helper instead of five copies

All five explorers that can hold a bootable file (these three plus the SD Card tab's two) now build their entries from `zxnu_workers.emulator_autostart_entries`. That matters for more than tidiness:

- an emulator cannot end up offered in one pane and missing in another;
- the Flatpak-MAME staging rule from #238 — it cannot see this process's `/tmp` — is applied everywhere **by construction**, rather than being re-remembered at each new call site;
- the two emulators' media sets stay genuinely distinct: a `.dsk` offers **CSpect only** (MAME's Next drivers take no disks), a `.scr` offers **MAME only**, a `.nex` or `.tap` offers both.

`RemoteExplorerWidget` receives the entries as an injected hook and still knows nothing about which emulators exist — without the hook it simply offers nothing. Both panes act on a single selected file only.

## Tests

- **The helper, behaviourally** — availability combinations, stable CSpect→MAME ordering, the media split, label composition, and the staging directories including the Flatpak branch (fixed directory, cleared each use, not a fresh per-launch temp dir).
- **The download-then-launch path end-to-end** against a real offscreen `RemoteExplorerWidget`: the download is queued into the emulator's staging dir, nothing launches until it completes, the launch uses the **downloaded copy**, the copy survives the launch, and a failed download cleans up and logs.
- **The three call sites** pinned at source level, including menu position and the single-file gate.

Mutation-checked rather than assumed:

| Mutation | Caught |
|---|---|
| Next pane launches the remote path instead of the downloaded copy | yes — by both the source contract and the behavioural test (`['/beast.nex']`) |
| constructor hook dropped, so panes silently offer nothing | yes |

I also verified empirically that PySide6 does not clobber the entry-carrying default argument with `triggered(bool)` — the trap that bites lambdas connected to Qt signals.

Five new strings across all six languages; the emulator name is interpolated, never translated, and that is asserted.

Full suite green (20/20).