### PR TITLE
SD Card local explorer: offer a plain "start with this file" too

### DIFF
--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -204,6 +204,23 @@ for label, marker in (
     check(f"the {label} action is gated on a loadable extension",
           "mame_can_autostart" in window)
 
+# ---- the local pane offers BOTH a plain start and a send-then-start -------
+# Emulator-neutral: these entries are generated from the shared helper, so the
+# same two checks cover CSpect and MAME together.
+check("the local explorer also offers a plain start (no transfer)",
+      "emulator_autostart_entries(host, file_path, is_dir)" in ops,
+      "mirrors the NextSync tab's local explorers")
+check("the plain start launches the local file as-is",
+      "_e.launch(file_path)" in ops)
+direct_at = ops.find("emulator_autostart_entries(host, file_path, is_dir)")
+send_at = ops.find('ui_tr_now("Send to SD Card and start CSpect with file {name}"')
+check("the plain start sits ABOVE the send-then-start entries",
+      direct_at != -1 and send_at != -1 and direct_at < send_at,
+      f"direct={direct_at} send={send_at}")
+check("...and does not replace them (both jobs stay available)",
+      send_at != -1
+      and 'ui_tr_now("Send to SD Card and start MAME with file {name}"' in ops)
+
 # Top of the menu, as asked for, and not at the price of the CSpect entry.
 img_at = ops.find('ui_tr_now("Start MAME with file {name}")')
 newfolder_at = ops.find("new_folder_label = ")

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -1594,11 +1594,26 @@ def build_local_explorer_ops(
             lambda: QTimer.singleShot(0, lambda: _local_zip_selection(
                 _local_explorer_selected_paths_or(file_path),
                 local_explorer_refresh, add_main_log_window)))
-        # "Send to SD Card and start CSpect with <file>" — top of the menu,
-        # offered only with CSpect installed, an image loaded, and a file
-        # CSpect can boot. It uploads into the folder the image explorer is
-        # showing and, once that succeeds, starts CSpect on the uploaded copy
-        # (the in-image path, which is what CSpect resolves against -mmc).
+        # "Start <emulator> with <file>" — very top of the menu, the same
+        # entries the NextSync tab's local explorers offer. These boot the
+        # local file as it is, with no transfer: the emulator reads it from
+        # the PC. The "Send to SD Card and start …" pair below does the other
+        # job — putting the file on the card first — so both are offered and
+        # the plain one comes first, being the cheaper of the two.
+        _emu_direct = emulator_autostart_entries(host, file_path, is_dir)
+        for _entry in _emu_direct:
+            menu.addAction(
+                _entry.label,
+                lambda _e=_entry: QTimer.singleShot(
+                    0, lambda: _e.launch(file_path)))
+        if _emu_direct:
+            menu.addSeparator()
+
+        # "Send to SD Card and start CSpect with <file>" — offered only with
+        # CSpect installed, an image loaded, and a file CSpect can boot. It
+        # uploads into the folder the image explorer is showing and, once that
+        # succeeds, starts CSpect on the local copy (a host path — see
+        # _cspect_start_from_image for why it cannot be the in-image one).
         if (not is_dir and cspect_can_autostart(file_path)
                 and _right_disk_content()
                 and getattr(host, "_cspect_executable_path", None)


### PR DESCRIPTION
The SD Card tab's local explorer only ever offered **"Send to SD Card and start &lt;emulator&gt; with &lt;file&gt;"**, which does two jobs at once. The NextSync tab's local explorers (from #239) offer the plain start — boot the file straight from the PC, no transfer — so the local pane now offers both.

Menu order for a bootable file, with both emulators available:

```
Start CSpect with file beast.nex
Start MAME with file beast.nex
────────────────────────────────
Send to SD Card and start CSpect with file beast.nex
────────────────────────────────
Send to SD Card and start MAME with file beast.nex
────────────────────────────────
Copy text to clipboard
…
```

The plain pair comes first as the cheaper of the two. Nothing is replaced — putting the file on the card first is still one click away.

Built from the shared `emulator_autostart_entries` helper, so the same availability, ordering and per-emulator media rules apply as in the other four explorers, and directories or unbootable files are still skipped.

## Tests

Four new emulator-neutral assertions (the entries are loop-generated from the helper, so one pair of checks covers CSpect and MAME together): the helper is used, the local file is launched as-is, the plain entries sit **above** the send-then-start ones, and they do not replace them.

The ordering — the specific thing asked for — is mutation-checked: moving the plain entries below the send-then-start pair fails the suite.

Full suite green (20/20).