### PR TITLE
SD Card tab: keep the local explorer usable with no image loaded

### DIFF
--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -45,6 +45,11 @@ Phases:
      arming the retro toggle then declines instead of crashing. Every phase
      blocks pygame (below), but this is the one that exercises that view.
                                                         (no hdfmonkey needed)
+ 12  SD Card tab with NO image loaded: the LOCAL (left) explorer must stay
+     usable — it browses the PC and its right-click menu carries the "Start
+     <emulator> with <file>" actions, neither of which needs an image. The
+     image-side half must stay disabled, so this pins a targeted fix rather
+     than "enable everything".                          (no hdfmonkey needed)
 
 Every phase cfg carries zxnu_update_check=false (except phase 7, which quits
 before the delayed check can fire) so the suite never talks to GitHub.
@@ -80,7 +85,7 @@ DROPSRC = os.path.join(SCRATCH, "dropsrc.txt")
 DELZONE = os.path.join(SCRATCH, "delzone")
 
 PHASE = int(sys.argv[1]) if len(sys.argv) > 1 else None
-ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 
 # Base cfg for the isolated app copy: update checks off (MAME/CSpect AND the
 # app's own GitHub release check) so no phase ever hits the network, and the
@@ -248,6 +253,12 @@ elif PHASE == 10:
         f.write("mame_update_check=false\ncspect_update_check=false\n"
                 "zxnu_update_check=false\ncontent_disclaimer_agreed=1\n")
     os.environ["ZX_NEXT_UNITE_UI_LANGUAGE"] = "es"
+elif PHASE == 12:
+    # No image loaded at all: the base cfg names no image, which is exactly
+    # the resting state this phase is about.
+    ensure_scratch(fresh=False)
+    with open(CFG, "w") as f:
+        f.write(BASE_CFG)
 elif PHASE == 11:
     # NextSync Remote Explorer with pygame absent (every phase blocks pygame —
     # see _NoPygame). The retro log needs pygame; the Remote Explorer's dual
@@ -1088,10 +1099,61 @@ def inspect_phase11():
     app.quit()
 
 
+def inspect_phase12():
+    """With NO disk image loaded, the SD Card tab's LOCAL explorer must stay
+    usable.
+
+    The left pane browses the PC: it needs neither an image nor hdfmonkey, and
+    its right-click menu carries the "Start <emulator> with <file>" actions,
+    which boot a local file with no transfer. It was greyed out all the same,
+    because the no-image resting state reuses set_all_buttons_disabled() — the
+    blunt lock meant for transfers — so the actions were unreachable until an
+    image happened to be loaded.
+
+    The image-side half must STILL be disabled here: with no image there is
+    nothing for it to act on, and that is what makes this a targeted fix rather
+    than "enable everything"."""
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit()
+        return
+
+    # Guard the premise: this phase is only meaningful with no image loaded.
+    img = (win.imageinput.currentText() or "").strip().strip('"')
+    check("premise: no disk image is loaded", not img or not os.path.isfile(img),
+          f"imageinput={img!r}")
+
+    local_widgets = (
+        ("local file tree", win.treeview),
+        ("local Up button", win.local_explorer_up_button),
+        ("local Refresh button", win.local_explorer_refresh_button),
+        ("local filter box", win.filtertext),
+        ("local filter label", win.filterlabel),
+        ("local drive combo", win.zx_next_unite_diskdrive),
+    )
+    for label, w in local_widgets:
+        check(f"the {label} is usable without an image", w.isEnabled())
+
+    # The image picker itself must obviously stay reachable, or no image could
+    # ever be loaded.
+    check("the image picker is still reachable",
+          win.imageinput.isEnabled() and win.selectimage.isEnabled())
+
+    # ...and the image-dependent half stays disabled: this is a targeted fix.
+    for label, w in (("image tree", win.image_treeview),
+                     ("->image transfer button", win.button_to_image),
+                     ("->disk transfer button", win.button_to_disk),
+                     ("in-image new-folder button", win.button_new_folder)):
+        check(f"the {label} stays disabled with no image", not w.isEnabled())
+    app.quit()
+
+
 INSPECTORS = {1: inspect_phase1, 2: inspect_phase2, 3: inspect_phase3,
               4: inspect_phase4, 5: inspect_phase5, 6: inspect_phase6,
               7: inspect_phase7, 8: inspect_phase8, 9: inspect_phase9,
-              10: inspect_phase10, 11: inspect_phase11}
+              10: inspect_phase10, 11: inspect_phase11, 12: inspect_phase12}
 
 _orig_exec = QApplication.exec
 def _patched_exec(*_a):

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -1837,6 +1837,21 @@ class MainWindow(QMainWindow):
         def enable_image_selection():
             self.imageinput.setDisabled(False)
             self.selectimage.setDisabled(False)
+            # The LOCAL explorer (left pane) needs no disk image: browsing the
+            # PC, filtering, zip/unzip and the "Start <emulator> with <file>"
+            # actions all work on their own. It is only greyed out here because
+            # set_all_buttons_disabled() is the same blunt lock used during
+            # transfers, so re-enable the local half in this resting state —
+            # otherwise no image (or no hdfmonkey) leaves the whole left pane
+            # dead and those actions unreachable.
+            # Everything image-side (the image tree, both transfer buttons, the
+            # in-image new-folder/rename/delete controls) deliberately stays
+            # disabled: there is nothing yet for them to act on.
+            for _local_widget in (self.zx_next_unite_diskdrive, self.filterlabel,
+                                  self.filtertext, self.treeview,
+                                  self.local_explorer_up_button,
+                                  self.local_explorer_refresh_button):
+                _local_widget.setDisabled(False)
             # The MAME group is gated on MAME + a valid image, not on hdfmonkey —
             # so refresh it here, the resting state used when the image explorer
             # is unavailable (e.g. hdfmonkey missing or a failed load). Keeps


### PR DESCRIPTION
The SD Card tab's **left (local) explorer** browses the PC. It needs neither a disk image nor hdfmonkey, and since #240 its right-click menu carries the **"Start &lt;emulator&gt; with &lt;file&gt;"** actions, which boot a local file with no transfer at all.

It was greyed out anyway whenever no image was loaded — so those actions, plus browsing, filtering and zip/unzip, were unreachable until an image happened to be mounted.

## Cause

The no-image resting state reuses `set_all_buttons_disabled()` — the blunt lock meant for *transfers* — and then re-enables only the image picker. Everything else, including the entire local half, stayed dead.

## Fix

`enable_image_selection()` (the idle/no-image resting state, called at startup, on a failed load, and when no image is selected) now also re-enables the local pane: the tree, its Up/Refresh buttons, the filter row and the drive combo.

Deliberately targeted rather than "enable everything":

| Stays disabled with no image | Why |
|---|---|
| image tree | nothing to list |
| both transfer buttons | nothing to transfer to/from |
| in-image new-folder / rename / delete | nothing to act on |

And during a transfer `set_all_buttons_disabled()` still runs on its own, so the local pane remains locked while an operation is in flight — that behaviour is unchanged.

## Test

New offscreen **phase 12** asserts both halves against the real app with no image loaded: six local widgets enabled, the image picker reachable, and four image-side controls still disabled.

It was verified to reproduce the bug rather than assumed to: with the fix reverted, all six local checks fail.

Full suite green (20/20, 12 offscreen phases).

---

### Note on `.bas`

You mentioned starting a `.nex` **or `.bas`**. `.nex` works; `.bas` is not offered, and that looks correct rather than an oversight — neither emulator can boot one from the command line:

- **MAME** — `mame -listmedia tbblue` lists no `.bas` under any medium (snapshot, quickload or cassette).
- **CSpect** — the only `.bas` mention in `CSpectReadme.txt` is `SAVE "d:name.bas"`, i.e. saving *from* BASIC onto the card; there is no documented command-line load for it.

A `.bas` is a NextBASIC program that NextZXOS loads once it is running, not a snapshot an emulator can be pointed at. Adding it to the extension lists would produce a menu entry that fails. If you know of a CSpect switch that does load one, say so and I'll wire it up.