### PR TITLE
Emulator launch failures: toast, so a refusal is visible off the SD Card tab

### DIFF
--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1147,6 +1147,31 @@ def inspect_phase12():
                      ("->disk transfer button", win.button_to_disk),
                      ("in-image new-folder button", win.button_new_folder)):
         check(f"the {label} stays disabled with no image", not w.isEnabled())
+
+    # A refusal to launch must be VISIBLE, not just logged. MAME needs an
+    # image, and with the local explorer now usable without one, "Start MAME
+    # with <file>" is reachable in exactly this state — from the NextSync tab
+    # too, whose user never sees the SD Card tab's log window. So the refusal
+    # has to toast. Driven through the real launcher, on the real refusal path.
+    toasts = []
+    real_toast = win._show_toast
+    win._show_toast = lambda title, message="", **kw: toasts.append(
+        (title, message, kw.get("variant")))
+    try:
+        launch_mame = getattr(win, "_launch_mame_fn", None)
+        check("the MAME launcher is exposed on the window", launch_mame is not None)
+        if launch_mame is not None:
+            launch_mame()          # no image loaded -> must refuse
+            check("refusing to launch MAME raises a toast, not just a log line",
+                  len(toasts) == 1, f"{len(toasts)} toast(s)")
+            if toasts:
+                title, message, variant = toasts[0]
+                check("the toast names the emulator", "MAME" in title, title)
+                check("the toast body says what to do about it",
+                      "image" in message.lower(), message)
+                check("the toast is styled as a failure", variant == "red", str(variant))
+    finally:
+        win._show_toast = real_toast
     app.quit()
 
 

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -235,6 +235,25 @@ def build_emulator_ops(
             execute_shell_command("vim", "./" + ZX_NEXT_UNITE_CONFIG_FILE_NAME)
         return
 
+    def _emulator_launch_failed(emulator, message):
+        """Report a launch that produced nothing, where the user can see it.
+
+        These launches are logged to the SD Card tab's window, which was fine
+        while "Launch CSpect/MAME" were buttons on that very tab. They are now
+        also reachable from the NextSync tab's explorers (and from the SD Card
+        local pane with no image loaded), so on any other tab a refusal would
+        look exactly like nothing happening. The log line stays — it is the
+        record — and the toast is what makes the refusal visible.
+        """
+        add_main_log_window(message)
+        try:
+            host._show_toast(
+                ui_tr_now("Could not start {emulator}").format(emulator=emulator),
+                message, variant="red", duration_ms=9000)
+        except (RuntimeError, AttributeError):
+            # Toasts are best-effort UI; never let one break a launch path.
+            logging.exception("could not show the launch-failure toast")
+
     def launch_cspect(autostart_file=None):
         """Launch CSpect against the loaded SD image.
 
@@ -344,13 +363,17 @@ def build_emulator_ops(
             except subprocess.CalledProcessError as ex:
                 if ex.returncode == 1:
                     logging.error("CSpect.exe is not present in the same local directory as zx-next-unite.Please install it from http://cspect.org")
-                    add_main_log_window(ui_tr_now(
+                    _emulator_launch_failed("CSpect", ui_tr_now(
                         "ERROR: CSpect.exe is not present in the same local "
                         "directory as zx-next-unite. Please install it from "
                         "http://cspect.org"))
                 else:
                     logging.error(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
+                    # The raw shell error stays English (a diagnostic), but the
+                    # user still needs to see that nothing started.
                     add_main_log_window(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
+                    _emulator_launch_failed("CSpect", ui_tr_now(
+                        "ERROR: Failed to launch CSpect: {error}").format(error=ex))
 
                 if platform.system() != "Windows":
                     logging.error("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
@@ -386,7 +409,7 @@ def build_emulator_ops(
         # missing) — otherwise MAME could never be launched without hdfmonkey.
         _sel_image = host.imageinput.currentText().strip().strip('"')
         if not (_sel_image and os.path.isfile(_sel_image)):
-            add_main_log_window(ui_tr_now(
+            _emulator_launch_failed("MAME", ui_tr_now(
                 "Select a valid ZX Spectrum Next disk image (.img/.hdf) "
                 "before launching MAME."))
             return
@@ -398,7 +421,7 @@ def build_emulator_ops(
         mame_path = getattr(host, "_mame_executable_path", None)
         if not _flatpak and not mame_path:
             logging.error("MAME executable not found on PATH. Cannot launch MAME.")
-            add_main_log_window(ui_tr_now(
+            _emulator_launch_failed("MAME", ui_tr_now(
                 "ERROR: MAME executable not found on PATH. Cannot launch MAME."))
             return
 
@@ -536,7 +559,7 @@ def build_emulator_ops(
                 )
         except Exception as ex:
             logging.error(f"ERROR: Failed to launch MAME: {ex}")
-            add_main_log_window(ui_tr_now(
+            _emulator_launch_failed("MAME", ui_tr_now(
                 "ERROR: Failed to launch MAME: {error}").format(error=ex))
             return
 

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -482,6 +482,8 @@ CATALOGS = {
             "No se pudieron listar las versiones de MAME: {error}",
         "ERROR: Failed to launch MAME: {error}":
             "ERROR: no se pudo iniciar MAME: {error}",
+        "ERROR: Failed to launch CSpect: {error}":
+            "ERROR: No se pudo iniciar CSpect: {error}",
         "ERROR: could not extract {name}: {error}":
             "ERROR: no se pudo extraer {name}: {error}",
         "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
@@ -1309,6 +1311,8 @@ CATALOGS = {
             "Não foi possível listar as versões do MAME: {error}",
         "ERROR: Failed to launch MAME: {error}":
             "ERRO: não foi possível iniciar o MAME: {error}",
+        "ERROR: Failed to launch CSpect: {error}":
+            "ERRO: Não foi possível iniciar o CSpect: {error}",
         "ERROR: could not extract {name}: {error}":
             "ERRO: não foi possível extrair {name}: {error}",
         "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
@@ -2134,6 +2138,8 @@ CATALOGS = {
             "Nie udało się pobrać listy wersji MAME: {error}",
         "ERROR: Failed to launch MAME: {error}":
             "BŁĄD: nie udało się uruchomić MAME: {error}",
+        "ERROR: Failed to launch CSpect: {error}":
+            "BŁĄD: Nie udało się uruchomić CSpect: {error}",
         "ERROR: could not extract {name}: {error}":
             "BŁĄD: nie udało się wypakować {name}: {error}",
         "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
@@ -2960,6 +2966,8 @@ CATALOGS = {
             "Не удалось получить список версий MAME: {error}",
         "ERROR: Failed to launch MAME: {error}":
             "ОШИБКА: не удалось запустить MAME: {error}",
+        "ERROR: Failed to launch CSpect: {error}":
+            "ОШИБКА: Не удалось запустить CSpect: {error}",
         "ERROR: could not extract {name}: {error}":
             "ОШИБКА: не удалось извлечь {name}: {error}",
         "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
@@ -3785,6 +3793,8 @@ CATALOGS = {
             "Nepodařilo se načíst seznam verzí MAME: {error}",
         "ERROR: Failed to launch MAME: {error}":
             "CHYBA: nepodařilo se spustit MAME: {error}",
+        "ERROR: Failed to launch CSpect: {error}":
+            "CHYBA: Nepodařilo se spustit CSpect: {error}",
         "ERROR: could not extract {name}: {error}":
             "CHYBA: nepodařilo se rozbalit {name}: {error}",
         "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":
@@ -4613,6 +4623,8 @@ CATALOGS = {
             "Impossible de lister les versions de MAME : {error}",
         "ERROR: Failed to launch MAME: {error}":
             "ERREUR : impossible de lancer MAME : {error}",
+        "ERROR: Failed to launch CSpect: {error}":
+            "ERREUR : Impossible de lancer CSpect : {error}",
         "ERROR: could not extract {name}: {error}":
             "ERREUR : impossible d'extraire {name} : {error}",
         "ERROR: hdfmonkey failed - A file can't be opened this is commonly caused by strange characters such as quotes and signs":


### PR DESCRIPTION
Both launchers reported failures only to the **SD Card tab's log window**. That was fine while "Launch CSpect" / "Launch Mame" were buttons on that very tab — but the "Start &lt;emulator&gt; with &lt;file&gt;" actions now reach them from the NextSync tab's three explorers (#239) and from the SD Card local pane with no image loaded (#241).

On any other tab that log line is invisible, so a refusal looked exactly like **nothing happening**. Easiest to hit with MAME, which requires a selected image — and #241 made the local explorer usable precisely when no image is loaded.

## What toasts now

Every launch path that ends in nothing gets a red 9-second toast alongside the existing log line:

| Emulator | Path |
|---|---|
| MAME | no valid disk image selected |
| MAME | executable not found on PATH |
| MAME | launch raised an exception |
| CSpect | `CSpect.exe` not present |
| CSpect | unhandled shell-execute error |

The log line stays — it is the record — and the toast is what makes the refusal visible. The title reuses the `Could not start {emulator}` string added in #239, so only **one** new string was needed (`ERROR: Failed to launch CSpect: {error}`), across all six languages.

The raw shell error stays English as a protocol-style diagnostic, and is accompanied by a translated line saying nothing started.

## Test

Offscreen **phase 12** already had the real app with no image loaded — exactly the refusal condition — so it drives the real launcher through its real refusal path and asserts a red toast that names MAME and points at the image.

Verified to catch a regression rather than assumed to: reverted to log-only, the check fails with `0 toast(s)`.

Full suite green (20/20, 12 offscreen phases).