### PR TITLE
Fix: Remote Explorer downloaded the file and then nothing happened

### DIFF
--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -1221,6 +1221,44 @@ def test_emulator_start_from_next():
     check("no hook -> no entries (the widget knows no emulators itself)",
           w3._emulator_entries("/anything.nex") == [])
 
+    # REGRESSION (reported): the file downloaded and then nothing happened.
+    # Both emulators need a mounted SD image, and on this tab there usually is
+    # none — so the launch could never work, and CSpect's launcher returned
+    # silently. Ask before transferring, and say why.
+    launched.clear()
+    blocked_entry = EmulatorAutostart(
+        "CSpect", "Start CSpect with file x.nex", launched.append,
+        lambda: tempfile.mkdtemp(dir=TMP),
+        lambda: "Load a ZX Spectrum Next disk image first")
+    w4, calls4 = make_widget(emulator_entries=lambda p: [blocked_entry])
+    connect_widget(w4, calls4, listing=[(False, 10, "x.nex")])
+    w4._emulator_start_from_next("/x.nex", blocked_entry)
+    check("a launch that cannot succeed downloads NOTHING",
+          not any(c[0] == "get" for c in calls4["q"]), str(calls4["q"]))
+    check("...and says why, visibly (toast, not just the log)",
+          len(calls4["toasts"]) == 1
+          and "disk image" in calls4["toasts"][0][1], str(calls4["toasts"]))
+    check("...and starts no emulator", launched == [])
+
+    # The worker names the arriving file from what the NEXT reports, not from
+    # the path we asked for, so a single-file get can land under a sub-path.
+    # The staging dir holds this download alone, so the file must still be
+    # found rather than reported as a failed download.
+    launched.clear()
+    stage3 = tempfile.mkdtemp(dir=TMP)
+    entry3 = EmulatorAutostart("CSpect", "Start CSpect with file y.nex",
+                               launched.append, lambda: stage3)
+    w5, calls5 = make_widget(emulator_entries=lambda p: [entry3])
+    connect_widget(w5, calls5, listing=[(False, 10, "y.nex")])
+    w5._emulator_start_from_next("/games/y.nex", entry3)
+    odd = os.path.join(stage3, "games", "y.nex")     # not <tmp>/y.nex
+    os.makedirs(os.path.dirname(odd), exist_ok=True)
+    open(odd, "wb").write(b"\x00" * 4)
+    w5.on_op_done(True, "get", "/games/y.nex")
+    QApplication.processEvents()
+    check("a file that lands under a sub-path is still found and booted",
+          launched == [odd], str(launched))
+
 
 def main():
     logging.disable(logging.CRITICAL)

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1170,6 +1170,37 @@ def inspect_phase12():
                 check("the toast body says what to do about it",
                       "image" in message.lower(), message)
                 check("the toast is styled as a failure", variant == "red", str(variant))
+
+        # REGRESSION (reported): "Start CSpect with file X" downloaded the file
+        # and then nothing happened. launch_cspect wrapped its whole body in a
+        # bare `if _right_disk_content():` with no else, so with no image
+        # mounted it returned in total silence — no launch, no log, no toast.
+        toasts.clear()
+        launch_cspect = getattr(win, "_launch_cspect_fn", None)
+        check("the CSpect launcher is exposed on the window",
+              launch_cspect is not None)
+        if launch_cspect is not None:
+            launch_cspect()        # no image loaded -> must refuse, not vanish
+            check("refusing to launch CSpect is never silent",
+                  len(toasts) == 1, f"{len(toasts)} toast(s)")
+            if toasts:
+                check("the CSpect toast names the emulator",
+                      "CSpect" in toasts[0][0], toasts[0][0])
+                check("the CSpect toast says an image is needed",
+                      "image" in toasts[0][1].lower(), toasts[0][1])
+
+        # And the pre-flight check both emulators share reports the same thing,
+        # so the Remote Explorer can ask BEFORE downloading anything.
+        blocker = getattr(win, "_emulator_launch_blocker", None)
+        check("a shared launch-precondition check is exposed",
+              blocker is not None)
+        if blocker is not None:
+            check("with no image, CSpect reports itself blocked",
+                  bool(blocker("CSpect")), repr(blocker("CSpect")))
+            check("with no image, MAME reports itself blocked",
+                  bool(blocker("MAME")), repr(blocker("MAME")))
+            check("an unknown emulator is not reported as blocked",
+                  blocker("Nonesuch") == "")
     finally:
         win._show_toast = real_toast
     app.quit()

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -254,6 +254,32 @@ def build_emulator_ops(
             # Toasts are best-effort UI; never let one break a launch path.
             logging.exception("could not show the launch-failure toast")
 
+    def _emulator_launch_blocker(emulator):
+        """Why *emulator* cannot start right now, or "" when it can.
+
+        Both emulators boot the Next from the mounted SD image, so both need
+        one; these checks mirror exactly what each launcher enforces itself.
+        Callers that must do expensive work BEFORE launching — the Remote
+        Explorer downloads the file off the Next first — ask this up front, so
+        the user is told immediately instead of after a pointless transfer.
+        """
+        if emulator == "CSpect":
+            if _right_disk_content():
+                return ""
+            return ui_tr_now(
+                "Load a ZX Spectrum Next disk image first — then CSpect can "
+                "boot it from the mounted SD card.")
+        if emulator == "MAME":
+            _img = (host.imageinput.currentText() or "").strip().strip('"')
+            if _img and os.path.isfile(_img):
+                return ""
+            return ui_tr_now(
+                "Select a valid ZX Spectrum Next disk image (.img/.hdf) "
+                "before launching MAME.")
+        return ""
+
+    host._emulator_launch_blocker = _emulator_launch_blocker
+
     def launch_cspect(autostart_file=None):
         """Launch CSpect against the loaded SD image.
 
@@ -274,119 +300,131 @@ def build_emulator_ops(
         accept an argument. That bool is filtered out by the isinstance() check
         below rather than by a keyword-only signature, which Qt handles less
         predictably across PySide versions."""
-        if _right_disk_content():  # check that we have an image content first
-            set_all_buttons_disabled()
+        # CSpect boots the Next from the mounted SD image, so it needs one.
+        # This used to be a bare `if` around the whole body with no else: with
+        # no image the call did nothing at all — no launch, no log, no toast.
+        # Harmless while the only caller was a button that was greyed out
+        # without an image, but the "Start CSpect with <file>" actions are
+        # reachable from the NextSync tab, where there is usually no image
+        # mounted, and there it looked like the action was simply broken.
+        if not _right_disk_content():
+            _emulator_launch_failed("CSpect", ui_tr_now(
+                "Load a ZX Spectrum Next disk image first — then CSpect can "
+                "boot it from the mounted SD card."))
+            return
 
-            # Editable "CSpect default launch parameters" from the Settings
-            # tab (persisted in SETTING_CUSTOM), falling back to the built-in
-            # default. The SD Card group options are appended on top below,
-            # mirroring how launch_mame handles its default command line.
-            cspect_default_params = configuration_dictionary.get(
-                SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS)
-            if not cspect_default_params:
-                cspect_default_params = CSPECT_DEFAULT_LAUNCH_PARAMETERS
-            cspect_arguments = " " + cspect_default_params + " "
-            # Selections are read by INDEX: these combos show translated labels,
-            # so currentText() no longer identifies the entry (see
-            # emulator_option_argument).
-            for _cspect_combo, _cspect_opts in (
-                    (host.cspect_screensize, CSPECT_SCREEN_SIZES),
-                    (host.cspect_sound, CSPECT_SOUND),
-                    (host.cspect_vsync, CSPECT_SCREEN_SYNC),
-                    (host.cspect_joystick, CSPECT_JOYSTICK),
-                    (host.cspect_mouse, CSPECT_MOUSE),
-                    (host.cspect_frequency, CSPECT_FREQUENCY),
-                    # ESC-key disable ("-esc"); "Disable ESC Key Off" (default)
-                    # passes nothing so ESC still exits.
-                    (host.cspect_esc, CSPECT_ESC)):
-                cspect_arguments += emulator_option_argument(
-                    _cspect_opts, _cspect_combo.currentIndex()) + " "
+        set_all_buttons_disabled()
 
-            # When the CSpect copy in use is a bundled itch.io install under
-            # downloads/cspect, it must be launched from its own folder so its
-            # Next ROMs resolve. The working directory then differs from the
-            # app directory, so the image path must be absolute.
-            cspect_exe = getattr(host, "_cspect_executable_path", None)
-            use_bundled = (getattr(host, "_cspect_from_downloads", False)
-                           and cspect_exe and os.path.isfile(cspect_exe))
-            # The path is normalised (unquoted) when loaded, but strip any
-            # stray surrounding quotes defensively before os.path work:
-            # os.path.abspath() on a string starting with '"' treats it as a
-            # relative path and prepends the cwd, yielding a bogus value like
-            # <cwd>\"C:\temp\img". Re-quote only the final path below (the
-            # -mmc= argument goes through the shell, so spaces need quoting).
-            img_path = (host.right_disk_image_path or "").strip().strip('"')
-            if use_bundled:
-                # CSpect runs from its own folder so its Next ROMs resolve;
-                # the working dir then differs from the app dir, so the image
-                # path must be absolute.
-                cspect_cwd = os.path.dirname(cspect_exe)
-                if img_path:
-                    img_path = os.path.abspath(img_path)
+        # Editable "CSpect default launch parameters" from the Settings
+        # tab (persisted in SETTING_CUSTOM), falling back to the built-in
+        # default. The SD Card group options are appended on top below,
+        # mirroring how launch_mame handles its default command line.
+        cspect_default_params = configuration_dictionary.get(
+            SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS)
+        if not cspect_default_params:
+            cspect_default_params = CSPECT_DEFAULT_LAUNCH_PARAMETERS
+        cspect_arguments = " " + cspect_default_params + " "
+        # Selections are read by INDEX: these combos show translated labels,
+        # so currentText() no longer identifies the entry (see
+        # emulator_option_argument).
+        for _cspect_combo, _cspect_opts in (
+                (host.cspect_screensize, CSPECT_SCREEN_SIZES),
+                (host.cspect_sound, CSPECT_SOUND),
+                (host.cspect_vsync, CSPECT_SCREEN_SYNC),
+                (host.cspect_joystick, CSPECT_JOYSTICK),
+                (host.cspect_mouse, CSPECT_MOUSE),
+                (host.cspect_frequency, CSPECT_FREQUENCY),
+                # ESC-key disable ("-esc"); "Disable ESC Key Off" (default)
+                # passes nothing so ESC still exits.
+                (host.cspect_esc, CSPECT_ESC)):
+            cspect_arguments += emulator_option_argument(
+                _cspect_opts, _cspect_combo.currentIndex()) + " "
+
+        # When the CSpect copy in use is a bundled itch.io install under
+        # downloads/cspect, it must be launched from its own folder so its
+        # Next ROMs resolve. The working directory then differs from the
+        # app directory, so the image path must be absolute.
+        cspect_exe = getattr(host, "_cspect_executable_path", None)
+        use_bundled = (getattr(host, "_cspect_from_downloads", False)
+                       and cspect_exe and os.path.isfile(cspect_exe))
+        # The path is normalised (unquoted) when loaded, but strip any
+        # stray surrounding quotes defensively before os.path work:
+        # os.path.abspath() on a string starting with '"' treats it as a
+        # relative path and prepends the cwd, yielding a bogus value like
+        # <cwd>\"C:\temp\img". Re-quote only the final path below (the
+        # -mmc= argument goes through the shell, so spaces need quoting).
+        img_path = (host.right_disk_image_path or "").strip().strip('"')
+        if use_bundled:
+            # CSpect runs from its own folder so its Next ROMs resolve;
+            # the working dir then differs from the app dir, so the image
+            # path must be absolute.
+            cspect_cwd = os.path.dirname(cspect_exe)
+            if img_path:
+                img_path = os.path.abspath(img_path)
+        else:
+            cspect_cwd = None
+        mmc_path = f'"{img_path}"' if img_path else img_path
+
+        cspect_arguments += " -mmc=" + mmc_path + " "
+
+        # Auto-start file: a HOST path, appended as CSpect's trailing
+        # argument. It is made absolute because CSpect may run from its
+        # own folder (the bundled itch.io copy does), and always quoted —
+        # this goes through the shell and Next files live under paths with
+        # spaces often enough.
+        if isinstance(autostart_file, str) and autostart_file.strip():
+            _auto = os.path.abspath(autostart_file.strip().strip('"'))
+            cspect_arguments += f'"{_auto}" '
+
+        # The command that will actually be invoked: the bundled itch.io
+        # copy by absolute path, otherwise the CSpect.exe resolved from the
+        # app directory / PATH (prefixed with mono on macOS/Linux).
+        if platform.system() == "Windows":
+            cspect_executable = f'"{cspect_exe}"' if use_bundled else "CSpect.exe"
+        else:
+            cspect_executable = f'mono "{cspect_exe}"' if use_bundled else "mono CSpect.exe"
+            # Inside the Flatpak sandbox there is no mono — delegate the
+            # launch to the host through the Flatpak portal, exactly like
+            # the MAME launch (mame_flatpak_command): every involved path
+            # (CSpect under ~/.var/app, the cwd, the -mmc image) is a real
+            # host path, so the host-side mono resolves them unchanged.
+            if os.environ.get("FLATPAK_ID"):
+                cspect_executable = "flatpak-spawn --host " + cspect_executable
+
+        logging.info(f"CSpect executable: {cspect_executable}")
+        add_main_log_window(f"CSpect executable: {cspect_executable}")
+        logging.info(f"Cspect start with arguments: {cspect_arguments}")
+        add_main_log_window(f"Cspect start with arguments: {cspect_arguments}")
+
+        try:
+            execute_shell_command(cspect_executable, cspect_arguments, cwd=cspect_cwd)
+        except subprocess.CalledProcessError as ex:
+            if ex.returncode == 1:
+                logging.error("CSpect.exe is not present in the same local directory as zx-next-unite.Please install it from http://cspect.org")
+                _emulator_launch_failed("CSpect", ui_tr_now(
+                    "ERROR: CSpect.exe is not present in the same local "
+                    "directory as zx-next-unite. Please install it from "
+                    "http://cspect.org"))
             else:
-                cspect_cwd = None
-            mmc_path = f'"{img_path}"' if img_path else img_path
+                logging.error(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
+                # The raw shell error stays English (a diagnostic), but the
+                # user still needs to see that nothing started.
+                add_main_log_window(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
+                _emulator_launch_failed("CSpect", ui_tr_now(
+                    "ERROR: Failed to launch CSpect: {error}").format(error=ex))
 
-            cspect_arguments += " -mmc=" + mmc_path + " "
-
-            # Auto-start file: a HOST path, appended as CSpect's trailing
-            # argument. It is made absolute because CSpect may run from its
-            # own folder (the bundled itch.io copy does), and always quoted —
-            # this goes through the shell and Next files live under paths with
-            # spaces often enough.
-            if isinstance(autostart_file, str) and autostart_file.strip():
-                _auto = os.path.abspath(autostart_file.strip().strip('"'))
-                cspect_arguments += f'"{_auto}" '
-
-            # The command that will actually be invoked: the bundled itch.io
-            # copy by absolute path, otherwise the CSpect.exe resolved from the
-            # app directory / PATH (prefixed with mono on macOS/Linux).
-            if platform.system() == "Windows":
-                cspect_executable = f'"{cspect_exe}"' if use_bundled else "CSpect.exe"
-            else:
-                cspect_executable = f'mono "{cspect_exe}"' if use_bundled else "mono CSpect.exe"
-                # Inside the Flatpak sandbox there is no mono — delegate the
-                # launch to the host through the Flatpak portal, exactly like
-                # the MAME launch (mame_flatpak_command): every involved path
-                # (CSpect under ~/.var/app, the cwd, the -mmc image) is a real
-                # host path, so the host-side mono resolves them unchanged.
+            if platform.system() != "Windows":
+                logging.error("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
+                add_main_log_window(ui_tr_now(
+                    "On MacOS and Linux mono is required as it runs under "
+                    "it. Please make sure mono is installed."))
                 if os.environ.get("FLATPAK_ID"):
-                    cspect_executable = "flatpak-spawn --host " + cspect_executable
-
-            logging.info(f"CSpect executable: {cspect_executable}")
-            add_main_log_window(f"CSpect executable: {cspect_executable}")
-            logging.info(f"Cspect start with arguments: {cspect_arguments}")
-            add_main_log_window(f"Cspect start with arguments: {cspect_arguments}")
-
-            try:
-                execute_shell_command(cspect_executable, cspect_arguments, cwd=cspect_cwd)
-            except subprocess.CalledProcessError as ex:
-                if ex.returncode == 1:
-                    logging.error("CSpect.exe is not present in the same local directory as zx-next-unite.Please install it from http://cspect.org")
-                    _emulator_launch_failed("CSpect", ui_tr_now(
-                        "ERROR: CSpect.exe is not present in the same local "
-                        "directory as zx-next-unite. Please install it from "
-                        "http://cspect.org"))
-                else:
-                    logging.error(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
-                    # The raw shell error stays English (a diagnostic), but the
-                    # user still needs to see that nothing started.
-                    add_main_log_window(f"ERROR: Unknown shell execute error: {ex.returncode} - :{ex}")
-                    _emulator_launch_failed("CSpect", ui_tr_now(
-                        "ERROR: Failed to launch CSpect: {error}").format(error=ex))
-
-                if platform.system() != "Windows":
-                    logging.error("On MacOS and Linux mono is required as it runs under it. Please make sure mono is installed.")
                     add_main_log_window(ui_tr_now(
-                        "On MacOS and Linux mono is required as it runs under "
-                        "it. Please make sure mono is installed."))
-                    if os.environ.get("FLATPAK_ID"):
-                        add_main_log_window(ui_tr_now(
-                            "Running as a Flatpak: mono must be installed on "
-                            "the HOST system — the launch is delegated there "
-                            "via flatpak-spawn."))
+                        "Running as a Flatpak: mono must be installed on "
+                        "the HOST system — the launch is delegated there "
+                        "via flatpak-spawn."))
 
-            set_all_buttons_enabled()
+        set_all_buttons_enabled()
 
 
     def launch_mame(autostart_file=None):

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -2252,6 +2252,17 @@ class RemoteExplorerWidget(QWidget):
         if not self._connected or self._op_active:
             return
         name = posixpath.basename(remote_path.rstrip("/")) or remote_path
+        # Ask BEFORE transferring anything: both emulators need a mounted SD
+        # image, and on this tab there often is none. Downloading first and
+        # only then discovering the launch cannot happen is what made this
+        # look like "the file downloads and nothing happens".
+        blocked = entry.blocked()
+        if blocked:
+            self._log(blocked)
+            self._on_toast(
+                ui_tr_now("Could not start {emulator}").format(emulator=entry.name),
+                blocked, "red")
+            return
         try:
             tmp = entry.staging_dir()
         except OSError as exc:
@@ -2264,12 +2275,29 @@ class RemoteExplorerWidget(QWidget):
 
         def _started(ok, _fails):
             local = os.path.join(tmp, name)
+            if ok and not os.path.isfile(local):
+                # The worker names the file from what the NEXT reports, not
+                # from the path we asked for (see _re_relname_under), so a
+                # single-file get can land under a sub-path. The staging dir
+                # holds this download and nothing else, so if exactly one file
+                # arrived it is the one to boot, whatever it ended up called.
+                arrived = [os.path.join(root, f)
+                           for root, _dirs, files in os.walk(tmp) for f in files]
+                if len(arrived) == 1:
+                    local = arrived[0]
             if not ok or not os.path.isfile(local):
                 shutil.rmtree(tmp, ignore_errors=True)
                 self._log(ui_tr_now(
                     "Start {emulator}: {name} could not be downloaded from "
                     "the Next, {emulator} was not started.").format(
                         emulator=entry.name, name=name))
+                self._on_toast(
+                    ui_tr_now("Could not start {emulator}").format(
+                        emulator=entry.name),
+                    ui_tr_now("Start {emulator}: {name} could not be "
+                              "downloaded from the Next, {emulator} was not "
+                              "started.").format(emulator=entry.name, name=name),
+                    "red")
                 return
             # Deferred so _end_operation fully unwinds before the launch.
             QTimer.singleShot(0, lambda: entry.launch(local))

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -82,8 +82,15 @@ class CompactButton(QPushButton):
 #   launch      call with a HOST path to boot the file
 #   staging_dir call to create and return a directory to put a host copy in,
 #               when the file is not already on the PC
+#   blocked     call for the reason this emulator cannot start right now, or ""
+#               when it can. Callers that must fetch the file first (the Next
+#               pane downloads it) check this BEFORE the transfer, so a launch
+#               that cannot succeed is reported instead of silently doing
+#               nothing after a download. Defaults to "never blocked" so a
+#               caller can still build an entry by hand.
 EmulatorAutostart = namedtuple("EmulatorAutostart",
-                               "name label launch staging_dir")
+                               "name label launch staging_dir blocked",
+                               defaults=(lambda: "",))
 
 
 def emulator_autostart_entries(host, path, is_dir=False):
@@ -109,13 +116,17 @@ def emulator_autostart_entries(host, path, is_dir=False):
     def _tmp(prefix):
         return lambda: tempfile.mkdtemp(prefix=prefix)
 
+    def _blocked(emulator):
+        fn = getattr(host, "_emulator_launch_blocker", None)
+        return (lambda: fn(emulator)) if fn else (lambda: "")
+
     if (cspect_can_autostart(path)
             and getattr(host, "_cspect_executable_path", None)
             and getattr(host, "_launch_cspect_fn", None)):
         entries.append(EmulatorAutostart(
             "CSpect",
             ui_tr_now("Start CSpect with file {name}").format(name=name),
-            host._launch_cspect_fn, _tmp("zxnu-cspect-")))
+            host._launch_cspect_fn, _tmp("zxnu-cspect-"), _blocked("CSpect")))
 
     _mame_usable = getattr(host, "_mame_usable", None)
     if (mame_can_autostart(path) and _mame_usable and _mame_usable()
@@ -133,7 +144,7 @@ def emulator_autostart_entries(host, path, is_dir=False):
         entries.append(EmulatorAutostart(
             "MAME",
             ui_tr_now("Start MAME with file {name}").format(name=name),
-            host._launch_mame_fn, _mame_staging_dir))
+            host._launch_mame_fn, _mame_staging_dir, _blocked("MAME")))
     return entries
 
 


### PR DESCRIPTION
Reported on the Next (right) pane: **"Start CSpect/MAME with file" downloads the file, then nothing follows.**

## Root cause

`launch_cspect` wrapped its **entire body** in a bare guard with no `else`:

```python
if _right_disk_content():      # no else, no return, no message
    ...all 112 lines of the launch...
```

With no SD image mounted it returned in complete silence — no launch, no log, no toast. That was harmless while its only caller was the "Launch CSpect" button, which is greyed out without an image. But the "Start …" actions added in #239 are reachable from the NextSync tab, **where there is usually no image mounted**, so the action looked simply broken.

MAME has the same requirement and refused too (visibly since #242), which is why you saw it with both emulators.

Both emulators genuinely need a mounted image — they boot the Next from it — so the requirement is right; the silence was the bug.

## Three changes

1. **`launch_cspect` reports instead of vanishing.** The guard is inverted to an early return with the same message its tooltip already uses, and the body dedented. Verified whitespace-only apart from the guard by comparing the stripped function bodies before and after.

2. **A shared precondition check** (`host._emulator_launch_blocker`) mirrors what each launcher enforces. The Next pane now asks **before transferring**, so a launch that cannot succeed no longer costs a pointless download — it says why immediately. Carried on `EmulatorAutostart` as `blocked`, with a default so hand-built entries keep working.

3. **The post-download lookup no longer insists on `<staging>/<name>`.** The worker names the arriving file from what the *Next* reports, not from the path we asked for (`_re_relname_under`), so a single-file `get` can land under a sub-path. The staging directory holds this one download and nothing else, so a lone arrival is booted whatever it ended up called. This is the likely cause of your "sometimes the file doesn't even appear" observation. A genuinely failed download now toasts as well, instead of only logging.

## On "the file doesn't appear on the left explorer"

That part is expected: unlike **Download (:&lt;-)**, which fetches into the local pane's current folder, this action stages the file in a temp directory and boots it from there — so it deliberately does not show up in the left pane. Say the word if you would rather it downloaded next to your local browsing folder, where you would keep it.

## Tests

| Check | Verified to catch |
|---|---|
| refusing to launch CSpect is never silent (real launcher, phase 12) | restoring the silent return → `0 toast(s)` |
| a blocked launch downloads **nothing** and toasts why | new widget test |
| a file arriving under a sub-path is still found and booted | new widget test |

Plus the shared precondition check asserted for both emulators, and that an unknown emulator is not reported as blocked.

Full suite green (20/20, 12 offscreen phases).