### PR TITLE
Remote Explorer: download to the local disk, and stop demanding an SD image

### DIFF
--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -125,6 +125,16 @@ if fn is not None:
           src.index("_auto_switch, _auto") < src.index("MAME_HARD_DISK_PARAMETER, mame_image"))
     check("an unsupported file does not silently vanish",
           "MAME cannot load {name} directly" in src)
+    # Verified live against MAME 0.288: `mame tbblue -snapshot foo.nex` boots
+    # with no -hard1 at all. So a file to boot lifts the image requirement —
+    # without this, "Start MAME with file …" was unusable from the NextSync
+    # tab, where no image is mounted.
+    check("a file to boot lifts the disk-image requirement",
+          "and not _has_autostart" in src,
+          "MAME loads a snapshot with no -hard1")
+    check("only a real file is passed as -hard1",
+          "os.path.isfile(mame_image)" in src,
+          "'-hard1 <not a file>' is fatal in MAME, not a no-op")
 
 # ---- booting a file that lives on the image must extract it first --------
 ops = open(os.path.join(REPO, "zxnu_sdcard_ops.py"), encoding="utf-8").read()

--- a/tests/test_nextsync_autostart.py
+++ b/tests/test_nextsync_autostart.py
@@ -176,15 +176,28 @@ check("the Next pane routes through the download-first path",
 seg = rex[rex.find("def _emulator_start_from_next"):]
 seg = seg[:seg.find("def _remote_unzip")]
 check("the Next pane downloads with the same 'get' op as Download",
-      '("get", remote_path, tmp)' in seg)
-check("...into the emulator's own staging directory",
-      "entry.staging_dir()" in seg,
-      "a plain mkdtemp would break Flatpak MAME")
+      '("get", remote_path, dest)' in seg)
+check("...into the LOCAL pane's folder, where the user can see and keep it",
+      "dest = self._local_dir()" in seg,
+      "a temp dir made the file vanish; Download puts it here")
+check("...falling back to a scratch dir only if that folder is unwritable",
+      "entry.staging_dir()" in seg and "os.access(dest, os.W_OK)" in seg)
 check("...and launches the DOWNLOADED copy, never the Next path",
       "entry.launch(local)" in seg and "entry.launch(remote_path)" not in seg)
-check("a failed download starts nothing and cleans up",
-      "shutil.rmtree(tmp, ignore_errors=True)" in seg
-      and "could not be downloaded from " in seg)
+check("a failed download starts nothing and says so",
+      "could not be downloaded from " in seg)
+# The destination is normally the user's own browsing folder, so the failure
+# path must never rmtree it — only a scratch dir this code created itself.
+check("a failed download NEVER deletes the user's local folder",
+      "if scratch:" in seg
+      and seg.count("shutil.rmtree(dest, ignore_errors=True)") == 1
+      and seg.index("if scratch:") < seg.index("shutil.rmtree(dest"),
+      "rmtree must be reachable only for a directory we made")
+# Booting a file needs no mounted image (MAME: no -hard1; CSpect: -mmc=<dir>),
+# so the pre-flight check must not turn a missing SD card into a red toast.
+check("a missing SD card does not block booting a file",
+      "autostart=True" in open(
+          os.path.join(REPO, "zxnu_workers.py"), encoding="utf-8").read())
 # Both panes act on exactly one selected FILE — a folder or a multi-selection
 # has no single file to boot.
 check("the Next pane only offers the entries for a single selected file",

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -147,6 +147,14 @@ def fwd(p):
     return p.replace("\\", "/")
 
 
+def samepath(a, b):
+    """True when two paths name the same file. _local_dir() hands back
+    forward-slashed paths while os.path.join uses the native separator, so a
+    raw string compare fails on Windows for paths that are in fact identical."""
+    return (os.path.normcase(os.path.realpath(a))
+            == os.path.normcase(os.path.realpath(b)))
+
+
 def normq(q):
     """A queue with every string normalised to forward slashes, so command
     comparisons are separator-agnostic."""
@@ -1174,44 +1182,57 @@ def test_emulator_start_from_next():
         staged.append(stage_root)
         return stage_root
 
+    # The download goes to the LOCAL pane's folder, exactly where the Download
+    # action puts things, so the file shows up in the left explorer and the
+    # user keeps it — not into a temp directory it can never be found in.
+    local_dir = tempfile.mkdtemp(dir=TMP)
     entry = EmulatorAutostart("CSpect", "Start CSpect with file beast.nex",
                               launched.append, make_stage)
-    w, calls = make_widget(emulator_entries=lambda p: [entry])
+    w, calls = make_widget(emulator_entries=lambda p: [entry],
+                           local_start_dir=local_dir)
     connect_widget(w, calls, listing=[(False, 4096, "beast.nex")])
 
-    # The download is queued against the emulator's own staging directory.
     w._emulator_start_from_next("/beast.nex", entry)
     q = list(calls["q"])
     check("the Next-pane action queues a download",
           any(c[0] == "get" and c[1] == "/beast.nex" for c in q), str(q))
-    check("...into the directory the emulator asked for",
-          staged == [stage_root] and any(len(c) > 2 and c[2] == stage_root
-                                         for c in q), str(q))
+    check("...into the LOCAL pane's folder, so the file lands where it shows",
+          any(len(c) > 2 and os.path.realpath(c[2]) == os.path.realpath(local_dir)
+              for c in q), str(q))
+    check("...and NOT into a scratch directory the user cannot find",
+          staged == [], str(staged))
     check("nothing is launched before the download finishes", launched == [])
 
     # Finish the download with the file actually present, as the worker would.
-    open(os.path.join(stage_root, "beast.nex"), "wb").write(b"\x00" * 8)
+    open(os.path.join(local_dir, "beast.nex"), "wb").write(b"\x00" * 8)
     w.on_op_done(True, "get", "/beast.nex")
     QApplication.processEvents()          # the launch is deferred by one tick
     check("the emulator is started once the file has arrived",
-          launched == [os.path.join(stage_root, "beast.nex")], str(launched))
+          len(launched) == 1 and samepath(launched[0],
+                                          os.path.join(local_dir, "beast.nex")),
+          str(launched))
     check("it is started on the DOWNLOADED copy, not the Next path",
           launched and not launched[0].startswith("/beast"), str(launched))
-    check("the copy survives the launch (the emulator is detached)",
-          os.path.isfile(os.path.join(stage_root, "beast.nex")))
+    check("the downloaded file is kept (it is the user's now)",
+          os.path.isfile(os.path.join(local_dir, "beast.nex")))
 
-    # A failed download must not start anything and must clean up after itself.
+    # A failed download must not start anything — and must NEVER delete the
+    # folder it downloaded into, which is the user's own browsing directory.
     launched.clear()
-    stage2 = tempfile.mkdtemp(dir=TMP)
+    local2 = tempfile.mkdtemp(dir=TMP)
+    keeper = os.path.join(local2, "precious.txt")
+    open(keeper, "wb").write(b"do not delete me")
     entry2 = EmulatorAutostart("MAME", "Start MAME with file x.nex",
-                               launched.append, lambda: stage2)
-    w2, calls2 = make_widget(emulator_entries=lambda p: [entry2])
+                               launched.append, lambda: stage_root)
+    w2, calls2 = make_widget(emulator_entries=lambda p: [entry2],
+                             local_start_dir=local2)
     connect_widget(w2, calls2, listing=[(False, 10, "x.nex")])
     w2._emulator_start_from_next("/x.nex", entry2)
     w2.on_op_done(False, "get", "/x.nex")   # download failed
     QApplication.processEvents()
     check("a failed download starts nothing", launched == [], str(launched))
-    check("...and removes the staging directory", not os.path.isdir(stage2))
+    check("a failed download NEVER deletes the user's local folder",
+          os.path.isdir(local2) and os.path.isfile(keeper), local2)
     check("...and says so in the log",
           any("could not be downloaded" in str(s) or "not started" in str(s)
               for s in calls2["log"]), str(calls2["log"][-3:]))
@@ -1221,43 +1242,48 @@ def test_emulator_start_from_next():
     check("no hook -> no entries (the widget knows no emulators itself)",
           w3._emulator_entries("/anything.nex") == [])
 
-    # REGRESSION (reported): the file downloaded and then nothing happened.
-    # Both emulators need a mounted SD image, and on this tab there usually is
-    # none — so the launch could never work, and CSpect's launcher returned
-    # silently. Ask before transferring, and say why.
+    # A genuine blocker (not a missing SD card — booting a file needs none)
+    # must be reported BEFORE any transfer, so the user never waits for a
+    # download that cannot lead anywhere.
     launched.clear()
     blocked_entry = EmulatorAutostart(
         "CSpect", "Start CSpect with file x.nex", launched.append,
         lambda: tempfile.mkdtemp(dir=TMP),
-        lambda: "Load a ZX Spectrum Next disk image first")
-    w4, calls4 = make_widget(emulator_entries=lambda p: [blocked_entry])
+        lambda: "CSpect could not be found")
+    w4, calls4 = make_widget(emulator_entries=lambda p: [blocked_entry],
+                             local_start_dir=tempfile.mkdtemp(dir=TMP))
     connect_widget(w4, calls4, listing=[(False, 10, "x.nex")])
     w4._emulator_start_from_next("/x.nex", blocked_entry)
     check("a launch that cannot succeed downloads NOTHING",
           not any(c[0] == "get" for c in calls4["q"]), str(calls4["q"]))
     check("...and says why, visibly (toast, not just the log)",
           len(calls4["toasts"]) == 1
-          and "disk image" in calls4["toasts"][0][1], str(calls4["toasts"]))
+          and "CSpect could not be found" in calls4["toasts"][0][1],
+          str(calls4["toasts"]))
     check("...and starts no emulator", launched == [])
 
     # The worker names the arriving file from what the NEXT reports, not from
     # the path we asked for, so a single-file get can land under a sub-path.
-    # The staging dir holds this download alone, so the file must still be
-    # found rather than reported as a failed download.
+    # It must still be found — BY NAME, since the destination is the user's own
+    # folder and "the only file in here" would pick up something unrelated.
     launched.clear()
-    stage3 = tempfile.mkdtemp(dir=TMP)
+    local3 = tempfile.mkdtemp(dir=TMP)
+    open(os.path.join(local3, "unrelated.bin"), "wb").write(b"x")
     entry3 = EmulatorAutostart("CSpect", "Start CSpect with file y.nex",
-                               launched.append, lambda: stage3)
-    w5, calls5 = make_widget(emulator_entries=lambda p: [entry3])
+                               launched.append, lambda: stage_root)
+    w5, calls5 = make_widget(emulator_entries=lambda p: [entry3],
+                             local_start_dir=local3)
     connect_widget(w5, calls5, listing=[(False, 10, "y.nex")])
     w5._emulator_start_from_next("/games/y.nex", entry3)
-    odd = os.path.join(stage3, "games", "y.nex")     # not <tmp>/y.nex
+    odd = os.path.join(local3, "games", "y.nex")     # not <dest>/y.nex
     os.makedirs(os.path.dirname(odd), exist_ok=True)
     open(odd, "wb").write(b"\x00" * 4)
     w5.on_op_done(True, "get", "/games/y.nex")
     QApplication.processEvents()
     check("a file that lands under a sub-path is still found and booted",
-          launched == [odd], str(launched))
+          len(launched) == 1 and samepath(launched[0], odd), str(launched))
+    check("...found by NAME, so an unrelated neighbour is never booted",
+          launched and os.path.basename(launched[0]) == "y.nex", str(launched))
 
 
 def main():

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1195,12 +1195,41 @@ def inspect_phase12():
         check("a shared launch-precondition check is exposed",
               blocker is not None)
         if blocker is not None:
-            check("with no image, CSpect reports itself blocked",
+            # With NOTHING to boot, the image is all there is to run, so it is
+            # genuinely required...
+            check("with no image and no file, CSpect reports itself blocked",
                   bool(blocker("CSpect")), repr(blocker("CSpect")))
-            check("with no image, MAME reports itself blocked",
+            check("with no image and no file, MAME reports itself blocked",
                   bool(blocker("MAME")), repr(blocker("MAME")))
+            # ...but booting a FILE needs no image at all: MAME loads a
+            # snapshot with no -hard1, and CSpect takes a plain folder as its
+            # -mmc root (its own beast.bat/NXtel.bat use `-mmc=./`). Demanding
+            # an image there is what made "Start … with file" unusable on the
+            # NextSync tab, where none is mounted.
+            check("booting a FILE needs no disk image (CSpect)",
+                  blocker("CSpect", autostart=True) == "",
+                  repr(blocker("CSpect", autostart=True)))
+            check("booting a FILE needs no disk image (MAME)",
+                  blocker("MAME", autostart=True) == "",
+                  repr(blocker("MAME", autostart=True)))
             check("an unknown emulator is not reported as blocked",
                   blocker("Nonesuch") == "")
+
+        # And the launchers themselves must now go through with a file even
+        # with no image loaded — no refusal, no red toast.
+        toasts.clear()
+        if launch_cspect is not None:
+            probe = os.path.join(SCRATCH, "probe.nex")
+            with open(probe, "wb") as f:
+                f.write(b"\x00" * 16)
+            # CSpect is very unlikely to be installed in this environment; the
+            # point is only that the IMAGE check no longer refuses. Skip if the
+            # detection found none, since then it refuses for another reason.
+            if getattr(win, "_cspect_executable_path", None):
+                launch_cspect(probe)
+                check("with a file, CSpect no longer demands a disk image",
+                      not any("disk image" in t[1].lower() for t in toasts),
+                      str(toasts))
     finally:
         win._show_toast = real_toast
     app.quit()

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -254,15 +254,22 @@ def build_emulator_ops(
             # Toasts are best-effort UI; never let one break a launch path.
             logging.exception("could not show the launch-failure toast")
 
-    def _emulator_launch_blocker(emulator):
+    def _emulator_launch_blocker(emulator, autostart=False):
         """Why *emulator* cannot start right now, or "" when it can.
 
-        Both emulators boot the Next from the mounted SD image, so both need
-        one; these checks mirror exactly what each launcher enforces itself.
-        Callers that must do expensive work BEFORE launching — the Remote
-        Explorer downloads the file off the Next first — ask this up front, so
-        the user is told immediately instead of after a pointless transfer.
+        Mirrors exactly what each launcher enforces, so callers that must do
+        expensive work BEFORE launching — the Remote Explorer downloads the
+        file off the Next first — can ask up front instead of discovering it
+        after a pointless transfer.
+
+        With *autostart* (a file is being booted) neither emulator needs a
+        mounted image: MAME loads a snapshot with no -hard1, and CSpect takes a
+        plain folder as its -mmc root, which is what its own sample launchers
+        do. Without a file there is nothing to run but the image itself, so
+        then it is genuinely required.
         """
+        if autostart:
+            return ""
         if emulator == "CSpect":
             if _right_disk_content():
                 return ""
@@ -307,7 +314,8 @@ def build_emulator_ops(
         # without an image, but the "Start CSpect with <file>" actions are
         # reachable from the NextSync tab, where there is usually no image
         # mounted, and there it looked like the action was simply broken.
-        if not _right_disk_content():
+        _has_autostart = isinstance(autostart_file, str) and bool(autostart_file.strip())
+        if not _right_disk_content() and not _has_autostart:
             _emulator_launch_failed("CSpect", ui_tr_now(
                 "Load a ZX Spectrum Next disk image first — then CSpect can "
                 "boot it from the mounted SD card."))
@@ -354,6 +362,17 @@ def build_emulator_ops(
         # <cwd>\"C:\temp\img". Re-quote only the final path below (the
         # -mmc= argument goes through the shell, so spaces need quoting).
         img_path = (host.right_disk_image_path or "").strip().strip('"')
+        # -mmc does not have to be a disk image: CSpect's own sample launchers
+        # point it at a FOLDER used as the SD-card root —
+        #     CSpect.exe -sound -w2 -zxnext -mmc=./ beast.nex
+        # (beast.bat / NXtel.bat / parallax.bat / mod_player.bat, shipped with
+        # CSpect). So booting a single file needs no mounted image at all: when
+        # none is loaded, the file's OWN folder becomes the card root. A loaded
+        # image still wins — it is the richer environment, and anything the
+        # program loads from the card then resolves as usual.
+        if not img_path and isinstance(autostart_file, str) and autostart_file.strip():
+            img_path = os.path.dirname(
+                os.path.abspath(autostart_file.strip().strip('"')))
         if use_bundled:
             # CSpect runs from its own folder so its Next ROMs resolve;
             # the working dir then differs from the app dir, so the image
@@ -446,7 +465,13 @@ def build_emulator_ops(
         # hdfmonkey-produced listing, which is empty when hdfmonkey is
         # missing) — otherwise MAME could never be launched without hdfmonkey.
         _sel_image = host.imageinput.currentText().strip().strip('"')
-        if not (_sel_image and os.path.isfile(_sel_image)):
+        # An image is the Next's hard disk, and without one there is nothing to
+        # boot — UNLESS a file was handed in, which MAME loads on its own:
+        # `mame tbblue -snapshot foo.nex` runs with no -hard1 at all (verified
+        # against MAME 0.288). Requiring an image there made "Start MAME with
+        # file …" unusable from the NextSync tab, where none is mounted.
+        _has_autostart = isinstance(autostart_file, str) and bool(autostart_file.strip())
+        if not (_sel_image and os.path.isfile(_sel_image)) and not _has_autostart:
             _emulator_launch_failed("MAME", ui_tr_now(
                 "Select a valid ZX Spectrum Next disk image (.img/.hdf) "
                 "before launching MAME."))
@@ -487,9 +512,13 @@ def build_emulator_ops(
         # install directory (see below), so resolve the image to an absolute
         # path to keep relative paths working. The "-hard1 <image>" pair is
         # appended last so the image is always the final argument.
+        # Only a real image file becomes -hard1. Before the auto-start case this
+        # was guaranteed by the early return above; now the function can get
+        # this far with the combo holding nothing (or a stale path), and
+        # "-hard1 <not a file>" is a fatal error in MAME rather than a no-op.
         mame_image = host.imageinput.currentText().strip().strip('"')
-        if mame_image:
-            mame_image = os.path.abspath(mame_image)
+        mame_image = os.path.abspath(mame_image) if (
+            mame_image and os.path.isfile(mame_image)) else ""
         # Drop any aspect/mouse/joystick options from the (editable) params —
         # these are now controlled by the MAME group combos and appended
         # below, so they must not be duplicated or conflict. The launcher

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -2244,18 +2244,22 @@ class RemoteExplorerWidget(QWidget):
         and the emulator started on that copy — the Next pane's counterpart to
         the SD Card tab extracting from the image with hdfmonkey.
 
-        The copy is deliberately NOT deleted on success: the emulator is
-        launched detached and opens the file after we return. Which directory
-        it goes to is the emulator's business (entry.staging_dir), because
-        Flatpak MAME cannot see this process's /tmp.
+        It lands in the LOCAL pane's current folder — exactly where the
+        Download action puts things — so it appears in the left explorer and
+        the user keeps it, instead of disappearing into a temp directory. The
+        file is deliberately NOT deleted afterwards: it is the user's now, and
+        the emulator is launched detached and opens it after we return.
+
+        NO disk image is involved and none is required. MAME loads a snapshot
+        with no -hard1, and CSpect takes a plain folder as its -mmc root (its
+        own sample launchers use `-mmc=./`), so the downloaded file's folder
+        serves as the card root.
         """
         if not self._connected or self._op_active:
             return
         name = posixpath.basename(remote_path.rstrip("/")) or remote_path
-        # Ask BEFORE transferring anything: both emulators need a mounted SD
-        # image, and on this tab there often is none. Downloading first and
-        # only then discovering the launch cannot happen is what made this
-        # look like "the file downloads and nothing happens".
+        # Only asks about things that genuinely stop a launch — booting a file
+        # needs no mounted image, so this does not fire for a missing SD card.
         blocked = entry.blocked()
         if blocked:
             self._log(blocked)
@@ -2263,30 +2267,43 @@ class RemoteExplorerWidget(QWidget):
                 ui_tr_now("Could not start {emulator}").format(emulator=entry.name),
                 blocked, "red")
             return
-        try:
-            tmp = entry.staging_dir()
-        except OSError as exc:
-            logging.exception("emulator staging dir unusable")
-            self._on_toast(
-                ui_tr_now("Could not start {emulator}").format(emulator=entry.name),
-                ui_tr_now("Could not prepare a folder for {name}: {error}")
-                .format(name=name, error=exc), "red")
-            return
+
+        # The local pane's folder, same as Download. Only if it cannot be
+        # written to (read-only media, permissions) does this fall back to the
+        # emulator's own staging directory.
+        dest = self._local_dir()
+        scratch = False
+        if not (dest and os.path.isdir(dest) and os.access(dest, os.W_OK)):
+            try:
+                dest = entry.staging_dir()
+                scratch = True
+            except OSError as exc:
+                logging.exception("emulator staging dir unusable")
+                self._on_toast(
+                    ui_tr_now("Could not start {emulator}").format(emulator=entry.name),
+                    ui_tr_now("Could not prepare a folder for {name}: {error}")
+                    .format(name=name, error=exc), "red")
+                return
 
         def _started(ok, _fails):
-            local = os.path.join(tmp, name)
+            local = os.path.join(dest, name)
             if ok and not os.path.isfile(local):
-                # The worker names the file from what the NEXT reports, not
-                # from the path we asked for (see _re_relname_under), so a
-                # single-file get can land under a sub-path. The staging dir
-                # holds this download and nothing else, so if exactly one file
-                # arrived it is the one to boot, whatever it ended up called.
-                arrived = [os.path.join(root, f)
-                           for root, _dirs, files in os.walk(tmp) for f in files]
-                if len(arrived) == 1:
-                    local = arrived[0]
+                # The worker names the arriving file from what the NEXT
+                # reports, not from the path we asked for (_re_relname_under),
+                # so a single-file get can land under a sub-path. Look for it
+                # by name — never by "the only file here", which was safe in a
+                # private staging dir but not in the user's own folder.
+                found = [os.path.join(root, f)
+                         for root, _dirs, files in os.walk(dest)
+                         for f in files if f == name]
+                if found:
+                    local = max(found, key=os.path.getmtime)
             if not ok or not os.path.isfile(local):
-                shutil.rmtree(tmp, ignore_errors=True)
+                # Only ever remove a directory WE made. dest is normally the
+                # user's own browsing folder, and deleting that would be
+                # catastrophic.
+                if scratch:
+                    shutil.rmtree(dest, ignore_errors=True)
                 self._log(ui_tr_now(
                     "Start {emulator}: {name} could not be downloaded from "
                     "the Next, {emulator} was not started.").format(
@@ -2299,6 +2316,7 @@ class RemoteExplorerWidget(QWidget):
                               "started.").format(emulator=entry.name, name=name),
                     "red")
                 return
+            self._local_refresh()      # show what just arrived
             # Deferred so _end_operation fully unwinds before the launch.
             QTimer.singleShot(0, lambda: entry.launch(local))
 
@@ -2306,7 +2324,7 @@ class RemoteExplorerWidget(QWidget):
             "Downloading {name} from the Next, then starting {emulator}…")
             .format(name=name, emulator=entry.name))
         self._run_op(ui_tr_now("Downloading {name}…").format(name=name),
-                     lambda: self._enqueue(("get", remote_path, tmp)),
+                     lambda: self._enqueue(("get", remote_path, dest)),
                      on_done=_started)
 
     def _remote_unzip(self, zip_path):

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -117,8 +117,10 @@ def emulator_autostart_entries(host, path, is_dir=False):
         return lambda: tempfile.mkdtemp(prefix=prefix)
 
     def _blocked(emulator):
+        # autostart=True: every entry here boots a FILE, and neither emulator
+        # needs a mounted disk image to do that.
         fn = getattr(host, "_emulator_launch_blocker", None)
-        return (lambda: fn(emulator)) if fn else (lambda: "")
+        return (lambda: fn(emulator, autostart=True)) if fn else (lambda: "")
 
     if (cspect_can_autostart(path)
             and getattr(host, "_cspect_executable_path", None)


### PR DESCRIPTION
Both faults were mine, from #239/#243.

## 1. It downloaded into a temp directory

The file never appeared in the left explorer and you didn't keep it. It now lands in the **local pane's current folder** — exactly where **Download (:&lt;-)** puts things — and the pane is refreshed so it shows up. A scratch directory is used only if that folder can't be written to.

Two safety consequences of that change, both handled:

- **The failure path may no longer delete the destination.** `shutil.rmtree` is now behind a `scratch` flag, so it can only remove a directory this code created. Harmless while the destination was always a temp dir; against your own browsing folder it would have been catastrophic.
- **The "which file arrived" fallback now matches by NAME**, not "the only file present". That shortcut was fine in a private staging dir and plainly wrong in a folder full of your files.

## 2. It demanded a mounted SD image — neither emulator needs one

This is what produced the red toast on a perfectly valid launch:

- **MAME** loads a snapshot with **no `-hard1` at all** — verified against MAME 0.288.
- **CSpect**'s `-mmc` takes a plain **folder** as the card root, not necessarily a disk image. Its own shipped launchers do exactly that:

  ```
  CSpect.exe -sound -w2 -zxnext -mmc=./ beast.nex
  ```
  (`beast.bat`, `NXtel.bat`, `parallax.bat`, `mod_player.bat`)

  With no image loaded, the downloaded file's own folder becomes the card root. A mounted image still wins when there is one — it's the richer environment.

So the image check now applies only when there is **nothing to boot but the image itself**. That is also why the earlier "load an image first" message appeared at all: I had fixed the silent failure by making the precondition visible, when the precondition itself was wrong for this case.

MAME additionally only passes `-hard1` for a path that is genuinely a file, since reaching the launch with no image is now possible and `-hard1 <not a file>` is fatal in MAME rather than a no-op.

## Tests

Reworked to the new behaviour, and they fail against the old one:

- download goes to the local pane's folder, **not** a scratch dir
- a failed download **never deletes the user's local folder** (asserted with a sentinel file, plus a source check that `rmtree` is reachable only under `if scratch:`)
- a file landing under a sub-path is found **by name**, with an unrelated neighbour present to prove it isn't just "the only file"
- `blocker(emulator, autostart=True) == ""` for both emulators — booting a file needs no image — while with nothing to boot both still report blocked

Full suite green (20/20, 12 offscreen phases).