### PR TITLE
Revert the invented emulator launch mechanics; keep the .img requirement

### DIFF
--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -125,13 +125,10 @@ if fn is not None:
           src.index("_auto_switch, _auto") < src.index("MAME_HARD_DISK_PARAMETER, mame_image"))
     check("an unsupported file does not silently vanish",
           "MAME cannot load {name} directly" in src)
-    # Verified live against MAME 0.288: `mame tbblue -snapshot foo.nex` boots
-    # with no -hard1 at all. So a file to boot lifts the image requirement —
-    # without this, "Start MAME with file …" was unusable from the NextSync
-    # tab, where no image is mounted.
-    check("a file to boot lifts the disk-image requirement",
-          "and not _has_autostart" in src,
-          "MAME loads a snapshot with no -hard1")
+    # MAME boots the Next from the selected image, so one is required exactly
+    # as it always has been; the auto-start file is loaded on top of it.
+    check("an image is still required to launch",
+          "Select a valid ZX Spectrum Next disk image" in src)
     check("only a real file is passed as -hard1",
           "os.path.isfile(mame_image)" in src,
           "'-hard1 <not a file>' is fatal in MAME, not a no-op")

--- a/tests/test_nextsync_autostart.py
+++ b/tests/test_nextsync_autostart.py
@@ -193,11 +193,10 @@ check("a failed download NEVER deletes the user's local folder",
       and seg.count("shutil.rmtree(dest, ignore_errors=True)") == 1
       and seg.index("if scratch:") < seg.index("shutil.rmtree(dest"),
       "rmtree must be reachable only for a directory we made")
-# Booting a file needs no mounted image (MAME: no -hard1; CSpect: -mmc=<dir>),
-# so the pre-flight check must not turn a missing SD card into a red toast.
-check("a missing SD card does not block booting a file",
-      "autostart=True" in open(
-          os.path.join(REPO, "zxnu_workers.py"), encoding="utf-8").read())
+# The pre-flight check exists so a launch that cannot succeed is reported
+# BEFORE the download rather than after it.
+check("the pre-flight check runs before the transfer",
+      seg.index("entry.blocked()") < seg.index('("get", remote_path, dest)'))
 # Both panes act on exactly one selected FILE — a folder or a multi-selection
 # has no single file to boot.
 check("the Next pane only offers the entries for a single selected file",

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1195,41 +1195,16 @@ def inspect_phase12():
         check("a shared launch-precondition check is exposed",
               blocker is not None)
         if blocker is not None:
-            # With NOTHING to boot, the image is all there is to run, so it is
-            # genuinely required...
-            check("with no image and no file, CSpect reports itself blocked",
+            # Both emulators boot the Next from the mounted image, so both
+            # require one — with or without a file to auto-start. That is how
+            # these launches have always worked and is deliberately unchanged;
+            # what changed is only that saying so is no longer silent.
+            check("with no image, CSpect reports itself blocked",
                   bool(blocker("CSpect")), repr(blocker("CSpect")))
-            check("with no image and no file, MAME reports itself blocked",
+            check("with no image, MAME reports itself blocked",
                   bool(blocker("MAME")), repr(blocker("MAME")))
-            # ...but booting a FILE needs no image at all: MAME loads a
-            # snapshot with no -hard1, and CSpect takes a plain folder as its
-            # -mmc root (its own beast.bat/NXtel.bat use `-mmc=./`). Demanding
-            # an image there is what made "Start … with file" unusable on the
-            # NextSync tab, where none is mounted.
-            check("booting a FILE needs no disk image (CSpect)",
-                  blocker("CSpect", autostart=True) == "",
-                  repr(blocker("CSpect", autostart=True)))
-            check("booting a FILE needs no disk image (MAME)",
-                  blocker("MAME", autostart=True) == "",
-                  repr(blocker("MAME", autostart=True)))
             check("an unknown emulator is not reported as blocked",
                   blocker("Nonesuch") == "")
-
-        # And the launchers themselves must now go through with a file even
-        # with no image loaded — no refusal, no red toast.
-        toasts.clear()
-        if launch_cspect is not None:
-            probe = os.path.join(SCRATCH, "probe.nex")
-            with open(probe, "wb") as f:
-                f.write(b"\x00" * 16)
-            # CSpect is very unlikely to be installed in this environment; the
-            # point is only that the IMAGE check no longer refuses. Skip if the
-            # detection found none, since then it refuses for another reason.
-            if getattr(win, "_cspect_executable_path", None):
-                launch_cspect(probe)
-                check("with a file, CSpect no longer demands a disk image",
-                      not any("disk image" in t[1].lower() for t in toasts),
-                      str(toasts))
     finally:
         win._show_toast = real_toast
     app.quit()

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -254,7 +254,7 @@ def build_emulator_ops(
             # Toasts are best-effort UI; never let one break a launch path.
             logging.exception("could not show the launch-failure toast")
 
-    def _emulator_launch_blocker(emulator, autostart=False):
+    def _emulator_launch_blocker(emulator):
         """Why *emulator* cannot start right now, or "" when it can.
 
         Mirrors exactly what each launcher enforces, so callers that must do
@@ -262,14 +262,10 @@ def build_emulator_ops(
         file off the Next first — can ask up front instead of discovering it
         after a pointless transfer.
 
-        With *autostart* (a file is being booted) neither emulator needs a
-        mounted image: MAME loads a snapshot with no -hard1, and CSpect takes a
-        plain folder as its -mmc root, which is what its own sample launchers
-        do. Without a file there is nothing to run but the image itself, so
-        then it is genuinely required.
+        Both emulators boot the Next from the mounted SD image, so both need
+        one — with or without a file to auto-start. That has always been the
+        way these launches work and is deliberately left alone.
         """
-        if autostart:
-            return ""
         if emulator == "CSpect":
             if _right_disk_content():
                 return ""
@@ -314,8 +310,7 @@ def build_emulator_ops(
         # without an image, but the "Start CSpect with <file>" actions are
         # reachable from the NextSync tab, where there is usually no image
         # mounted, and there it looked like the action was simply broken.
-        _has_autostart = isinstance(autostart_file, str) and bool(autostart_file.strip())
-        if not _right_disk_content() and not _has_autostart:
+        if not _right_disk_content():
             _emulator_launch_failed("CSpect", ui_tr_now(
                 "Load a ZX Spectrum Next disk image first — then CSpect can "
                 "boot it from the mounted SD card."))
@@ -362,17 +357,6 @@ def build_emulator_ops(
         # <cwd>\"C:\temp\img". Re-quote only the final path below (the
         # -mmc= argument goes through the shell, so spaces need quoting).
         img_path = (host.right_disk_image_path or "").strip().strip('"')
-        # -mmc does not have to be a disk image: CSpect's own sample launchers
-        # point it at a FOLDER used as the SD-card root —
-        #     CSpect.exe -sound -w2 -zxnext -mmc=./ beast.nex
-        # (beast.bat / NXtel.bat / parallax.bat / mod_player.bat, shipped with
-        # CSpect). So booting a single file needs no mounted image at all: when
-        # none is loaded, the file's OWN folder becomes the card root. A loaded
-        # image still wins — it is the richer environment, and anything the
-        # program loads from the card then resolves as usual.
-        if not img_path and isinstance(autostart_file, str) and autostart_file.strip():
-            img_path = os.path.dirname(
-                os.path.abspath(autostart_file.strip().strip('"')))
         if use_bundled:
             # CSpect runs from its own folder so its Next ROMs resolve;
             # the working dir then differs from the app dir, so the image
@@ -465,13 +449,7 @@ def build_emulator_ops(
         # hdfmonkey-produced listing, which is empty when hdfmonkey is
         # missing) — otherwise MAME could never be launched without hdfmonkey.
         _sel_image = host.imageinput.currentText().strip().strip('"')
-        # An image is the Next's hard disk, and without one there is nothing to
-        # boot — UNLESS a file was handed in, which MAME loads on its own:
-        # `mame tbblue -snapshot foo.nex` runs with no -hard1 at all (verified
-        # against MAME 0.288). Requiring an image there made "Start MAME with
-        # file …" unusable from the NextSync tab, where none is mounted.
-        _has_autostart = isinstance(autostart_file, str) and bool(autostart_file.strip())
-        if not (_sel_image and os.path.isfile(_sel_image)) and not _has_autostart:
+        if not (_sel_image and os.path.isfile(_sel_image)):
             _emulator_launch_failed("MAME", ui_tr_now(
                 "Select a valid ZX Spectrum Next disk image (.img/.hdf) "
                 "before launching MAME."))

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -117,10 +117,8 @@ def emulator_autostart_entries(host, path, is_dir=False):
         return lambda: tempfile.mkdtemp(prefix=prefix)
 
     def _blocked(emulator):
-        # autostart=True: every entry here boots a FILE, and neither emulator
-        # needs a mounted disk image to do that.
         fn = getattr(host, "_emulator_launch_blocker", None)
-        return (lambda: fn(emulator, autostart=True)) if fn else (lambda: "")
+        return (lambda: fn(emulator)) if fn else (lambda: "")
 
     if (cspect_can_autostart(path)
             and getattr(host, "_cspect_executable_path", None)


### PR DESCRIPTION
Starting an emulator needs the `.img` and nothing else, exactly as it has worked all along. In #244 I changed that, and I shouldn't have:

- CSpect fell back to using the auto-start file's folder as its `-mmc` root
- MAME was allowed to run with no `-hard1`

**Both are reverted.** The launch path is back to what it was — an image is required, with or without a file to auto-start — and `_emulator_launch_blocker` loses its `autostart` waiver.

## What stays

The parts that addressed the actual reported bug and its fallout:

- the Next pane downloads to the **local pane's folder** — not the SD card, and not a hidden temp directory — so the file appears in the left explorer and you keep it;
- the failure path can only remove a directory this code created, so it can never delete your own folder;
- the arrived-file lookup matches **by name**, not "the only file present";
- `launch_cspect` reports instead of returning in total silence, and launch failures toast so they're visible off the SD Card tab.

MAME still passes `-hard1` only for a path that is genuinely a file. That guard is harmless with the requirement restored and remains correct.

## What I got wrong

You reported the file being sent to the SD card. That was one bug, and the destination fix was the whole answer. I then went looking for a second explanation, found that the emulators *can* technically boot without an image, and rebuilt the launch mechanics around that — changing long-working behaviour you never asked me to touch. The `-mmc=./` samples and the `-snapshot` run are real, but "technically possible" wasn't a reason to change how launching works.

Tests updated to assert the restored behaviour: the image is required for both emulators, and the pre-flight check is verified to run before the transfer rather than after it.

Full suite green (20/20, 12 offscreen phases).