### PR TITLE
Remote Explorer: running a downloaded file is not gated on a disk image

### DIFF
--- a/tests/test_cspect_autostart.py
+++ b/tests/test_cspect_autostart.py
@@ -85,6 +85,16 @@ if fn is not None:
     # /tmp/... on POSIX).
     check("the auto-start argument is made an absolute host path",
           "os.path.abspath(autostart_file" in src)
+    # Running a downloaded FILE is not gated on a mounted image (the Remote
+    # Explorer fetches a program off the Next and runs it locally); launching
+    # the IMAGE itself still is. -mmc is then left out rather than passed with
+    # an empty value.
+    check("running a file is not gated on a mounted image",
+          "not _right_disk_content() and not _has_autostart" in src)
+    check("launching the image itself still requires one",
+          "Load a ZX Spectrum Next disk image first" in src)
+    check("-mmc is omitted entirely when there is no image",
+          "if mmc_path:" in src)
     check("no leading-slash stripping (host path, not an image path)",
           'autostart_file.strip().lstrip("/")' not in src)
 

--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -125,10 +125,13 @@ if fn is not None:
           src.index("_auto_switch, _auto") < src.index("MAME_HARD_DISK_PARAMETER, mame_image"))
     check("an unsupported file does not silently vanish",
           "MAME cannot load {name} directly" in src)
-    # MAME boots the Next from the selected image, so one is required exactly
-    # as it always has been; the auto-start file is loaded on top of it.
-    check("an image is still required to launch",
+    # Launching the IMAGE still requires one (the Launch Mame button's job);
+    # running a downloaded FILE does not, so the Remote Explorer can boot a
+    # program fetched off the Next with no image mounted.
+    check("launching the image itself still requires an image",
           "Select a valid ZX Spectrum Next disk image" in src)
+    check("running a file is not gated on an image",
+          "and not _has_autostart" in src)
     check("only a real file is passed as -hard1",
           "os.path.isfile(mame_image)" in src,
           "'-hard1 <not a file>' is fatal in MAME, not a no-op")

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1195,14 +1195,23 @@ def inspect_phase12():
         check("a shared launch-precondition check is exposed",
               blocker is not None)
         if blocker is not None:
-            # Both emulators boot the Next from the mounted image, so both
-            # require one — with or without a file to auto-start. That is how
-            # these launches have always worked and is deliberately unchanged;
-            # what changed is only that saying so is no longer silent.
-            check("with no image, CSpect reports itself blocked",
+            # Launching the IMAGE needs an image — that is the Launch CSpect /
+            # Launch Mame buttons' job, unchanged.
+            check("with no image, launching the image itself is blocked (CSpect)",
                   bool(blocker("CSpect")), repr(blocker("CSpect")))
-            check("with no image, MAME reports itself blocked",
+            check("with no image, launching the image itself is blocked (MAME)",
                   bool(blocker("MAME")), repr(blocker("MAME")))
+            # Launching a downloaded FILE does not: the Remote Explorer fetches
+            # a program off the Next to the local disk and runs it, with no SD
+            # image involved. Gating that on an image is what produced the
+            # "Could not start CSpect — load a disk image first" toast on a
+            # perfectly valid launch.
+            check("running a downloaded FILE is never gated on an image (CSpect)",
+                  blocker("CSpect", autostart=True) == "",
+                  repr(blocker("CSpect", autostart=True)))
+            check("running a downloaded FILE is never gated on an image (MAME)",
+                  blocker("MAME", autostart=True) == "",
+                  repr(blocker("MAME", autostart=True)))
             check("an unknown emulator is not reported as blocked",
                   blocker("Nonesuch") == "")
     finally:

--- a/zxnu_emulator_ops.py
+++ b/zxnu_emulator_ops.py
@@ -254,7 +254,7 @@ def build_emulator_ops(
             # Toasts are best-effort UI; never let one break a launch path.
             logging.exception("could not show the launch-failure toast")
 
-    def _emulator_launch_blocker(emulator):
+    def _emulator_launch_blocker(emulator, autostart=False):
         """Why *emulator* cannot start right now, or "" when it can.
 
         Mirrors exactly what each launcher enforces, so callers that must do
@@ -262,10 +262,11 @@ def build_emulator_ops(
         file off the Next first — can ask up front instead of discovering it
         after a pointless transfer.
 
-        Both emulators boot the Next from the mounted SD image, so both need
-        one — with or without a file to auto-start. That has always been the
-        way these launches work and is deliberately left alone.
+        Launching the IMAGE needs an image; launching a downloaded FILE
+        (*autostart*) does not, and must not be gated on one.
         """
+        if autostart:
+            return ""
         if emulator == "CSpect":
             if _right_disk_content():
                 return ""
@@ -303,14 +304,17 @@ def build_emulator_ops(
         accept an argument. That bool is filtered out by the isinstance() check
         below rather than by a keyword-only signature, which Qt handles less
         predictably across PySide versions."""
-        # CSpect boots the Next from the mounted SD image, so it needs one.
-        # This used to be a bare `if` around the whole body with no else: with
-        # no image the call did nothing at all — no launch, no log, no toast.
-        # Harmless while the only caller was a button that was greyed out
-        # without an image, but the "Start CSpect with <file>" actions are
-        # reachable from the NextSync tab, where there is usually no image
-        # mounted, and there it looked like the action was simply broken.
-        if not _right_disk_content():
+        # Launching the IMAGE needs an image — that is the Launch CSpect
+        # button's job and is unchanged. Launching a FILE does not: the Remote
+        # Explorer downloads a program off the Next to the local disk and just
+        # runs it, with no SD image in the picture, so the image check must not
+        # stand in its way.
+        #
+        # (This was also a bare `if` around the whole body with no else, so
+        # with no image the call did nothing at all — no launch, no log, no
+        # toast. Hence the report of "the file downloads and nothing happens".)
+        _has_autostart = isinstance(autostart_file, str) and bool(autostart_file.strip())
+        if not _right_disk_content() and not _has_autostart:
             _emulator_launch_failed("CSpect", ui_tr_now(
                 "Load a ZX Spectrum Next disk image first — then CSpect can "
                 "boot it from the mounted SD card."))
@@ -366,9 +370,13 @@ def build_emulator_ops(
                 img_path = os.path.abspath(img_path)
         else:
             cspect_cwd = None
-        mmc_path = f'"{img_path}"' if img_path else img_path
-
-        cspect_arguments += " -mmc=" + mmc_path + " "
+        # With an image, -mmc mounts it as the SD card exactly as always. With
+        # none (running a downloaded file on its own), the switch is left out
+        # altogether rather than passed empty — "-mmc=" with no value is an
+        # argument CSpect has to make sense of, and there is nothing to mount.
+        mmc_path = f'"{img_path}"' if img_path else ""
+        if mmc_path:
+            cspect_arguments += " -mmc=" + mmc_path + " "
 
         # Auto-start file: a HOST path, appended as CSpect's trailing
         # argument. It is made absolute because CSpect may run from its
@@ -449,7 +457,11 @@ def build_emulator_ops(
         # hdfmonkey-produced listing, which is empty when hdfmonkey is
         # missing) — otherwise MAME could never be launched without hdfmonkey.
         _sel_image = host.imageinput.currentText().strip().strip('"')
-        if not (_sel_image and os.path.isfile(_sel_image)):
+        # As for CSpect: launching the IMAGE needs one, launching a downloaded
+        # FILE does not — the Remote Explorer runs it on its own, with no image
+        # in the picture. The -hard1 pair below is simply omitted then.
+        _has_autostart = isinstance(autostart_file, str) and bool(autostart_file.strip())
+        if not (_sel_image and os.path.isfile(_sel_image)) and not _has_autostart:
             _emulator_launch_failed("MAME", ui_tr_now(
                 "Select a valid ZX Spectrum Next disk image (.img/.hdf) "
                 "before launching MAME."))

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -117,8 +117,10 @@ def emulator_autostart_entries(host, path, is_dir=False):
         return lambda: tempfile.mkdtemp(prefix=prefix)
 
     def _blocked(emulator):
+        # autostart=True: every entry here runs a FILE, which is never gated
+        # on a mounted SD image.
         fn = getattr(host, "_emulator_launch_blocker", None)
-        return (lambda: fn(emulator)) if fn else (lambda: "")
+        return (lambda: fn(emulator, autostart=True)) if fn else (lambda: "")
 
     if (cspect_can_autostart(path)
             and getattr(host, "_cspect_executable_path", None)


### PR DESCRIPTION
Starting a program fetched off the Next has nothing to do with the SD card: NextSync brings the file to the local machine and the emulator runs it there. The image check refused that with **"Could not start CSpect — load a ZX Spectrum Next disk image first"**, which is simply the wrong question for this action.

Both launchers now apply the image requirement **only when there is no file to run** — i.e. when launching the *image itself*, which is what the Launch CSpect / Launch Mame buttons do, and which is unchanged.

## The launch command is otherwise untouched

With an image, `-mmc` and `-hard1` are built exactly as they always have been. With none, the switch is simply **left out** rather than passed empty — `-mmc=` with no value is still an argument CSpect has to interpret, and there is nothing to mount.

No card root is invented from the file's folder, and no other mechanics change. That was the wrong turn in #244, reverted in #245, and it is not reintroduced here.

## Tests

- `blocker(emulator, autostart=True) == ""` for both emulators — running a file is never gated on an image
- `blocker(emulator)` still reports blocked for both — launching the image itself still needs one
- `-mmc` is omitted entirely when there is no image
- the CSpect gate is asserted as `not _right_disk_content() and not _has_autostart`, so a plain re-tightening would fail

Full suite green (20/20, 12 offscreen phases).