### PR TITLE
Offer the "Start with file" actions for .nex only

### DIFF
--- a/tests/test_cspect_autostart.py
+++ b/tests/test_cspect_autostart.py
@@ -135,7 +135,8 @@ for label, marker in (
     check(f"the {label} action is gated on CSpect being installed",
           "_cspect_executable_path" in window, "no detection gate found")
     check(f"the {label} action is gated on a bootable extension",
-          "cspect_can_autostart" in window)
+          "emulator_offers_autostart" in window,
+          "narrowed to .nex: CSpect crashes on a .tap trailing argument")
 
 # It must be the FIRST entry of the image menu (asked for: top of the list).
 img_at = ops.find('ui_tr_now("Start CSpect with file {name}")')

--- a/tests/test_mame_autostart.py
+++ b/tests/test_mame_autostart.py
@@ -212,7 +212,8 @@ for label, marker in (
           "_mame_usable()" in window,
           "must use _mame_usable() so Flatpak MAME counts too")
     check(f"the {label} action is gated on a loadable extension",
-          "mame_can_autostart" in window)
+          "emulator_offers_autostart" in window,
+          "narrowed to .nex, same gate as CSpect")
 
 # ---- the local pane offers BOTH a plain start and a send-then-start -------
 # Emulator-neutral: these entries are generated from the shared helper, so the

--- a/tests/test_nextsync_autostart.py
+++ b/tests/test_nextsync_autostart.py
@@ -77,13 +77,48 @@ check("a directory is never offered", names(both, "/games", True) == [])
 check("a readme is never offered", names(both, "/docs/readme.txt") == [])
 check("empty / None are safe",
       names(both, "") == [] and names(both, None) == [])
-# The two emulators genuinely take different media, and the helper must respect
-# that rather than assuming what one can boot the other can too.
-check("a .dsk is offered for CSpect only (MAME's Next drivers take no disks)",
-      names(both, "/games/disk.dsk") == ["CSpect"])
-check("a .scr is offered for MAME only (CSpect does not boot screens)",
-      names(both, "/loading.scr") == ["MAME"])
-check("a .tap is offered for both", names(both, "/tape.tap") == ["CSpect", "MAME"])
+# .nex ONLY, however much more the emulators nominally accept. CSpect crashes
+# outright on a .tap trailing argument (seen as exit 0xC0000094 integer divide
+# by zero and 0xE0434352 unhandled .NET exception, while every .nex launched
+# normally), and MAME's -cassette merely inserts a tape without starting it.
+check("a .tap is NOT offered — it crashes CSpect",
+      names(both, "/tape.tap") == [])
+check("nor a .tzx", names(both, "/tape.tzx") == [])
+check("nor a .dsk / .trd / .scl", not any(
+    names(both, "/x" + e) for e in (".dsk", ".trd", ".scl")))
+check("nor a .sna or .z80 snapshot", not any(
+    names(both, "/x" + e) for e in (".sna", ".z80")))
+check("nor a .scr (MAME would only show a screen)",
+      names(both, "/loading.scr") == [])
+check("only .nex reaches the menu, in both emulators",
+      names(both, "/games/beast.nex") == ["CSpect", "MAME"])
+
+# Tripwire on the offer set itself. What each emulator ACCEPTS is a separate
+# (and still accurate) question — MAME's media mapping needs it to pick
+# -snapshot — so the two must not be conflated back together.
+from zxnu_config import (  # noqa: E402
+    CSPECT_AUTOSTART_EXTENSIONS,
+    EMULATOR_AUTOSTART_OFFER_EXTENSIONS,
+    MAME_SNAPSHOT_EXTENSIONS,
+    emulator_offers_autostart,
+    mame_autostart_argument,
+)
+
+check("the offer set is exactly .nex",
+      tuple(EMULATOR_AUTOSTART_OFFER_EXTENSIONS) == (".nex",),
+      str(EMULATOR_AUTOSTART_OFFER_EXTENSIONS))
+check("it is NARROWER than what the emulators accept",
+      set(EMULATOR_AUTOSTART_OFFER_EXTENSIONS) < set(CSPECT_AUTOSTART_EXTENSIONS)
+      and set(EMULATOR_AUTOSTART_OFFER_EXTENSIONS) < set(MAME_SNAPSHOT_EXTENSIONS),
+      "offering != accepting; keep both facts")
+check("MAME's media mapping still knows the wider truth",
+      mame_autostart_argument("/x.tap") == "-cassette"
+      and mame_autostart_argument("/x.nex") == "-snapshot")
+check("matching is case-insensitive and safe on empty/None",
+      emulator_offers_autostart("/A.NEX")
+      and not emulator_offers_autostart("")
+      and not emulator_offers_autostart(None)
+      and not emulator_offers_autostart("/games/nex-collection"))
 
 # ---- the entries are usable as menu items --------------------------------
 entries = emulator_autostart_entries(both, "/games/beast.nex")

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -1162,6 +1162,27 @@ def mame_can_autostart(path):
     return bool(mame_autostart_argument(path))
 
 
+# What the "Start <emulator> with <file>" actions actually OFFER — narrower
+# than what either emulator can technically be handed.
+#
+# CSpect CRASHES on a .tap passed as its trailing argument: observed exit
+# 0xC0000094 (integer divide by zero) on gplotter.tap and 0xE0434352 (unhandled
+# .NET exception) on sanxion128v3.tap, while every .nex launched normally. And
+# MAME's -cassette only INSERTS a tape — the user still has to LOAD "" — so it
+# is not a "start this file" experience either.
+#
+# The per-emulator tables above still describe what each emulator ACCEPTS
+# (that knowledge is correct and used to pick MAME's media switch); this is the
+# separate question of what is worth putting in a menu.
+EMULATOR_AUTOSTART_OFFER_EXTENSIONS = (".nex",)
+
+
+def emulator_offers_autostart(path):
+    """True when a "Start <emulator> with <file>" action should be offered."""
+    return bool(path) and str(path).lower().endswith(
+        EMULATOR_AUTOSTART_OFFER_EXTENSIONS)
+
+
 def mame_autostart_staging_dir():
     """Where to put a file extracted from the SD image before handing it to
     FLATPAK MAME.

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -1614,7 +1614,7 @@ def build_local_explorer_ops(
         # uploads into the folder the image explorer is showing and, once that
         # succeeds, starts CSpect on the local copy (a host path — see
         # _cspect_start_from_image for why it cannot be the in-image one).
-        if (not is_dir and cspect_can_autostart(file_path)
+        if (not is_dir and emulator_offers_autostart(file_path)
                 and _right_disk_content()
                 and getattr(host, "_cspect_executable_path", None)
                 and getattr(host, "_launch_cspect_fn", None)
@@ -1648,7 +1648,7 @@ def build_local_explorer_ops(
         # The MAME twin of the action above. Same shape, same reason for
         # starting on the LOCAL file rather than the copy just written into
         # the image: MAME cannot read a path inside the mounted image.
-        if (not is_dir and mame_can_autostart(file_path)
+        if (not is_dir and emulator_offers_autostart(file_path)
                 and _right_disk_content()
                 and host._mame_usable()
                 and getattr(host, "_launch_mame_fn", None)
@@ -3030,7 +3030,7 @@ def build_transfer_clipboard_ops(
             item_path = (name_item.data(IMG_PATH_ROLE) or "") \
                 if name_item is not None else ""
             _emu_entry_added = False
-            if (not is_dir and cspect_can_autostart(item_path)
+            if (not is_dir and emulator_offers_autostart(item_path)
                     and getattr(host, "_cspect_executable_path", None)
                     and getattr(host, "_launch_cspect_fn", None)):
                 menu.addAction(
@@ -3039,7 +3039,7 @@ def build_transfer_clipboard_ops(
                     lambda p=item_path: QTimer.singleShot(
                         0, lambda: _cspect_start_from_image(p)))
                 _emu_entry_added = True
-            if (not is_dir and mame_can_autostart(item_path)
+            if (not is_dir and emulator_offers_autostart(item_path)
                     and host._mame_usable()
                     and getattr(host, "_launch_mame_fn", None)):
                 menu.addAction(

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -19,8 +19,9 @@ import time
 from collections import deque, namedtuple
 from zxnu_config import (IGNOREFILE, MAX_PAYLOAD, PORT, SYNCPOINT,
                          UP_DIRECTORY, VERSION3, VERSION4,
-                         cspect_can_autostart, is_filetype_a_directory,
-                         mame_autostart_staging_dir, mame_can_autostart)
+                         cspect_can_autostart, emulator_offers_autostart,
+                         is_filetype_a_directory, mame_autostart_staging_dir,
+                         mame_can_autostart)
 from PySide6.QtCore import (
     QEvent, QObject, QPoint, QRect, QRunnable, QSize, QSortFilterProxyModel,
     QTimer, Qt, Signal, Slot,
@@ -109,7 +110,10 @@ def emulator_autostart_entries(host, path, is_dir=False):
     the SD image, or from the Next) do.
     """
     entries = []
-    if is_dir or not path:
+    # .nex only. Both emulators accept more than that in principle, but CSpect
+    # crashes outright on a .tap trailing argument and MAME merely inserts a
+    # tape without starting it — see EMULATOR_AUTOSTART_OFFER_EXTENSIONS.
+    if is_dir or not emulator_offers_autostart(path):
         return entries
     name = os.path.basename(str(path).rstrip("/\\")) or str(path)
 


### PR DESCRIPTION
CSpect crashes when a `.tap` is passed as its trailing argument. Straight from the app log, with the identical command line that works for every `.nex`:

| File | Exit code | Meaning |
|---|---|---|
| `gplotter.tap` | 3221225620 | `0xC0000094` — integer divide by zero |
| `sanxion128v3.tap` | 3762504530 | `0xE0434352` — unhandled .NET exception |

**The app itself survived** — the `CalledProcessError` was caught and logged, and the session carried on — but an emulator dying on launch is not something to offer a menu entry for.

MAME is no better here: its `-cassette` only *inserts* a tape, leaving you to `LOAD ""` yourself, so it was never a "start this file" action either.

## Change

All five explorers' **"Start &lt;emulator&gt; with file"** entries, plus the two **"Send to SD Card and start …"** entries, now gate on one new predicate — `emulator_offers_autostart`: `.nex`, case-insensitive.

The image-explorer pair is included deliberately: it feeds the same launchers, so a `.tap` there would have crashed CSpect the same way.

## What is *not* changed

What each emulator **accepts** stays a separate — and still accurate — question. `mame_autostart_argument` continues to map `.tap` → `-cassette` and `.nex` → `-snapshot`, which is what picks MAME's media switch when it does run something.

A tripwire asserts the offer set is exactly `.nex` **and** is strictly narrower than both capability tables, so "offering" and "accepting" cannot quietly be merged back into one list.

## Tests

`.tap`, `.tzx`, `.dsk`, `.trd`, `.scl`, `.sna`, `.z80`, `.scr` all assert **no** entries; `.nex`/`.NEX` assert both emulators. The two SD-card menu-gate assertions now name the narrower predicate.

Full suite green (20/20, 12 offscreen phases).