### PR TITLE
Bump version to 9.5.0

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -73,7 +73,7 @@ zip) stays untouched and a Flatpak failure can never block a release.
    sources:
      - type: git
        url: https://github.com/jclauzel/ZX-Next-Unite.git
-       tag: v9.4.9
+       tag: v9.5.0
        commit: <full commit sha of the tag>
    ```
 

--- a/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
@@ -50,6 +50,7 @@
     <color type="primary" scheme_preference="dark">#1c1c60</color>
   </branding>
   <releases>
+    <release version="9.5.0" date="2026-07-31"/>
     <release version="9.4.9" date="2026-07-31"/>
     <release version="9.4.8" date="2026-07-31"/>
     <release version="9.4.7" date="2026-07-31"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.4.9"
+version = "9.5.0"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.4.9"
+ZX_NEXT_UNITE_VERSION = "9.5.0"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
`ZX_NEXT_UNITE_VERSION`, `pyproject.toml` and the AppStream release list are kept in step — `release.yml` gates the tag on the first two matching.

## What 9.5.0 contains

**Start a file in an emulator** — new right-click actions across all five explorers that can hold a bootable file:

| Explorer | Action |
|---|---|
| SD Card — local | `Start …` (no transfer) and `Send to SD Card and start …` |
| SD Card — image | `Start …` (extracts with hdfmonkey first) |
| NextSync — classic local | `Start …` |
| Remote Explorer — local | `Start …` |
| Remote Explorer — Next | `Start …` (downloads to the local pane's folder first) |

Offered for `.nex` only: CSpect crashes on a `.tap` trailing argument, and MAME's `-cassette` only inserts a tape without starting it.

**MAME** — release picker (last 10 for the platform), and a fix for the Windows self-extracting installer hanging on an invisible error dialog.

**Localisation** — the console and dialog sweep is finished across the six languages; 347 runtime literals with no catalog gaps.

**Fixes** — the greyed-out local explorer with no image loaded, silent emulator-launch failures (now toasted so they are visible off the SD Card tab), and translated compact buttons no longer truncating.

Full suite green (20/20, 12 offscreen phases).