### PR TITLE
Fix the menu label on POSIX: split paths on both separators

### DIFF
--- a/tests/test_nextsync_autostart.py
+++ b/tests/test_nextsync_autostart.py
@@ -131,9 +131,15 @@ check("the label names its emulator",
       str([e.label for e in entries]))
 check("launching passes the host path straight through",
       entries[0].launch("/tmp/x.nex") == ("cspect", "/tmp/x.nex"))
-check("a Windows path is labelled by base name, not the whole path",
-      "C:\\" not in emulator_autostart_entries(
-          both, "C:\\games\\beast.nex")[0].label)
+# Both separators, on EVERY platform: os.path.basename ignores "\" on POSIX,
+# so this failed on CI (Linux) while passing on every Windows dev machine.
+# The paths reaching the helper come from the Next as well as the local disk.
+for _sep_path in ("C:\\games\\beast.nex", "C:/GAMES/beast.nex",
+                  "/games/beast.nex", "beast.nex"):
+    _label = emulator_autostart_entries(both, _sep_path)[0].label
+    check(f"labelled by base name, not the whole path: {_sep_path!r}",
+          _label.endswith("beast.nex") and "games" not in _label.lower(),
+          _label)
 
 # ---- staging directories --------------------------------------------------
 # Only callers that must FETCH the file first use these (the SD image and the

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -115,7 +115,14 @@ def emulator_autostart_entries(host, path, is_dir=False):
     # tape without starting it — see EMULATOR_AUTOSTART_OFFER_EXTENSIONS.
     if is_dir or not emulator_offers_autostart(path):
         return entries
-    name = os.path.basename(str(path).rstrip("/\\")) or str(path)
+    # Split on BOTH separators regardless of platform. os.path.basename does
+    # not treat "\" as one on POSIX, so a Windows-style path was labelled in
+    # full there ("Start CSpect with file C:\games\beast.nex") — and the paths
+    # reaching here come from the Next as well as from the local disk, so the
+    # separator is not always the host's. Caught by CI on Linux; every dev
+    # machine here is Windows, where it looked fine.
+    _p = str(path).replace("\\", "/").rstrip("/")
+    name = _p.rsplit("/", 1)[-1] or str(path)
 
     def _tmp(prefix):
         return lambda: tempfile.mkdtemp(prefix=prefix)


### PR DESCRIPTION
The `v9.5.0` release build failed its test suite on CI (Linux), so no release was produced:

```
FAIL  a Windows path is labelled by base name, not the whole path
```

`os.path.basename` does not treat `\` as a separator on POSIX, so a Windows-style path was labelled **in full** there — "Start CSpect with file `C:\games\beast.nex`" instead of "…`beast.nex`". The name is now taken with a plain string split on both separators, which behaves identically on every platform.

## Not just a test artefact

The paths reaching this helper come from **the Next** as well as from the local disk, so the separator is not always the host's. It looked correct on every machine here because they're all Windows — only CI exercises the POSIX branch. Good catch by the release gate.

## Verified against the actual failure

Forcing `posixpath` into the module reproduces CI's behaviour locally. Against the old code the label came out as the full path; against the new code:

```
PASS 'C:\games\beast.nex'     -> 'Start CSpect with file beast.nex'
PASS 'C:/GAMES/beast.nex'       -> 'Start CSpect with file beast.nex'
PASS '/games/beast.nex'         -> 'Start CSpect with file beast.nex'
PASS 'beast.nex'                -> 'Start CSpect with file beast.nex'
```

The test now covers all four forms rather than the single backslash case.

Full suite green (20/20, 12 offscreen phases).