### PR TITLE
Bridge: never strand a blocked HTTP caller when the Next stalls

### DIFF
--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -44,6 +44,7 @@ SUITES = [
     ("test_classic_sync.py",    180, None),
     ("test_listen.py",          120, None),
     ("test_remote_listen.py",   120, None),
+    ("test_bridge_stall.py",    180, None),
     ("test_remote_explorer_widget.py", 180, None),
     ("test_http_bridge.py",     240, "flask"),
     ("test_retro_log_widget.py", 120, None),

--- a/tests/test_bridge_stall.py
+++ b/tests/test_bridge_stall.py
@@ -1,0 +1,230 @@
+"""Regression test: a stalled Next must never strand a blocked HTTP caller.
+
+The bug this locks down (found from a real three-box tree copy: remote N-Go
+dot -> PC listen server -> HTTP bridge -> ZXNextRemote). Copying a folder
+transferred two files, then wedged on the third:
+
+  * the session loop parks the socket at a 1 s timeout so idle polling stays
+    responsive, and `get` read its reply under that same 1 s;
+  * the Next legitimately goes quiet for longer than a second sometimes (SD
+    seeks, its directory re-open/skip walk, its own retry backoff);
+  * `socket.timeout` IS an `OSError`, so the exception escaped
+    `_re_recv_reply`, escaped the `get` dispatch BEFORE `reply.put(...)`,
+    and landed in the session-level handler — killing the whole -listen
+    session and orphaning the sink the HTTP thread was blocked on;
+  * that thread then waited out the entire bridge timeout receiving neither
+    bytes nor a status, so the client saw pure silence and eventually gave
+    up on its own. The dot meanwhile printed "get done" (it ignores the
+    final block's ack result) and kept polling, looking perfectly healthy.
+
+Three properties are asserted here:
+
+  1. BridgeReply.put is idempotent — the first answer wins, so a
+     blanket "resolve everything we still owe" on teardown can never
+     clobber a real result the HTTP thread has not collected yet.
+  2. A stalled command resolves its caller (with an error) instead of
+     hanging, AND the session survives to serve the next command.
+  3. A session that dies mid-command still answers whoever is blocked.
+
+Run with: python test_bridge_stall.py
+"""
+import os
+import queue
+import socket
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from PySide6.QtCore import QCoreApplication                      # noqa: E402
+import zxnu_workers                                              # noqa: E402
+from zxnu_workers import (RemoteExplorerSignals,                 # noqa: E402
+                          run_remote_listen_server)
+from zxnu_http_bridge import BridgeReply                         # noqa: E402
+
+PORT = 2057
+ok = True
+
+
+def check(name, cond, detail=""):
+    global ok
+    print(("PASS " if cond else "FAIL ") + name + ("  " + str(detail) if detail else ""))
+    if not cond:
+        ok = False
+
+
+def frame(payload, pkt):
+    c0 = c1 = 0
+    for b in payload:
+        c0 ^= b
+        c1 = (c1 + c0) & 0xFF
+    return ((len(payload) + 5).to_bytes(2, "big") + bytes(payload) +
+            bytes([c0, c1, pkt & 0xFF]))
+
+
+def rx_payload(sock, timeout=10.0):
+    """Read one framed block, returning its payload."""
+    sock.settimeout(timeout)
+    hdr = b""
+    while len(hdr) < 2:
+        chunk = sock.recv(2 - len(hdr))
+        if not chunk:
+            raise AssertionError("peer closed while reading a block header")
+        hdr += chunk
+    total = (hdr[0] << 8) | hdr[1]
+    rest = b""
+    while len(rest) < total - 2:
+        chunk = sock.recv(total - 2 - len(rest))
+        if not chunk:
+            raise AssertionError("peer closed mid-block")
+        rest += chunk
+    return rest[:-3]
+
+
+# ---------------------------------------------------------------- 1. sink
+def test_reply_idempotent():
+    r = BridgeReply()
+    check("reply: starts unresolved", r.resolved is False)
+    check("reply: first put accepted", r.put({'ok': True, 'n': 1}) is True)
+    check("reply: now resolved", r.resolved is True)
+    check("reply: second put refused", r.put({'ok': False, 'error': 'late'}) is False)
+    got = r.wait(1.0)
+    check("reply: the FIRST answer is what the caller reads",
+          got == {'ok': True, 'n': 1}, got)
+    # The teardown path blanket-resolves everything it might owe; doing that
+    # to an already-answered sink must not corrupt the queue.
+    check("reply: nothing queued behind it", r.wait(0.05) is None)
+
+
+# ------------------------------------------------------- 2 & 3. the session
+def start_session(cmd_q, stop):
+    app = QCoreApplication.instance() or QCoreApplication(sys.argv)  # noqa: F841
+    sig = RemoteExplorerSignals()
+    state = {"connected": False, "errors": []}
+    sig.connected.connect(lambda: state.update(connected=True))
+    sig.disconnected.connect(lambda: state.update(connected=False))
+    sig.error.connect(lambda m: state["errors"].append(m))
+    th = threading.Thread(
+        target=run_remote_listen_server,
+        args=(sig, cmd_q, stop), kwargs={"port": PORT}, daemon=True)
+    th.start()
+    return th, state
+
+
+def connect_dot():
+    """Play the dot far enough to be a connected peer."""
+    end = time.time() + 5.0
+    while time.time() < end:
+        try:
+            s = socket.create_connection(("127.0.0.1", PORT), timeout=5)
+            break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        raise AssertionError("listen server never came up")
+    s.sendall(b"Listen")
+    assert rx_payload(s) == b"Listening"
+    return s
+
+
+def test_stall_resolves_and_session_survives():
+    # A real minute is not worth waiting for in a test; the helper reads the
+    # module attribute at call time exactly so this is possible.
+    zxnu_workers.RE_REPLY_TIMEOUT = 1.5
+
+    cmd_q, stop = queue.Queue(), threading.Event()
+    th, state = start_session(cmd_q, stop)
+    dot = connect_dot()
+    try:
+        # --- a get whose reply never arrives ---------------------------
+        r1 = BridgeReply()
+        cmd_q.put(("get", "/getit/install.bas", os.path.dirname(__file__), r1))
+        dot.sendall(b"Poll")
+        cmd = rx_payload(dot)
+        check("stall: the server issued the get", cmd[0:1] == b'G', cmd[:20])
+        # ...and now the "Next" says nothing at all, like a dot that burned
+        # its retries on the final block and went back to polling.
+
+        t0 = time.time()
+        res = r1.wait(20.0)
+        waited = time.time() - t0
+        check("stall: the blocked caller IS answered (not left hanging)",
+              res is not None, res)
+        check("stall: answered as a failure", bool(res) and res.get('ok') is False, res)
+        check("stall: answered promptly, not after the bridge timeout",
+              waited < 15.0, f"{waited:.1f}s")
+
+        # --- and the session is still alive ----------------------------
+        # THE property that regressed: before the per-command timeout, the
+        # escaping socket.timeout tore the whole session down, so this poll
+        # met a closed socket. Catch that rather than crashing, so a
+        # regression reads as a FAIL line instead of a traceback.
+        r2 = BridgeReply()
+        cmd_q.put(("mkdir", "/afterwards", r2))
+        try:
+            dot.sendall(b"Poll")
+            cmd2 = rx_payload(dot)
+            alive = cmd2[0:1] == b'M'
+            detail = cmd2[:20]
+        except (OSError, AssertionError) as ex:
+            alive, detail = False, f"session died: {ex!r}"
+        check("stall: session SURVIVED - next command still dispatched",
+              alive, detail)
+        if alive:
+            dot.sendall(frame(b'O', 0))
+            rx_payload(dot)                      # the server's ack
+            res2 = r2.wait(10.0)
+            check("stall: the follow-up command answers normally",
+                  bool(res2) and res2.get('ok') is True, res2)
+    finally:
+        stop.set()
+        try:
+            dot.close()
+        except OSError:
+            pass
+        th.join(timeout=10)
+        zxnu_workers.RE_REPLY_TIMEOUT = 60.0
+
+
+def test_dropped_link_resolves_caller():
+    """The dot vanishing mid-command must answer the blocked caller too."""
+    zxnu_workers.RE_REPLY_TIMEOUT = 5.0
+    cmd_q, stop = queue.Queue(), threading.Event()
+    th, state = start_session(cmd_q, stop)
+    dot = connect_dot()
+    try:
+        r = BridgeReply()
+        cmd_q.put(("get", "/whatever.bin", os.path.dirname(__file__), r))
+        dot.sendall(b"Poll")
+        check("drop: the server issued the get", rx_payload(dot)[0:1] == b'G')
+        dot.close()                       # the Next disappears mid-transfer
+        res = r.wait(20.0)
+        check("drop: the blocked caller IS answered", res is not None, res)
+        check("drop: answered as a failure",
+              bool(res) and res.get('ok') is False, res)
+    finally:
+        stop.set()
+        th.join(timeout=10)
+        zxnu_workers.RE_REPLY_TIMEOUT = 60.0
+
+
+def test_long_timeout_under_client_patience():
+    """The bridge must give up BEFORE its strictest client does, or the user
+    sees silence instead of a 504 naming the stalled operation."""
+    from zxnu_http_bridge import LONG_TIMEOUT
+    # ZXNextRemote's HTTP_FIRSTBYTE_TICKS is 5 minutes (300 s).
+    check("timeout: bridge answers before a 300 s client gives up",
+          LONG_TIMEOUT < 300.0, LONG_TIMEOUT)
+    check("timeout: still long enough for a real relayed transfer",
+          LONG_TIMEOUT >= 120.0, LONG_TIMEOUT)
+
+
+if __name__ == "__main__":
+    test_reply_idempotent()
+    test_long_timeout_under_client_patience()
+    test_stall_resolves_and_session_survives()
+    test_dropped_link_resolves_caller()
+    print("\nRESULT: " + ("ALL PASS" if ok else "FAILURES"))
+    sys.exit(0 if ok else 1)

--- a/zxnu_http_bridge.py
+++ b/zxnu_http_bridge.py
@@ -75,7 +75,14 @@ def flask_available():
     except (ImportError, ValueError):
         return False
 DEFAULT_TIMEOUT = 45.0     # quick verbs: one poll round-trip + margin
-LONG_TIMEOUT = 900.0       # get/put/rcpy/rfsize/rmtree can move real data
+# get/put/rcpy/rfsize/rmtree can move real data. Deliberately just UNDER
+# the patience of the strictest known client (ZXNextRemote gives a relayed
+# transfer 300 s to produce its first byte): whoever gives up first decides
+# what the user sees, and a 504 naming the stalled op beats silence. It
+# costs nothing real — a relay that needs longer than the client will wait
+# has already failed from the client's seat. Raise BOTH together if the
+# bridge ever streams instead of collect-then-respond.
+LONG_TIMEOUT = 270.0
 _LONG_OPS = ("get", "put", "rcpy", "rfsize", "rmtree")
 
 
@@ -92,15 +99,35 @@ def fmt_size(nbytes):
 
 class BridgeReply:
     """The result sink a bridge command carries through a host's command
-    queue. The executor calls :meth:`put` exactly once with the result dict;
-    the HTTP thread blocks in :meth:`wait`. Hosts detect a bridge command by
-    ``isinstance(cmd[-1], BridgeReply)``."""
+    queue. The executor calls :meth:`put` with the result dict; the HTTP
+    thread blocks in :meth:`wait`. Hosts detect a bridge command by
+    ``isinstance(cmd[-1], BridgeReply)``.
+
+    :meth:`put` is IDEMPOTENT — the first result wins and later ones are
+    dropped. That is what lets an executor blanket-resolve every reply it
+    might still owe when a session dies (see ``_fail_inflight`` in
+    zxnu_workers.py) without any risk of overwriting a real answer that
+    the HTTP thread has not collected yet. Before that guarantee existed,
+    an exception raised mid-command left the reply unresolved forever and
+    the HTTP caller blocked for the whole bridge timeout, receiving no
+    bytes and no status — the "transfer wedges on the Nth file" bug."""
 
     def __init__(self):
         self._q = queue.Queue()
+        self._lock = threading.Lock()
+        self._done = False
 
     def put(self, result):
+        with self._lock:
+            if self._done:
+                return False
+            self._done = True
         self._q.put(dict(result))
+        return True
+
+    @property
+    def resolved(self):
+        return self._done
 
     def wait(self, timeout):
         try:

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -459,10 +459,50 @@ def _re_recv_block(conn):
     return (payload, rest[-1])
 
 
+#: Seconds a single command's reply may go quiet before we give up on it.
+#: Generous on purpose — this is the gap BETWEEN blocks, and the Next can
+#: legitimately pause for seconds (SD seeks, the directory re-open/skip
+#: walk, its own retry backoff), not the time a whole transfer takes.
+RE_REPLY_TIMEOUT = 60.0
+
+
+def _re_reply_call(conn, handler, timeout=None):
+    """:func:`_re_recv_reply` under a per-command socket timeout.
+
+    The session loop parks the socket at a 1 s timeout so an idle poll
+    cycle stays responsive (see ``conn.settimeout(1.0)`` in the loop head).
+    That is far too short to read a command's REPLY, and a ``socket.timeout``
+    raised inside ``_re_recv_reply`` used to escape the entire session loop
+    — ``socket.timeout`` is an ``OSError`` subclass, so it landed in the
+    session-level handler, killed the ``-listen`` session AND skipped the
+    ``reply.put(...)`` that the HTTP caller was blocked on. The caller then
+    waited out the whole bridge timeout for bytes that were never coming:
+    the "tree copy wedges on the Nth file, the dot says done, the app sees
+    nothing" bug. rcpy/rfsize had carried this fix inline for a while; now
+    every command shares it, so a stall fails ONE command and the session
+    lives on.
+
+    ``timeout`` defaults to :data:`RE_REPLY_TIMEOUT` read at CALL time, so
+    the test suite can shorten it without waiting out a real minute."""
+    try:
+        conn.settimeout(RE_REPLY_TIMEOUT if timeout is None else timeout)
+        return _re_recv_reply(conn, handler)
+    except socket.timeout:
+        return False
+    finally:
+        try:
+            conn.settimeout(1.0)     # back to the responsive idle cadence
+        except OSError:
+            pass
+
+
 def _re_recv_reply(conn, handler):
     """Read the framed blocks the Next pushes in reply to a command, acking each
     with "Ok". handler(payload) returns True to stop. Returns True on clean
-    completion, False on drop."""
+    completion, False on drop.
+
+    Call it through :func:`_re_reply_call`, never directly: on its own it
+    inherits whatever socket timeout the session loop last set (1 s)."""
     expected = 0
     while True:
         blk = _re_recv_block(conn)
@@ -610,6 +650,25 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
     def log(msg):
         sig.log.emit(msg)
 
+    # Bridge sinks this session still owes an answer to. An HTTP caller is
+    # BLOCKED on each of these, so every exit path — clean quit, dropped
+    # connection, or an exception nobody predicted — has to resolve them,
+    # or the caller waits out its whole timeout receiving neither bytes nor
+    # a status. BridgeReply.put is idempotent, so resolving one that has
+    # already answered is a no-op; the list is pruned as it goes, and in
+    # practice holds at most the running command plus a pending put.
+    owed = []
+
+    def _owe(r):
+        if r is not None:
+            owed[:] = [x for x in owed if not x.resolved]
+            owed.append(r)
+
+    def _fail_owed(err):
+        for r in owed:
+            r.put({'ok': False, 'error': err})
+        owed[:] = []
+
     srv = None
     try:
         try:
@@ -728,6 +787,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                     # the last element: fill that instead of emitting signals
                     # (bridge traffic must be silent to the Remote Explorer UI).
                     reply = cmd[-1] if isinstance(cmd[-1], BridgeReply) else None
+                    _owe(reply)          # an HTTP thread is blocked on this
                     if op == "rmtree":
                         # Recursive folder delete: open a walk job and start with
                         # the root's listing (handled below, on this same poll).
@@ -779,7 +839,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                                     _e.append((bool(flags & 1), size, name))
                             return False
                         _re_sendpacket(conn, b"L" + path.encode(), 0)
-                        if _re_recv_reply(conn, _h):
+                        if _re_reply_call(conn, _h):
                             if st['failed']:
                                 if reply:
                                     reply.put({'ok': False,
@@ -840,7 +900,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                                 return True
                             return False
                         _re_sendpacket(conn, b"G" + remote.encode(), 0)
-                        ok = _re_recv_reply(conn, _h)
+                        ok = _re_reply_call(conn, _h)
                         if st['f']:
                             st['f'].close()
                         if reply:
@@ -878,7 +938,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             _r['ok'] = (payload[0:1] == b'O')
                             return True
                         _re_sendpacket(conn, opc + path.encode(), 0)
-                        if _re_recv_reply(conn, _h):
+                        if _re_reply_call(conn, _h):
                             if reply:
                                 reply.put({'ok': bool(res['ok'])})
                             else:
@@ -913,7 +973,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                                     _e.append((bool(flags & 1), name))
                             return False
                         _re_sendpacket(conn, b"L" + path.encode(), 0)
-                        if _re_recv_reply(conn, _h):
+                        if _re_reply_call(conn, _h):
                             subs = []
                             if not st['failed']:
                                 base = path.rstrip("/")
@@ -948,7 +1008,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             _r['ok'] = (payload[0:1] == b'O')
                             return True
                         _re_sendpacket(conn, opc + path.encode(), 0)
-                        if _re_recv_reply(conn, _h):
+                        if _re_reply_call(conn, _h):
                             job = rmtree_jobs.get(jid)
                             if job is not None:
                                 if not res['ok']:
@@ -986,7 +1046,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                         # kill the session like other commands' drops would:
                         # drives is an optional nicety, so degrade instead.
                         try:
-                            got_reply = _re_recv_reply(conn, _h)
+                            got_reply = _re_reply_call(conn, _h)
                         except socket.timeout:
                             got_reply = False
                         if got_reply and res['cur']:
@@ -1024,7 +1084,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             return True
                         _re_sendpacket(conn, b"Z" + drv.encode(), 0)
                         try:
-                            got_reply = _re_recv_reply(conn, _h)
+                            got_reply = _re_reply_call(conn, _h)
                         except socket.timeout:
                             got_reply = False
                         if got_reply and res['blocks'] is not None:
@@ -1068,16 +1128,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             return True
                         _re_sendpacket(conn, b"C" + src.encode() + b"\x00" +
                                        dst.encode(), 0)
-                        try:
-                            conn.settimeout(60.0)
-                            got_reply = _re_recv_reply(conn, _h)
-                        except socket.timeout:
-                            got_reply = False
-                        finally:
-                            try:
-                                conn.settimeout(1.0)
-                            except OSError:
-                                pass
+                        got_reply = _re_reply_call(conn, _h)
                         if got_reply and res['ok'] is not None:
                             if reply:
                                 reply.put({'ok': bool(res['ok']),
@@ -1119,16 +1170,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                                 }
                             return True         # 'O' or 'F' both end the reply
                         _re_sendpacket(conn, b"S" + path.encode(), 0)
-                        try:
-                            conn.settimeout(60.0)
-                            got_reply = _re_recv_reply(conn, _h)
-                        except socket.timeout:
-                            got_reply = False
-                        finally:
-                            try:
-                                conn.settimeout(1.0)
-                            except OSError:
-                                pass
+                        got_reply = _re_reply_call(conn, _h)
                         if reply:
                             if res['data'] is not None:
                                 reply.put({'ok': True, **res['data']})
@@ -1151,7 +1193,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             return True
                         # 'V' + old + NUL + new, in one length-framed block.
                         _re_sendpacket(conn, b"V" + old.encode() + b"\x00" + new.encode(), 0)
-                        if _re_recv_reply(conn, _h):
+                        if _re_reply_call(conn, _h):
                             if reply:
                                 reply.put({'ok': bool(res['ok'])})
                             else:
@@ -1183,7 +1225,19 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                     _re_sendpacket(conn, b"I", 0)   # keep the Next polling
     except OSError as ex:
         sig.error.emit(f"Remote explorer server error: {ex}")
+        _fail_owed(f"the -listen session ended: {ex}")
+    except Exception as ex:                                   # noqa: BLE001
+        # Never let an unforeseen error strand a blocked HTTP caller in
+        # silence: report it, answer whoever is waiting, then re-raise so
+        # the failure still reaches the log/crash handler.
+        logging.exception("Remote explorer server: unhandled error")
+        sig.error.emit(f"Remote explorer server error: {ex}")
+        _fail_owed(f"the -listen session failed: {ex}")
+        raise
     finally:
+        # Clean exits owe answers too — a "quit" mid-transfer, the Next
+        # dropping the link, or the user stopping the server.
+        _fail_owed("the -listen session ended before the command finished")
         if srv is not None:
             try:
                 srv.close()


### PR DESCRIPTION
## The bug

From a real three-box tree copy (remote N-Go dot → PC listen server → HTTP bridge → ZXNextRemote): copying a folder transferred two files, then wedged on the third. The client saw **no bytes and no status at all** for its full 5-minute patience; the dot printed `get done` and carried on polling, looking perfectly healthy. Raising the Flask connection limit changed nothing.

## Root cause

The session loop parks the socket at a **1 s timeout** so idle polling stays responsive ([`conn.settimeout(1.0)`](zxnu_workers.py#L680) at the loop head) — and every command read its *reply* under that same 1 s. The Next legitimately goes quiet for longer than a second (SD seeks, its directory re-open/skip walk, its own retry backoff).

`socket.timeout` **is an `OSError` subclass**, so the exception:

1. escaped `_re_recv_reply`,
2. escaped the `get` dispatch **before `reply.put(...)`**,
3. landed in the session-level handler — killing the whole `-listen` session **and** orphaning the sink the HTTP thread was blocked on.

That thread then waited out the entire bridge timeout (900 s) for bytes that were never coming, while the client gave up at 300 s. `rcpy`/`rfsize` already carried an inline fix for exactly this; every other verb — `get` included — was missed.

The dot's `get done` is not a lie about the data, just about the ack: `send_block_rt`'s result is discarded for the final `B` block, so it prints "done" after burning all 12 retries into an abandoned socket.

## The fix

- **`_re_reply_call()`** — `_re_recv_reply` under a per-command socket timeout (`RE_REPLY_TIMEOUT`, 60 s *between blocks*), catching `socket.timeout` locally so a stall fails **one command** and the session lives on. All ten call sites use it; `rcpy`/`rfsize`'s duplicated inline versions fold into it.
- **`BridgeReply.put` is idempotent** (first answer wins) and exposes `.resolved`, so an executor can blanket-resolve everything it might still owe without ever clobbering a real result in flight.
- **`run_remote_listen_server` tracks the sinks it owes** and resolves them on *every* exit path — `OSError`, any unforeseen exception (logged and re-raised), and the clean `finally`. A caller now always gets an answer, even when the session dies mid-command.
- **`LONG_TIMEOUT` 900 → 270 s** so the bridge gives up just *before* its strictest client (ZXNextRemote allows 300 s to first byte) — a real stall surfaces as a `504` naming the operation instead of silence. This costs nothing: a relay slower than the client's patience had already failed from the client's seat.

## Tests

New `tests/test_bridge_stall.py` (registered in `run_all.py`) asserts the sink is idempotent, a stalled command answers its caller promptly *and the session survives*, a dropped link answers too, and the timeout ordering holds.

Verified it is a genuine regression test with a negative control — monkeypatching the dispatch back to the raw reply read:

```
PASS stall: the blocked caller IS answered   (fix 1 alone rescues this)
FAIL stall: session SURVIVED - next command still dispatched
     session died: ConnectionAbortedError(10053, ...)
```

The two fixes are complementary: the guaranteed reply rescues the caller, the per-command timeout keeps the session alive. Full suite green (`test_http_bridge`, `test_remote_listen`, `test_listen`), `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)