### PR TITLE
CI: run the test suite on every push and pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+# CI: run the test suite on every push and pull request.
+#
+# Until this existed the suite ONLY ran inside release.yml, i.e. on a `v*`
+# tag — so a regression was discovered after the tag had been cut, when
+# fixing it means retagging. This workflow is the same job, moved earlier:
+# keep the two in step, and treat release.yml's `test` job as the
+# authoritative copy if they ever drift (it is what actually gates a
+# release).
+#
+# Deliberately NOT duplicated from release.yml by a reusable workflow: the
+# release job carries a tag-versus-version check that has no meaning here,
+# and the indirection costs more than the twenty lines it would save.
+name: test
+
+on:
+  push:
+    branches: ["**"]
+    paths-ignore:
+      - "**/*.md"
+      - "flatpak/**"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "flatpak/**"
+  workflow_dispatch:
+
+# A new push to the same branch supersedes an in-flight run: the suite
+# takes minutes and only the newest commit's result is interesting.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # ubuntu-22.04 to match release.yml (see the glibc note in its build job).
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false        # a 3.10-only break must not hide a 3.13 one
+      matrix:
+        # The documented source-install floor and the version the release
+        # binaries bundle — keeps the "Python 3.10+" claim honest.
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Qt runtime libraries and Xvfb (headless test display)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libegl1 libgl1 libxkbcommon0 fontconfig xvfb \
+            libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+            libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 \
+            libxkbcommon-x11-0 libxcb-cursor0
+      - name: Install dependencies
+        run: python -m pip install -r REQUIREMENTS.txt
+      - name: Lint (ruff)
+        # pyproject.toml keeps this deliberately permissive so the legacy
+        # monolith is not churned; it must nevertheless stay green.
+        run: |
+          python -m pip install ruff
+          ruff check .
+      - name: Run the test suite
+        # Under Xvfb, NOT QT_QPA_PLATFORM=offscreen: the suite manages Qt
+        # platforms itself (test_ui_offscreen.py opts into offscreen), and
+        # test_retro_log_widget.py NEEDS the real platform — pygame crashes
+        # natively under a forced offscreen (segfaulted the 3.10 leg on CI).
+        run: xvfb-run -a python tests/run_all.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,13 @@
 # and the indirection costs more than the twenty lines it would save.
 name: test
 
+# push is limited to main on purpose: with `branches: ["**"]` every PR
+# branch runs the suite TWICE, once for the push and once for the pull
+# request. This pairing gates every PR and re-gates main after each merge,
+# for half the runs.
 on:
   push:
-    branches: ["**"]
+    branches: [main]
     paths-ignore:
       - "**/*.md"
       - "flatpak/**"


### PR DESCRIPTION
## Why

The test suite only ever ran inside `release.yml` — on a `v*` tag. So a regression is found *after* the tag is cut, when fixing it means retagging. Every PR merged today reported *"no checks reported on the branch"*; my local runs were the only verification, which is a thin safety net for a repo this size.

`flatpak.yml` only triggers on `flatpak/**`, and `publish.yml` on a published release — so there was genuinely no push/PR gate.

## What

The same job as `release.yml`'s `test`, moved earlier:

- `ubuntu-22.04`, matching the release build (glibc note lives there)
- the **3.10 + 3.13** matrix that keeps the documented "Python 3.10+" floor honest
- Qt runtime libs + **Xvfb** — deliberately *not* `QT_QPA_PLATFORM=offscreen`: the suite manages Qt platforms itself, and `test_retro_log_widget.py` needs the real one (pygame segfaults natively under a forced offscreen — it took out the 3.10 leg on CI once already)
- `tests/run_all.py`
- plus a **ruff gate** — `pyproject.toml` keeps it deliberately permissive so the legacy monolith is not churned, but it must stay green

Operational details: docs and `flatpak/**` are path-ignored, `concurrency` cancels an in-flight run when a branch is pushed again (the suite takes minutes and only the newest commit matters), and `fail-fast: false` so a 3.10-only break cannot mask a 3.13 one.

Deliberately **not** factored into a reusable workflow shared with `release.yml`: that job carries a tag-versus-version check with no meaning here, and the indirection would cost more than the twenty lines it saves. The header notes that `release.yml`'s copy is authoritative if they ever drift, since it is what actually gates a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)