### PR TITLE
Remote explorer: notice a Next that was switched off

### DIFF
--- a/tests/test_bridge_stall.py
+++ b/tests/test_bridge_stall.py
@@ -38,7 +38,7 @@ import time
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from PySide6.QtCore import QCoreApplication                      # noqa: E402
+from PySide6.QtCore import QCoreApplication, Qt                  # noqa: E402
 import zxnu_workers                                              # noqa: E402
 from zxnu_workers import (RemoteExplorerSignals,                 # noqa: E402
                           run_remote_listen_server)
@@ -103,14 +103,29 @@ def start_session(cmd_q, stop):
     app = QCoreApplication.instance() or QCoreApplication(sys.argv)  # noqa: F841
     sig = RemoteExplorerSignals()
     state = {"connected": False, "errors": []}
-    sig.connected.connect(lambda: state.update(connected=True))
-    sig.disconnected.connect(lambda: state.update(connected=False))
-    sig.error.connect(lambda m: state["errors"].append(m))
+    # DirectConnection: no Qt event loop runs in this thread, so a queued
+    # connection would never deliver and every state assertion would pass
+    # vacuously (which is exactly what happened the first time).
+    sig.connected.connect(lambda: state.update(connected=True),
+                          Qt.DirectConnection)
+    sig.disconnected.connect(lambda: state.update(connected=False),
+                             Qt.DirectConnection)
+    sig.error.connect(lambda m: state["errors"].append(m), Qt.DirectConnection)
+    sig.log.connect(lambda m: state["errors"].append(m), Qt.DirectConnection)
     th = threading.Thread(
         target=run_remote_listen_server,
         args=(sig, cmd_q, stop), kwargs={"port": PORT}, daemon=True)
     th.start()
     return th, state
+
+
+def wait_until(fn, timeout=5.0):
+    end = time.time() + timeout
+    while time.time() < end:
+        if fn():
+            return True
+        time.sleep(0.05)
+    return False
 
 
 def connect_dot():
@@ -210,6 +225,46 @@ def test_dropped_link_resolves_caller():
         zxnu_workers.RE_REPLY_TIMEOUT = 60.0
 
 
+def test_silent_peer_is_reaped():
+    """A Next that is switched off never sends a FIN — the socket just goes
+    quiet. Before this, the session sat "connected" forever and the UI kept
+    claiming a Next was attached (reported after a machine had been off for
+    hours). The peer drives the session and polls continuously when idle,
+    so silence is the signal; no probe is needed."""
+    zxnu_workers.PEER_SILENCE_LIMIT = 2.0
+    zxnu_workers.RE_REPLY_TIMEOUT = 5.0
+    cmd_q, stop = queue.Queue(), threading.Event()
+    th, state = start_session(cmd_q, stop)
+    dot = connect_dot()
+    try:
+        # Behave normally first, so this is a live session going quiet
+        # rather than one that never started.
+        dot.sendall(b"Poll")
+        check("silent: a poll is answered while alive",
+              len(rx_payload(dot)) >= 1)
+        check("silent: session reports connected", state["connected"] is True)
+
+        # ...and now the Next "loses power": no FIN, no RST, just silence.
+        t0 = time.time()
+        ended = wait_until(lambda: state["connected"] is False, timeout=20.0)
+        waited = time.time() - t0
+        check("silent: the dead peer IS noticed", ended, state)
+        check("silent: noticed at about the limit, not forever",
+              waited < 12.0, f"{waited:.1f}s")
+        check("silent: it says why, in the log",
+              any("no word from the Next" in e for e in state["errors"]),
+              state["errors"][-1:])
+    finally:
+        stop.set()
+        try:
+            dot.close()
+        except OSError:
+            pass
+        th.join(timeout=10)
+        zxnu_workers.PEER_SILENCE_LIMIT = 45.0
+        zxnu_workers.RE_REPLY_TIMEOUT = 60.0
+
+
 def test_long_timeout_under_client_patience():
     """The bridge must give up BEFORE its strictest client does, or the user
     sees silence instead of a 504 naming the stalled operation."""
@@ -226,5 +281,6 @@ if __name__ == "__main__":
     test_long_timeout_under_client_patience()
     test_stall_resolves_and_session_survives()
     test_dropped_link_resolves_caller()
+    test_silent_peer_is_reaped()
     print("\nRESULT: " + ("ALL PASS" if ok else "FAILURES"))
     sys.exit(0 if ok else 1)

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -851,6 +851,8 @@ CATALOGS = {
             "Recibiendo: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Explorador remoto: conectado a {address}",
+        "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
+            "Explorador remoto: sin noticias del Next durante {seconds}s: se da por perdido (¿apagado? ¿Wi-Fi caído?)",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Explorador remoto: navega a una carpeta en el explorador izquierdo, pulsa 'Set current folder as new sync root folder', haz clic en 'Start Remote Explorer NextSync server' y luego ejecuta {command} en tu Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -1933,6 +1935,8 @@ CATALOGS = {
             "A receber: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Explorador remoto: ligado a {address}",
+        "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
+            "Explorador remoto: sem resposta do Next há {seconds}s: assume-se que desapareceu (desligado? Wi-Fi caiu?)",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Explorador remoto: navega até uma pasta no explorador esquerdo, prime 'Set current folder as new sync root folder', clica em 'Start Remote Explorer NextSync server' e depois executa {command} no teu Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -3013,6 +3017,8 @@ CATALOGS = {
             "Odbieranie: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Eksplorator zdalny: połączono z {address}",
+        "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
+            "Eksplorator zdalny: brak sygnału od Nexta od {seconds}s — uznano za utracony (wyłączony? zerwane Wi-Fi?)",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Eksplorator zdalny: przejdź do folderu w lewym eksploratorze, naciśnij 'Set current folder as new sync root folder', kliknij 'Start Remote Explorer NextSync server', a następnie uruchom {command} na swoim Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -4095,6 +4101,8 @@ CATALOGS = {
             "Получение: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Удалённый проводник: подключено к {address}",
+        "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
+            "Удалённый проводник: от Next нет данных {seconds}с — считаем, что он пропал (выключен? пропал Wi-Fi?)",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Удалённый проводник: перейдите к папке в левом проводнике, нажмите 'Set current folder as new sync root folder', затем 'Start Remote Explorer NextSync server' и выполните {command} на Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -5176,6 +5184,8 @@ CATALOGS = {
             "Přijímání: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Vzdálený průzkumník: připojeno k {address}",
+        "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
+            "Vzdálený průzkumník: od Nextu {seconds}s nic nepřišlo — považuje se za ztracený (vypnutý? spadla Wi-Fi?)",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Vzdálený průzkumník: přejděte do složky v levém průzkumníku, stiskněte 'Set current folder as new sync root folder', klikněte na 'Start Remote Explorer NextSync server' a pak na Nextu spusťte {command}.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -6260,6 +6270,8 @@ CATALOGS = {
             "Réception : {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Explorateur distant : connecté à {address}",
+        "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
+            "Explorateur distant : plus de nouvelles du Next depuis {seconds}s — considéré comme perdu (éteint ? Wi-Fi coupé ?)",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Explorateur distant : accédez à un dossier dans l'explorateur de gauche, appuyez sur 'Set current folder as new sync root folder', cliquez sur 'Start Remote Explorer NextSync server', puis exécutez {command} sur votre Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -465,6 +465,13 @@ def _re_recv_block(conn):
 #: walk, its own retry backoff), not the time a whole transfer takes.
 RE_REPLY_TIMEOUT = 60.0
 
+#: Seconds of TOTAL silence from a connected Next before we conclude it is
+#: gone. The peer drives the session and polls continuously when idle (every
+#: second or two), so silence is unambiguous — but keep this well clear of
+#: that cadence: a spurious disconnect drops a session that was merely busy.
+#: Only counted between commands; a command's reply has its own timeout.
+PEER_SILENCE_LIMIT = 45.0
+
 
 def _re_reply_call(conn, handler, timeout=None):
     """:func:`_re_recv_reply` under a per-command socket timeout.
@@ -702,6 +709,14 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
 
         with conn:
             conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            try:
+                # Belt and braces to the silence timer below: the OS will
+                # eventually reap a half-open socket by itself. Its default
+                # schedule is hours, so this is a backstop, never the
+                # mechanism.
+                conn.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            except OSError:
+                pass
             # The Next opens the session with the "Listen" handshake keyword.
             data = conn.recv(1024)
             if data != b"Listen":
@@ -734,16 +749,37 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
             rmtree_jobs = {}   # job id -> {'root': path, 'fails': 0}
             rmtree_seq = 0
 
+            # Dead-peer detection. A Next that is switched off (or unplugged,
+            # or whose Wi-Fi drops) never sends a FIN: the socket simply goes
+            # quiet, and recv() times out forever while the UI keeps claiming
+            # a Next is connected — reported after a machine sat "connected"
+            # to a Next that had been off for hours.
+            #
+            # No probe is needed to notice, because THE NEXT DRIVES: an idle
+            # peer polls us every second or two (the dot's idle throttle,
+            # ZXNextRemote's is faster), so silence is itself the signal. The
+            # timer only runs HERE, between commands — a command's own reply
+            # is read inside _re_reply_call, which has its own timeout — so a
+            # slow operation can never be mistaken for a dead peer.
+            last_rx = time.monotonic()
             while not stop_event.is_set():
                 try:
                     conn.settimeout(1.0)
                     data = conn.recv(1024)
                 except socket.timeout:
+                    if time.monotonic() - last_rx >= PEER_SILENCE_LIMIT:
+                        log(ui_tr_now(
+                            "Remote explorer: no word from the Next for "
+                            "{seconds}s — assuming it is gone (powered off? "
+                            "Wi-Fi dropped?)").format(
+                                seconds=int(PEER_SILENCE_LIMIT)))
+                        break
                     continue
                 except OSError:
                     break
                 if not data:
                     break
+                last_rx = time.monotonic()
 
                 # A put in flight is served by the Next pulling the bytes with
                 # "Get"/"Gee" (or asking to resend with "Retry"/"Restart"). A newer


### PR DESCRIPTION
## The report

A machine left connected and unattended: the Next was switched off, and hours later the Remote Explorer still showed it attached.

A powered-off Next (or unplugged, or Wi-Fi dropped) **never sends a FIN** — the socket just goes quiet, `recv()` times out forever, and the session loop keeps looping happily.

## Fix — no probe needed

You suggested an "are you alive?" poll, and the good news is the protocol already gives us one for free: **the Next drives the session.** An idle peer polls *us* every second or two (the dot's idle throttle; ZXNextRemote's is faster), so **silence is itself the signal** — we only have to notice it.

```python
except socket.timeout:
    if time.monotonic() - last_rx >= PEER_SILENCE_LIMIT:
        log("… no word from the Next for 45s — assuming it is gone …")
        break
```

Two details that matter:

- **`PEER_SILENCE_LIMIT` is 45 s**, far clear of the 1-2 s poll cadence. A spurious disconnect would drop a session that was merely busy, which is worse than the bug.
- **The timer runs only between commands.** A command's own reply is read inside `_re_reply_call`, which has its own timeout — so a slow operation can never be mistaken for a dead peer.

On expiry the session ends through the normal disconnect path, which the app already handles by restarting the listen server. `SO_KEEPALIVE` is set too, purely as a backstop — the OS reaps half-open sockets on a schedule measured in hours.

## Test

New case: connect, verify the session is live, then go silent and assert it is reaped near the limit with the reason logged.

Two things it caught while being written, both worth remembering for tests in this file:

- **Qt signals need `Qt.DirectConnection`** when no event loop runs in the test thread. Without it the first version "passed" in 0.0 s against a flag that was never set — a vacuous green.
- The new log line had to be added to **all six i18n catalogs**; the i18n tripwire failed the build until it was, which is exactly its job.

`ruff` clean; `test_bridge_stall`, `test_remote_listen`, `test_http_bridge`, `test_i18n` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)