### PR TITLE
9.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.4"
+version = "9.5.5"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.4"
+ZX_NEXT_UNITE_VERSION = "9.5.5"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Version bump for today's work, in both places the release workflow checks (`ZX_NEXT_UNITE_VERSION` and `pyproject.toml`) — it gates the tag against both.

**Bridge robustness**
- A stalled Next no longer strands a blocked HTTP caller (#254): per-command socket timeout so a stall fails one command rather than the session, and every `BridgeReply` is resolved on every exit path. `LONG_TIMEOUT` 900 → 270 s so the bridge answers before its strictest client gives up.
- Diagnostics (#255, #258): in-flight tracking, a watchdog that names anything unanswered after 15 s, and the response code/size/duration logged unconditionally.

**Remote explorer**
- Notices a Next that was switched off (#259). A powered-off peer never sends a FIN, so the session sat "connected" indefinitely — reported after a machine had been off for hours. The peer polls constantly, so silence is the signal.

**Dot**
- `.sync5` 5.7.1 (#256): an unacked terminal block no longer reports `get done`, which is what sent the bridge-stall investigation to the wrong end of the wire.

**CI**
- The suite now runs on every PR and on `main` (#257) instead of only on a `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)