### PR TITLE
9.5.7: Remote Explorer Modified column pinned to the OS-local wall clock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.6"
+version = "9.5.7"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -940,6 +940,34 @@ def test_sync_root_and_local_pane():
           w._browse_dir() == root.replace("\\", "/"))
 
 
+def test_modified_column_local_time():
+    """The Modified column must show the OS-LOCAL wall time. QDateTime's
+    toString prints whatever spec the stamp carries, and Qt has shipped
+    file times in both LocalTime and UTC specs — a UTC-spec'd stamp shown
+    raw is hours off (the 9.5.6 hardware report). The expectation is
+    computed with datetime.fromtimestamp, the OS-local reference. On a
+    UTC-offset machine (the dev box) this FAILS if UTC ever leaks; on a
+    UTC-zone runner it still pins the formatting path."""
+    import datetime
+
+    root = tdir("mt_root")
+    f = tfile(root, "stamped.txt")
+    # A fixed local wall moment (mktime = local tuple -> epoch), so the
+    # expectation is deterministic and not "now"-flaky.
+    when = time.mktime((2026, 1, 15, 10, 30, 0, 0, 0, -1))
+    os.utime(f, (when, when))
+
+    w, _calls = make_widget(local_start_dir=root)
+    select_local(w, f)                 # waits out the async population
+    six = w.local_model.index(f)
+    shown = w.local_model.data(six.siblingAtColumn(3),
+                               Qt.ItemDataRole.DisplayRole)
+    expect = datetime.datetime.fromtimestamp(
+        os.path.getmtime(f)).strftime("%Y-%m-%d %H:%M")
+    check("Modified column shows the OS-local wall time",
+          shown == expect, f"shown={shown!r} expected={expect!r}")
+
+
 def test_local_file_operations():
     root = tdir("lop_root")
     w, calls = make_widget(local_start_dir=root)
@@ -1306,6 +1334,7 @@ def main():
         test_rcpy_precheck_and_background()
         test_cancel_and_disconnect_mid_op()
         test_sync_root_and_local_pane()
+        test_modified_column_local_time()
         test_local_file_operations()
         test_drag_and_drop()
         test_arrow_pulse_and_overlay_resize()

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.6"
+ZX_NEXT_UNITE_VERSION = "9.5.7"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -147,9 +147,19 @@ class ColoredFileSystemModel(QFileSystemModel):
             # Blank for the ".." row; folders keep their real mtime. Sorting
             # compares the actual QDateTime (DotDotFirstProxyModel.lessThan),
             # never this string.
+            #
+            # toLocalTime() is load-bearing: QDateTime.toString() prints the
+            # time in whatever spec the QDateTime CARRIES, and Qt has shipped
+            # file-time stamps in both LocalTime and UTC specs across
+            # versions/platforms (Windows file times are UTC FILETIMEs
+            # underneath). Displaying a UTC-spec'd stamp raw shifts every
+            # date by the timezone offset — hours off, silently. Converting
+            # explicitly is a no-op when the stamp is already local and the
+            # correct wall-clock everywhere else.
             if self.fileName(index) == "..":
                 return ""
-            return self.lastModified(index).toString("yyyy-MM-dd HH:mm")
+            return (self.lastModified(index)
+                    .toLocalTime().toString("yyyy-MM-dd HH:mm"))
         if role == Qt.ItemDataRole.ForegroundRole and index.isValid():
             c = self._colours
             if self.fileName(index) == "..":  # the parent ".." up-entry


### PR DESCRIPTION
The local pane's Modified column (new in 9.5.6) formatted `QFileSystemModel.lastModified()` directly. `QDateTime.toString()` prints the time **in whatever spec the stamp carries**, and Qt has shipped file-time stamps in both LocalTime and UTC specs across versions/platforms (Windows file times are UTC FILETIMEs underneath) — a UTC-spec'd stamp shown raw is shifted by the whole timezone offset, silently.

**Fix:** `.toLocalTime()` before formatting — a no-op when the stamp is already local (verified on PySide6 6.11.1: spec comes back LocalTime and matches `datetime.fromtimestamp`), the correct wall clock in every other case.

**Test:** new `test_modified_column_local_time` pins the displayed string to the OS-local reference (`datetime.fromtimestamp`) on a file with a fixed mtime, driven through the real model offscreen. On a UTC-offset machine (the dev box, UTC+2) it fails if UTC ever leaks into the display again.

**Note for verification on 9.5.7:** if a file still looks hours off after this, compare it against Windows File Explorer — same value there means the file's *mtime itself* is shifted (e.g. written onto a FAT SD card by a Next whose RTC runs UTC), which no display code can fix.

Full suite: ALL PASS. `ruff check .` clean. Version 9.5.7 in both `zxnu_config.py` and `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)