### PR TITLE
9.5.8: listen session survives view switches; ranged /get; named disconnects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.7"
+version = "9.5.8"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_http_bridge.py
+++ b/tests/test_http_bridge.py
@@ -152,6 +152,28 @@ def phase_a():
     st, body = http(HTTP_A, "/get?path=/games/lev")
     check("A /get folder -> 400", st == 400 and b"folder" in body, body)
 
+    # Ranged slices (ZXNextRemote 0.7.10's overrun-proof retry): &off=&len=
+    # windows of one cached relay; EOF = a short slice; the cache drops
+    # once the end is served and a mid-file cache miss recovers by
+    # re-relaying.
+    got = b""
+    ok_slices = True
+    while True:
+        st, part = http(HTTP_A, f"/get?path=boot.bas&off={len(got)}&len=16")
+        ok_slices = ok_slices and st == 200
+        got += part
+        if len(part) < 16:
+            break
+    check("A /get ranged reassembles", ok_slices and got == filebytes,
+          (ok_slices, len(got)))
+    st, part = http(HTTP_A, "/get?path=boot.bas&off=13&len=16")
+    check("A /get ranged cache-miss recovers",
+          st == 200 and part == filebytes[13:29], part)
+    st, part = http(HTTP_A, "/get?path=boot.bas&off=999&len=16")
+    check("A /get ranged past EOF -> empty", st == 200 and part == b"", part)
+    st, part = http(HTTP_A, "/get?path=boot.bas&off=-1&len=16")
+    check("A /get ranged bad off -> 400", st == 400, (st, part))
+
     st, body = http(HTTP_A, "/put?path=/ho/up2.bin", body=b"\x01\x02" * 100)
     check("A /put", st == 200 and b"OK put /ho/up2.bin (200 bytes)" in body, body)
 

--- a/tests/test_remote_listen.py
+++ b/tests/test_remote_listen.py
@@ -395,6 +395,35 @@ def main():
         print(f"FAIL idle-stop: alive={t2.is_alive()} after {dt:.2f}s")
         ok = False
 
+    # ── a peer that hangs up must be NAMED, not a silent break ─────────
+    # The empty-recv and OSError exits used to break without a word: the
+    # session just "blinked reconnecting" and nobody knew who hung up
+    # (the N-Go tree-copy report). Close the socket right after the
+    # handshake and require the reason line + the disconnected signal.
+    sig3 = RemoteExplorerSignals()
+    logs3, disc3 = [], []
+    sig3.log.connect(logs3.append, Qt.DirectConnection)
+    sig3.disconnected.connect(lambda: disc3.append(1), Qt.DirectConnection)
+    stop3 = threading.Event()
+    t3 = threading.Thread(target=run_remote_listen_server,
+                          args=(sig3, queue.Queue(), stop3, PORT + 2),
+                          daemon=True)
+    t3.start()
+    time.sleep(0.3)
+    s3 = socket.create_connection(("127.0.0.1", PORT + 2), timeout=5)
+    s3.sendall(b"Listen")
+    assert rx_payload(s3) == b"Listening"
+    s3.close()                            # FIN with no Bye, mid-session
+    t3.join(timeout=5)
+    stop3.set()
+    if (not t3.is_alive() and disc3
+            and any("closed the connection" in ln for ln in logs3)):
+        print("PASS hangup: peer FIN is named in the log + disconnected")
+    else:
+        print("FAIL hangup: alive=", t3.is_alive(), "disc=", disc3,
+              "logs=", logs3)
+        ok = False
+
     shutil.rmtree(tmp, ignore_errors=True)
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
     sys.exit(0 if ok else 1)

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1061,10 +1061,15 @@ def inspect_phase11():
         app.quit()
         return
 
-    check("the Remote Explorer is the visible page of the log stack",
-          win.nextsync_log_stack.currentWidget() is re_widget,
+    # The stack page is the CONTAINER (explorer + mini log) since the RE
+    # view grew its own log strip; the explorer widget lives inside it.
+    check("the Remote Explorer container is the visible page of the log stack",
+          win.nextsync_log_stack.currentWidget() is win._re_container
+          and re_widget.parent() is win._re_container,
           str(win.nextsync_log_stack.currentWidget()))
     check("the Remote Explorer is actually visible", re_widget.isVisible())
+    check("the mini log is built and visible below the panes",
+          win._re_mini_log is not None and win._re_mini_log.isVisible())
 
     # Both file panes: the local tree and the Next tree.
     trees = re_widget.findChildren(QTreeView)
@@ -1105,7 +1110,8 @@ def inspect_phase11():
     tabs.setCurrentIndex(0)
     QCoreApplication.processEvents()
     check("returning to the Remote Explorer still shows it",
-          win.nextsync_log_stack.currentWidget() is re_widget)
+          win.nextsync_log_stack.currentWidget() is win._re_container
+          and re_widget.isVisible())
     app.quit()
 
 

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.7"
+ZX_NEXT_UNITE_VERSION = "9.5.8"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_http_bridge.py
+++ b/zxnu_http_bridge.py
@@ -310,6 +310,12 @@ class NextSyncHttpBridge:
         # connection_limit may be >1.
         self._put_spool = {}
         self._spool_lock = threading.Lock()
+        # Ranged /get relay cache: the last file pulled from the Next, kept
+        # for slice serving (ZXNextRemote's overrun-proof retry pulls ~90
+        # slices per 115KB — one dot-speed relay, then RAM). One entry:
+        # any off=0 request refreshes it, serving the final slice drops it.
+        self._get_cache = {"path": None, "data": b""}
+        self._get_cache_lock = threading.Lock()
         # In-flight request registry: rid -> [method, path, start, last_note].
         # Every request is tracked whether or not -v is on, because the two
         # things it powers are worth having always: the live count (exposed
@@ -482,6 +488,8 @@ class NextSyncHttpBridge:
             self._inflight.clear()
         with self._spool_lock:
             self._put_spool.clear()   # drop any unfinished chunked uploads
+        with self._get_cache_lock:
+            self._get_cache = {"path": None, "data": b""}
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -548,6 +556,8 @@ class NextSyncHttpBridge:
             with self._inflight_lock:
                 entry = self._inflight.pop(rid, None)
                 n = len(self._inflight)
+            if request.environ.get("zxnu.trace_quiet"):
+                return resp        # mid-file ranged slice: tracked, unlogged
             elapsed = time.monotonic() - entry[2] if entry else 0.0
             # A streamed body has no length to report yet; everything the
             # bridge serves today is a complete in-memory response.
@@ -719,20 +729,65 @@ class NextSyncHttpBridge:
             v = need(("path", "file"))
             if not v:
                 return bad("missing ?path=")
-            res = run("get", v[0])
-            if not res.get("ok"):
-                return fail(res, f"get {v[0]}")
-            name = os.path.basename(v[0].rstrip("/"))
-            data = res.get("data") or b""
-            if request.args.get("b64") in ("1", "true", "yes"):
-                # Base64 body: 7-bit-safe for CSpect's emulated ESP, where
-                # the caller adds .http's -7 flag to decode it back.
-                return Response(base64.b64encode(data) + b"\n",
-                                mimetype="text/plain")
-            return Response(
-                data, mimetype="application/octet-stream",
-                headers={"Content-Disposition":
-                         f'attachment; filename="{name}"'})
+            path = v[0]
+            name = os.path.basename(path.rstrip("/"))
+            b64 = request.args.get("b64") in ("1", "true", "yes")
+            off_arg = request.args.get("off")
+            if off_arg is None:
+                res = run("get", path)
+                if not res.get("ok"):
+                    return fail(res, f"get {path}")
+                data = res.get("data") or b""
+                if b64:
+                    # Base64 body: 7-bit-safe for CSpect's emulated ESP, where
+                    # the caller adds .http's -7 flag to decode it back.
+                    return Response(base64.b64encode(data) + b"\n",
+                                    mimetype="text/plain")
+                return Response(
+                    data, mimetype="application/octet-stream",
+                    headers={"Content-Disposition":
+                             f'attachment; filename="{name}"'})
+            # ---- ranged slices (ZXNextRemote 0.7.10's overrun-proof retry).
+            # &off=&len= serve windows of ONE relay, cached bridge-side: a
+            # client whose UART cannot survive a streamed body (FIFO overrun
+            # during its SD writes) pulls the file in verified bites while
+            # the far Next still streams it only once. EOF for the client is
+            # a short slice; X-Total-Size rides along for the curious.
+            try:
+                off = int(off_arg)
+                ln = int(request.args.get("len") or "1280")
+            except ValueError:
+                return bad("off/len must be integers")
+            if off < 0 or not (1 <= ln <= 16384):
+                return bad("off/len out of range")
+            with self._get_cache_lock:
+                c = self._get_cache
+                data = c["data"] if (off and c["path"] == path) else None
+            if data is None:
+                # A fresh file (off=0) — or an evicted cache: relay anew.
+                res = run("get", path)
+                if not res.get("ok"):
+                    return fail(res, f"get {path}")
+                data = res.get("data") or b""
+                with self._get_cache_lock:
+                    self._get_cache = {"path": path, "data": data}
+            chunk = bytes(data[off:off + ln])
+            done = off + ln >= len(data)
+            if done:
+                with self._get_cache_lock:
+                    if self._get_cache["path"] == path:
+                        self._get_cache = {"path": None, "data": b""}
+            elif off and not self._verbose:
+                # ~90 mid-file slices would bury the console: only the
+                # relay (off=0) and the final slice keep their trace line.
+                request.environ["zxnu.trace_quiet"] = True
+            headers = {"X-Total-Size": str(len(data))}
+            if b64:
+                return Response(base64.b64encode(chunk) + b"\n",
+                                mimetype="text/plain", headers=headers)
+            headers["Content-Disposition"] = f'attachment; filename="{name}"'
+            return Response(chunk, mimetype="application/octet-stream",
+                            headers=headers)
 
         def _put_append(path, body):
             """Chunked upload for callers that cannot send a whole file in

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -851,8 +851,14 @@ CATALOGS = {
             "Recibiendo: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Explorador remoto: conectado a {address}",
+        "Remote explorer: connection error from the Next ({error}) — session over.":
+            "Explorador remoto: error de conexión con el Next ({error}); sesión terminada.",
+        "Remote explorer: the Next closed the connection.":
+            "Explorador remoto: el Next cerró la conexión.",
         "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
             "Explorador remoto: sin noticias del Next durante {seconds}s: se da por perdido (¿apagado? ¿Wi-Fi caído?)",
+        "Remote explorer: server keeps running in the background — stop it from the Remote Explorer view.":
+            "Explorador remoto: el servidor sigue ejecutándose en segundo plano; deténlo desde la vista Remote Explorer.",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Explorador remoto: navega a una carpeta en el explorador izquierdo, pulsa 'Set current folder as new sync root folder', haz clic en 'Start Remote Explorer NextSync server' y luego ejecuta {command} en tu Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -1935,8 +1941,14 @@ CATALOGS = {
             "A receber: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Explorador remoto: ligado a {address}",
+        "Remote explorer: connection error from the Next ({error}) — session over.":
+            "Explorador remoto: erro de ligação com o Next ({error}); sessão terminada.",
+        "Remote explorer: the Next closed the connection.":
+            "Explorador remoto: o Next fechou a ligação.",
         "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
             "Explorador remoto: sem resposta do Next há {seconds}s: assume-se que desapareceu (desligado? Wi-Fi caiu?)",
+        "Remote explorer: server keeps running in the background — stop it from the Remote Explorer view.":
+            "Explorador remoto: o servidor continua a correr em segundo plano; pára-o na vista Remote Explorer.",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Explorador remoto: navega até uma pasta no explorador esquerdo, prime 'Set current folder as new sync root folder', clica em 'Start Remote Explorer NextSync server' e depois executa {command} no teu Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -3017,8 +3029,14 @@ CATALOGS = {
             "Odbieranie: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Eksplorator zdalny: połączono z {address}",
+        "Remote explorer: connection error from the Next ({error}) — session over.":
+            "Eksplorator zdalny: błąd połączenia z Nextem ({error}) — sesja zakończona.",
+        "Remote explorer: the Next closed the connection.":
+            "Eksplorator zdalny: Next zamknął połączenie.",
         "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
             "Eksplorator zdalny: brak sygnału od Nexta od {seconds}s — uznano za utracony (wyłączony? zerwane Wi-Fi?)",
+        "Remote explorer: server keeps running in the background — stop it from the Remote Explorer view.":
+            "Eksplorator zdalny: serwer nadal działa w tle — zatrzymaj go w widoku Remote Explorer.",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Eksplorator zdalny: przejdź do folderu w lewym eksploratorze, naciśnij 'Set current folder as new sync root folder', kliknij 'Start Remote Explorer NextSync server', a następnie uruchom {command} na swoim Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -4101,8 +4119,14 @@ CATALOGS = {
             "Получение: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Удалённый проводник: подключено к {address}",
+        "Remote explorer: connection error from the Next ({error}) — session over.":
+            "Удалённый проводник: ошибка соединения с Next ({error}) — сеанс завершён.",
+        "Remote explorer: the Next closed the connection.":
+            "Удалённый проводник: Next закрыл соединение.",
         "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
             "Удалённый проводник: от Next нет данных {seconds}с — считаем, что он пропал (выключен? пропал Wi-Fi?)",
+        "Remote explorer: server keeps running in the background — stop it from the Remote Explorer view.":
+            "Удалённый проводник: сервер продолжает работать в фоне — остановите его в виде Remote Explorer.",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Удалённый проводник: перейдите к папке в левом проводнике, нажмите 'Set current folder as new sync root folder', затем 'Start Remote Explorer NextSync server' и выполните {command} на Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -5184,8 +5208,14 @@ CATALOGS = {
             "Přijímání: {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Vzdálený průzkumník: připojeno k {address}",
+        "Remote explorer: connection error from the Next ({error}) — session over.":
+            "Vzdálený průzkumník: chyba spojení s Nextem ({error}) — relace ukončena.",
+        "Remote explorer: the Next closed the connection.":
+            "Vzdálený průzkumník: Next ukončil spojení.",
         "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
             "Vzdálený průzkumník: od Nextu {seconds}s nic nepřišlo — považuje se za ztracený (vypnutý? spadla Wi-Fi?)",
+        "Remote explorer: server keeps running in the background — stop it from the Remote Explorer view.":
+            "Vzdálený průzkumník: server dál běží na pozadí — zastavte ho v pohledu Remote Explorer.",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Vzdálený průzkumník: přejděte do složky v levém průzkumníku, stiskněte 'Set current folder as new sync root folder', klikněte na 'Start Remote Explorer NextSync server' a pak na Nextu spusťte {command}.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":
@@ -6270,8 +6300,14 @@ CATALOGS = {
             "Réception : {name} -> {path}",
         "Remote explorer: connected to {address}":
             "Explorateur distant : connecté à {address}",
+        "Remote explorer: connection error from the Next ({error}) — session over.":
+            "Explorateur distant : erreur de connexion avec le Next ({error}) — session terminée.",
+        "Remote explorer: the Next closed the connection.":
+            "Explorateur distant : le Next a fermé la connexion.",
         "Remote explorer: no word from the Next for {seconds}s — assuming it is gone (powered off? Wi-Fi dropped?)":
             "Explorateur distant : plus de nouvelles du Next depuis {seconds}s — considéré comme perdu (éteint ? Wi-Fi coupé ?)",
+        "Remote explorer: server keeps running in the background — stop it from the Remote Explorer view.":
+            "Explorateur distant : le serveur continue de tourner en arrière-plan — arrêtez-le depuis la vue Remote Explorer.",
         "Remote explorer: navigate to a folder in the left file explorer, press 'Set current folder as new sync root folder', click 'Start Remote Explorer NextSync server', then run {command} on your Next.":
             "Explorateur distant : accédez à un dossier dans l'explorateur de gauche, appuyez sur 'Set current folder as new sync root folder', cliquez sur 'Start Remote Explorer NextSync server', puis exécutez {command} sur votre Next.",
         "Remote explorer: port {port} is already in use — is another ZX-Next-Unite (or NextSync server) already running?":

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -35,7 +35,7 @@ from PySide6.QtGui import (QKeySequence)
 from PySide6.QtWidgets import (QWidget, QLabel, QPushButton, QCheckBox,
     QComboBox, QLineEdit, QHBoxLayout, QVBoxLayout, QProgressBar, QTreeView,
     QFileSystemModel, QGroupBox, QRadioButton, QButtonGroup, QListWidget,
-    QTabBar, QStackedWidget, QAbstractItemView)
+    QTabBar, QStackedWidget, QAbstractItemView, QMenu, QApplication)
 
 from zxnu_http_bridge import NextSyncHttpBridge, QueueBridgeHost
 from zxnu_network import detect_local_ipv4
@@ -430,6 +430,10 @@ def build_nextsync_pane(
     host._re_stop = None
     host._re_queue = None
     host._re_sig = None
+    host._re_mini_log = None       # Remote Explorer mini log (list side)
+    host._re_mini_retro = None     # ...and its lazy retro sibling
+    host._re_mini_stack = None
+    host._re_container = None      # RE widget + mini log, one stack entry
     host._re_running = False
     host._re_pulse_timer = None            # green "running" pulse (play label)
     host._re_start_btn_pulse_timer = None  # yellow "start me" pulse (start button)
@@ -757,6 +761,45 @@ def build_nextsync_pane(
         except Exception:
             pass
 
+    def _re_mini_sync_mode():
+        # Keep the Remote Explorer's mini log on the same Classic/Retro
+        # side as the big log window. The retro sibling is built lazily
+        # (pygame only spins up if the user actually uses Retro mode) and
+        # seeded from the mini list, newest-first source read bottom-up.
+        stack = getattr(host, "_re_mini_stack", None)
+        if stack is None:
+            return
+        if getattr(host, "_nextsync_pygame_on", False):
+            if host._re_mini_retro is None:
+                try:
+                    from zxnu_pygame import RetroLogWidget
+                    mini_r = RetroLogWidget(
+                        scrollable=True, follow_tail=True, context_copy=True,
+                        font_px=getattr(host, "_retro_log_font_size",
+                                        DEFAULT_RETRO_LOG_FONT_SIZE))
+                    mini_r.set_font_step_cb(
+                        lambda d: host._step_retro_log_font(d))
+                    try:
+                        mini_r.enable_background(
+                            getattr(host, "_nextsync_pygame_anim", True))
+                        mini_r.set_text_color(
+                            qcolor_to_hex(host.img_color_retro_log))
+                    except Exception:
+                        pass
+                    for i in range(host._re_mini_log.count() - 1, -1, -1):
+                        mini_r.append(host._re_mini_log.item(i).text())
+                    host._re_mini_retro = mini_r
+                    stack.addWidget(mini_r)
+                except Exception:
+                    logging.exception("Remote Explorer mini retro log failed")
+                    return                    # pygame missing: stay classic
+            stack.setCurrentWidget(host._re_mini_retro)
+            host._re_mini_retro.start()
+        else:
+            if getattr(host, "_re_mini_retro", None) is not None:
+                host._re_mini_retro.stop()
+            stack.setCurrentWidget(host._re_mini_log)
+
     def _nextsync_build_remote_explorer():
         if host._re_widget is not None:
             return host._re_widget
@@ -782,7 +825,46 @@ def build_nextsync_pane(
             on_toast=lambda title, msg, variant="red": host._show_toast(
                 title, msg, variant=variant, duration_ms=9000))
         host._re_widget = widget
-        host.nextsync_log_stack.addWidget(widget)
+        # ---- mini log under the explorer panes (2026-08-07): tracing the
+        # bridge/server activity used to require flipping to the Classic
+        # tab — which, before the same-day fix, even stopped the server.
+        # This is the same stream (add_nextsync_log_window mirrors into
+        # it), newest first like the classic list, right-click to copy,
+        # with a retro sibling that follows the Classic/Retro toggle.
+        container = QWidget()
+        _lay = QVBoxLayout(container)
+        _lay.setContentsMargins(0, 0, 0, 0)
+        _lay.setSpacing(4)
+        _lay.addWidget(widget, 1)
+        mini = QListWidget(container)
+        mini.setContextMenuPolicy(Qt.CustomContextMenu)
+
+        def _re_mini_menu(pos):
+            menu = QMenu(mini)
+            item = mini.itemAt(pos)
+            if item is not None:
+                menu.addAction(
+                    ui_tr_now("Copy"),
+                    lambda: QApplication.clipboard().setText(item.text()))
+            menu.addAction(
+                ui_tr_now("Copy all text"),
+                lambda: QApplication.clipboard().setText("\n".join(
+                    mini.item(i).text() for i in range(mini.count()))))
+            menu.exec(mini.mapToGlobal(pos))
+        mini.customContextMenuRequested.connect(_re_mini_menu)
+        # Seed with the classic log's story so far (it shows newest-first;
+        # same order here).
+        for i in range(min(host.nextsync_log.count(), 200)):
+            mini.addItem(host.nextsync_log.item(i).text())
+        mini_stack = QStackedWidget(container)
+        mini_stack.setFixedHeight(110)
+        mini_stack.addWidget(mini)
+        _lay.addWidget(mini_stack)
+        host._re_mini_log = mini
+        host._re_mini_stack = mini_stack
+        host._re_container = container
+        host.nextsync_log_stack.addWidget(container)
+        _re_mini_sync_mode()
         _re_apply_item_colors()          # tint to the user's configured colours
         # Sync the cached sync root with whatever the widget restored (a saved
         # path enables Start; first run leaves it disabled).
@@ -1224,8 +1306,10 @@ def build_nextsync_pane(
 
     def _nextsync_toggle_remote_explorer(checked):
         if checked:
-            widget = _nextsync_build_remote_explorer()
-            host.nextsync_log_stack.setCurrentWidget(widget)
+            _nextsync_build_remote_explorer()
+            # The stack entry is the container (explorer + mini log).
+            host.nextsync_log_stack.setCurrentWidget(host._re_container)
+            _re_mini_sync_mode()
             # Swap the normal sync controls for the dedicated server control.
             host.nextsync_prepare_server.setVisible(False)
             host.nextsync_start_server.setVisible(False)
@@ -1249,16 +1333,35 @@ def build_nextsync_pane(
             host.nextsync_fileexplorer_and_buttons_container.setVisible(False)
             host.nextsync_filterlabel.setVisible(False)
             host.nextsync_filtertext.setVisible(False)
-            add_nextsync_log_window(
-                ui_tr_now(
-                    "Remote explorer: navigate to a folder in the left file "
-                    "explorer, press 'Set current folder as new sync root "
-                    "folder', click 'Start Remote Explorer NextSync server', "
-                    "then run {command} on your Next.").format(
-                        command="'.sync5 -L' (-l or -listen)"))
+            # The full walkthrough is for the EMPTY state only: with a sync
+            # root already set (or the server already running) it read like
+            # the app had forgotten the root it was actively using.
+            if (not getattr(host, "_re_sync_root", "")
+                    and not getattr(host, "_re_running", False)):
+                add_nextsync_log_window(
+                    ui_tr_now(
+                        "Remote explorer: navigate to a folder in the left file "
+                        "explorer, press 'Set current folder as new sync root "
+                        "folder', click 'Start Remote Explorer NextSync server', "
+                        "then run {command} on your Next.").format(
+                            command="'.sync5 -L' (-l or -listen)"))
         else:
-            _nextsync_stop_listen_server()
+            # The listen server SURVIVES leaving the Remote Explorer view
+            # (2026-08-07). Stopping it here sent a protocol 'Q' — or, with
+            # a transfer in flight, a force-close after the goodbye grace —
+            # every time the user flipped to the Classic tab to watch the
+            # console… which is exactly where the HTTP bridge lines print.
+            # The bridge rides this same session, so a peek at the log
+            # killed the peer's connection ("Server quit." / "put FAIL
+            # link down r1" on the Next) and every later bridge call
+            # answered 503, looking like a phantom server crash. Stopping
+            # is now only ever explicit: the Start/Stop button, the SD
+            # tab's context menu, or app exit.
             _re_stop_startbtn_pulse()   # leaving the RE view: drop the pulse
+            if getattr(host, "_re_running", False):
+                add_nextsync_log_window(ui_tr_now(
+                    "Remote explorer: server keeps running in the "
+                    "background — stop it from the Remote Explorer view."))
             # Restore the log view that matches the current retro/classic
             # choice — NOT always the classic list. Forcing the list here
             # while retro mode is on desyncs the retro toggle: the button
@@ -1377,6 +1480,7 @@ def build_nextsync_pane(
             host.nextsync_pygame_button.setText(ui_tr_now("🖼 Switch to 'Classic' view mode"))
             host.nextsync_log_stack.setCurrentWidget(widget)
             widget.start()
+            _re_mini_sync_mode()       # the RE view's mini log follows
             _nextsync_pygame_persist(True)
         else:
             host._nextsync_pygame_on = False
@@ -1384,6 +1488,7 @@ def build_nextsync_pane(
             if host._nextsync_retro_log is not None:
                 host._nextsync_retro_log.stop()
             host.nextsync_log_stack.setCurrentWidget(host.nextsync_log)
+            _re_mini_sync_mode()       # the RE view's mini log follows
             _nextsync_pygame_persist(False)
 
     host.nextsync_pygame_button.toggled.connect(_nextsync_on_pygame_toggled)

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -485,6 +485,27 @@ def build_sdcard_utils(
             except Exception:
                 pass
 
+        # And into the Remote Explorer view's mini log (both siblings),
+        # so bridge/server activity is traceable without flipping to the
+        # Classic tab. Bounded: a long session must not grow it forever.
+        mini = getattr(host, "_re_mini_log", None)
+        if mini is not None:
+            try:
+                if from_top:
+                    mini.insertItem(0, string_to_log)
+                else:
+                    mini.addItem(string_to_log)
+                while mini.count() > 500:
+                    mini.takeItem(mini.count() - 1)
+            except Exception:
+                pass
+        mini_r = getattr(host, "_re_mini_retro", None)
+        if mini_r is not None:
+            try:
+                mini_r.append(string_to_log)
+            except Exception:
+                pass
+
     def add_help_content(string_to_log:str, from_top:bool = True):
 
         newItem = QListWidgetItem()

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -586,7 +586,15 @@ def _re_relname_under(remote, name):
 
 
 def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
-                             max_payload=1024):
+                             max_payload=512):
+    # max_payload is 512, not the protocol's 1024 cap: ZXNextRemote's bench
+    # testing found Next CLONES (N-Go) corrupt >512-byte continuous UART
+    # bursts at the Medium/Fast rates — deterministically, close checksums —
+    # and its own server dropped to 512-byte data chunks for exactly that.
+    # A put served from here with 1024-byte frames hit the same wall
+    # (2026-08-07: "put FAIL ... r1" on the N-Go, dead session, bridge 502).
+    # Real Nexts and the dot are indifferent; the cost is one extra 5-byte
+    # frame header per KB.
     """Run the NextSync ``.sync5 -listen`` remote file server in a worker thread.
 
     Waits for a Next running ``.sync5 -listen`` to connect, then drives it from
@@ -779,11 +787,30 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                             "{seconds}s — assuming it is gone (powered off? "
                             "Wi-Fi dropped?)").format(
                                 seconds=int(PEER_SILENCE_LIMIT)))
+                        logging.warning(
+                            "Remote explorer: peer silent for %ss — "
+                            "assuming it is gone", int(PEER_SILENCE_LIMIT))
                         break
                     continue
-                except OSError:
+                # The two breaks below used to be SILENT: a session that
+                # died here (the Next's ESP resetting the TCP link, a
+                # Wi-Fi drop surfacing as ConnectionReset, …) left no
+                # trace anywhere — the UI just started blinking for a
+                # reconnect and the user was left guessing WHO hung up.
+                # Name the reason, in the console AND the file log.
+                except OSError as ex:
+                    log(ui_tr_now(
+                        "Remote explorer: connection error from the Next "
+                        "({error}) — session over.").format(error=ex))
+                    logging.warning(
+                        "Remote explorer: connection error from the Next: %s",
+                        ex)
                     break
                 if not data:
+                    log(ui_tr_now(
+                        "Remote explorer: the Next closed the connection."))
+                    logging.info(
+                        "Remote explorer: the Next closed the connection.")
                     break
                 last_rx = time.monotonic()
 


### PR DESCRIPTION
One day of hardware-driven fixes with the N-Go + real Next test rig:

- **Root cause of the "NextSync server disconnects" mystery**: the NextSync tab's internal Remote Explorer ⇄ Classic mode-tabs stopped the listen server on every switch to the Classic view — exactly where the HTTP bridge log prints. The server now survives view switches; stopping is only ever explicit.
- **Ranged `/get` slices** (`&off=&len=`, one-file relay cache, `X-Total-Size`, quiet mid-file traces) so ZXNextRemote's overrun-proof retry can pull big files in verified bites.
- **Every listen-session disconnect is named** (console + file log): peer FIN, connection error with errno, silence timeout — plus a peer-FIN regression test.
- **512-byte put frames** (was 1024): clones corrupt longer continuous UART bursts at Medium/Fast.
- **Mini log in the Remote Explorer view** (same stream, copy menu, retro sibling) and the sync-root walkthrough only prints when no root/server exists.

Full suite green (incl. offscreen phases, i18n tripwire), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)