### PR TITLE
HTTP bridge: paced ranged-slice writes (fit the Next's UART FIFO)

### DIFF
--- a/zxnu_http_bridge.py
+++ b/zxnu_http_bridge.py
@@ -783,11 +783,35 @@ class NextSyncHttpBridge:
                 request.environ["zxnu.trace_quiet"] = True
             headers = {"X-Total-Size": str(len(data))}
             if b64:
-                return Response(base64.b64encode(chunk) + b"\n",
-                                mimetype="text/plain", headers=headers)
-            headers["Content-Disposition"] = f'attachment; filename="{name}"'
-            return Response(chunk, mimetype="application/octet-stream",
-                            headers=headers)
+                body = base64.b64encode(chunk) + b"\n"
+                mimetype = "text/plain"
+            else:
+                headers["Content-Disposition"] = \
+                    f'attachment; filename="{name}"'
+                mimetype = "application/octet-stream"
+                body = chunk
+            # PACED writes (ZXNextRemote 0.7.15's hardware round): the
+            # Next's UART RX FIFO is 512 bytes with no flow control
+            # behind it, and its client must drain a continuous burst
+            # mid-flight or lose the tail — hardware showed slices
+            # starving at ~one espframe-ring's worth at Medium
+            # (1.152 Mbaud, 4.4 ms of FIFO grace; remy's .http never
+            # sees this only because it stays at 115200 = 44 ms). So a
+            # slice is sent as ≤256-byte TCP pushes with a breather in
+            # between: each push fits the FIFO whole even if the client
+            # naps through it. Adds ~20 ms per KB slice — invisible next
+            # to the relay. Content-Length is set explicitly because a
+            # streamed response has no automatic one and the client
+            # VERIFIES it per slice.
+            headers["Content-Length"] = str(len(body))
+
+            def paced(payload=body):
+                for i in range(0, len(payload), 256):
+                    yield payload[i:i + 256]
+                    time.sleep(0.005)
+
+            return Response(paced(), mimetype=mimetype, headers=headers,
+                            direct_passthrough=True)
 
         def _put_append(path, body):
             """Chunked upload for callers that cannot send a whole file in


### PR DESCRIPTION
## Why

ZXNextRemote''s hardware rounds (0.7.12-0.7.15 debug instrumentation) showed ranged `/get` slices starving mid-burst at Medium UART: the Next''s 512-byte RX FIFO gives its client 4.4 ms of grace, and a slice arriving as one continuous TCP burst loses its tail whenever the client stalls longer than that. remy''s `.http` dot never hits this because it runs the wire at 115200 (44 ms of grace).

## What

Each ranged slice response is now streamed as **≤256-byte TCP pushes with a 5 ms breather** between them — every push fits the FIFO whole even if the client naps through the burst. Costs ~20 ms per KB slice, invisible next to the dot-speed relay. `Content-Length` is set explicitly (streamed responses have no automatic one; the client verifies it per slice). The streamed full-file `/get` path is unchanged.

## Verification

- `python tests/test_http_bridge.py` — ALL PASS
- `ruff check zxnu_http_bridge.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)