### PR TITLE
Ctrl-A selects contents, never the '..' row - and works again on the SD tab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.9"
+version = "9.5.10"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -34,6 +34,7 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from PySide6.QtCore import QItemSelectionModel, QMimeData, QPointF, Qt, QUrl
 from PySide6.QtGui import QColor, QDropEvent
+from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 import zxnu_remote_explorer as rex
@@ -1191,6 +1192,57 @@ def test_compact_buttons_fit_translated_labels():
     w.deleteLater()
 
 
+def test_select_all_skips_updir():
+    """Ctrl-A (and programmatic selectAll) selects a listing's CONTENTS,
+    never the ".." parent row pinned on top — on BOTH panes. A select-all
+    fed into delete/copy/drag must not smuggle the folder above in."""
+    print("\n== Select All skips the '..' row ==")
+
+    # -- Next pane: below drive root, so the '..' row exists --------------
+    w, calls = make_widget()
+    connect_widget(w, calls)
+    w.on_listing("/GAMES", [(False, 10, "a.tap"), (False, 20, "b.tap"),
+                            (True, 0, "SUB")])
+    names = [w.next_model.item(r, 0).text()
+             for r in range(w.next_model.rowCount())]
+    check("next pane fixture shows '..' + 3 entries",
+          len(names) == 4 and ".." in names, repr(names))
+    QTest.keyClick(w.next_view, Qt.Key_A, Qt.ControlModifier)
+    sel = [ix.data(RE_PATH_ROLE)
+           for ix in w.next_view.selectionModel().selectedRows(0)]
+    check("next pane Ctrl-A selects the three entries", len(sel) == 3,
+          repr(sel))
+    check("next pane Ctrl-A leaves '..' out", ".." not in sel, repr(sel))
+    w.next_view.clearSelection()
+    w.next_view.selectAll()
+    sel = [ix.data(RE_PATH_ROLE)
+           for ix in w.next_view.selectionModel().selectedRows(0)]
+    check("next pane selectAll() skips '..' too",
+          len(sel) == 3 and ".." not in sel, repr(sel))
+
+    # -- local pane: a real folder with a parent --------------------------
+    root = tdir("ctrla_root")
+    for n in ("one.txt", "two.txt"):
+        tfile(root, n)
+    os.mkdir(os.path.join(root, "sub"))
+    w, calls = make_widget(local_start_dir=root)
+    lroot = w.local_view.rootIndex()
+    deadline = time.monotonic() + 10.0
+    while (time.monotonic() < deadline
+           and w.local_proxy.rowCount(lroot) < 4):
+        QApplication.processEvents()
+        time.sleep(0.02)
+    lnames = [w.local_proxy.index(r, 0, lroot).data()
+              for r in range(w.local_proxy.rowCount(lroot))]
+    check("local pane fixture shows '..' + 3 entries",
+          len(lnames) == 4 and ".." in lnames, repr(lnames))
+    QTest.keyClick(w.local_view, Qt.Key_A, Qt.ControlModifier)
+    lsel = [ix.data() for ix in w.local_view.selectionModel().selectedRows(0)]
+    check("local pane Ctrl-A selects the three entries", len(lsel) == 3,
+          repr(lsel))
+    check("local pane Ctrl-A leaves '..' out", ".." not in lsel, repr(lsel))
+
+
 def test_emulator_start_from_next():
     """'Start <emulator> with <file>' on the NEXT pane.
 
@@ -1342,6 +1394,7 @@ def main():
         test_idle_details_provider()
         test_compact_buttons_fit_translated_labels()
         test_emulator_start_from_next()
+        test_select_all_skips_updir()
     finally:
         shutil.rmtree(TMP, ignore_errors=True)
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")

--- a/tests/test_select_all_updir.py
+++ b/tests/test_select_all_updir.py
@@ -1,0 +1,133 @@
+"""Offscreen regression tests for bind_select_all_except_updir
+(zxnu_workers) — the Ctrl-A / Select All override that keeps the ".."
+parent-directory row OUT of the selection.
+
+Two bugs drove this (both found on the same day, both user-reported):
+  * the Remote Explorer's panes and the SD Card tab's local tree selected
+    the ".." row along with everything else on Ctrl-A, so "select all and
+    delete/drag" quietly included the folder above;
+  * on the SD Card tab Ctrl-A did nothing AT ALL — set_treeview_properties
+    (zxnu_sdcard_ops) re-applied SingleSelection on every refresh, silently
+    downgrading the ExtendedSelection the pane had asked for. That function
+    now re-applies ExtendedSelection; the widget-level proof lives here as
+    a construction-equivalent check.
+
+This file exercises the helper on the SD-card local pane's exact
+construction (QFileSystemModel + DotDotFirstProxyModel + QTreeView); the
+Remote Explorer's two panes are covered on the real widget in
+test_remote_explorer_widget.py."""
+import os
+import sys
+import tempfile
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from PySide6.QtCore import QCoreApplication, QDir, Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import (QAbstractItemView, QApplication,
+                               QFileSystemModel, QTreeView)
+
+from zxnu_workers import DotDotFirstProxyModel, bind_select_all_except_updir
+
+ok = True
+
+
+def check(label, cond, detail=""):
+    global ok
+    print(f"{'PASS' if cond else 'FAIL'} {label}"
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        ok = False
+
+
+def wait_until(cond, timeout=15.0):
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        QCoreApplication.processEvents()
+        if cond():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+app = QApplication(sys.argv)
+
+# A folder WITH a parent, so the ".." row exists (a drive root has none).
+root = tempfile.mkdtemp(prefix="ctrla-")
+for n in ("aaa.txt", "bbb.txt", "ccc.txt"):
+    with open(os.path.join(root, n), "w") as f:
+        f.write("x")
+os.mkdir(os.path.join(root, "sub"))
+
+# The SD Card tab's local pane construction, line for line
+# (zxnu_sdcard_explorer._build_local_pane).
+model = QFileSystemModel()
+model.setRootPath("/")
+model.setFilter(~QDir.NoDotAndDotDot | QDir.NoDot)
+
+view = QTreeView()
+view.setSortingEnabled(True)
+view.setSelectionMode(QAbstractItemView.ExtendedSelection)
+
+proxy = DotDotFirstProxyModel(recursiveFilteringEnabled=True,
+                              filterRole=QFileSystemModel.FileNameRole)
+proxy.setSourceModel(model)
+proxy.setSortCaseSensitivity(Qt.CaseInsensitive)
+proxy.setDynamicSortFilter(True)
+view.setModel(proxy)
+view.setRootIndex(proxy.mapFromSource(model.index(root)))
+bind_select_all_except_updir(
+    view, lambda ix: model.fileName(proxy.mapToSource(ix)) == "..")
+view.show()
+
+wait_until(lambda: proxy.rowCount(view.rootIndex()) >= 5)
+names = [proxy.index(r, 0, view.rootIndex()).data()
+         for r in range(proxy.rowCount(view.rootIndex()))]
+check("fixture: 5 rows including '..'", len(names) == 5 and ".." in names,
+      repr(names))
+
+# --- Ctrl-A: everything except ".." ----------------------------------------
+QTest.keyClick(view, Qt.Key_A, Qt.ControlModifier)
+QCoreApplication.processEvents()
+sel = sorted(ix.data() for ix in view.selectionModel().selectedRows(0))
+check("Ctrl-A selects the four entries", len(sel) == 4, repr(sel))
+check("Ctrl-A leaves '..' unselected", ".." not in sel, repr(sel))
+
+# --- the programmatic path takes the same override --------------------------
+view.clearSelection()
+view.selectAll()
+QCoreApplication.processEvents()
+sel = sorted(ix.data() for ix in view.selectionModel().selectedRows(0))
+check("selectAll() also skips '..'", len(sel) == 4 and ".." not in sel,
+      repr(sel))
+
+# --- '..' stays clickable / selectable by hand ------------------------------
+updir_ix = next(proxy.index(r, 0, view.rootIndex())
+                for r in range(proxy.rowCount(view.rootIndex()))
+                if proxy.index(r, 0, view.rootIndex()).data() == "..")
+view.clearSelection()
+view.setCurrentIndex(updir_ix)
+check("'..' can still be selected by hand (only Select All skips it)",
+      [ix.data() for ix in view.selectionModel().selectedRows(0)] == [".."])
+
+# --- Ctrl-A in ExtendedSelection is what the SD tab relies on ---------------
+# (the set_treeview_properties regression: SingleSelection made Ctrl-A a
+# no-op — assert the mode the pane asks for actually keeps Ctrl-A alive)
+view.setSelectionMode(QAbstractItemView.SingleSelection)
+view.clearSelection()
+QTest.keyClick(view, Qt.Key_A, Qt.ControlModifier)
+QCoreApplication.processEvents()
+single = len(view.selectionModel().selectedRows(0))
+view.setSelectionMode(QAbstractItemView.ExtendedSelection)
+view.clearSelection()
+QTest.keyClick(view, Qt.Key_A, Qt.ControlModifier)
+QCoreApplication.processEvents()
+extended = len(view.selectionModel().selectedRows(0))
+check("SingleSelection kills Ctrl-A (the SD-tab bug), Extended restores it",
+      single <= 1 < extended, f"single={single} extended={extended}")
+
+print("RESULT: ALL PASS" if ok else "RESULT: FAILURES")
+sys.exit(0 if ok else 1)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.9"
+ZX_NEXT_UNITE_VERSION = "9.5.10"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -38,7 +38,8 @@ from zxnu_config import (
 )
 from zxnu_workers import (
     CompactButton, DotDotFirstProxyModel, HdfProgressDialog,
-    zip_create_with_dialog, zip_extract_with_dialog, zip_unique_name,
+    bind_select_all_except_updir, zip_create_with_dialog,
+    zip_extract_with_dialog, zip_unique_name,
 )
 
 # Roles carrying the remote entry's full posix path and its directory flag.
@@ -405,6 +406,8 @@ class RemoteExplorerWidget(QWidget):
         self.local_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.local_view.setUniformRowHeights(True)
         self.local_view.setSortingEnabled(True)
+        # Ctrl-A selects the folder's contents, never the ".." parent row.
+        bind_select_all_except_updir(self.local_view, self._is_local_updir)
         # Show Name / Type / Size / Modified, ordering the first three like the
         # SD-card image tree — QFileSystemModel's native order is Name(0),
         # Size(1), Type(2), Date Modified(3), so swap Size/Type visually and let
@@ -538,6 +541,9 @@ class RemoteExplorerWidget(QWidget):
         self.next_view.setUniformRowHeights(True)
         self.next_view.setRootIsDecorated(False)
         self.next_view.setColumnWidth(0, 250)
+        # Ctrl-A selects the listing's contents, never the ".." parent row.
+        bind_select_all_except_updir(
+            self.next_view, lambda ix: ix.data(RE_PATH_ROLE) == "..")
         # The Next model is rebuilt on every listing, so instead of Qt's view sort
         # (which would sort the Size column as text and unpin "..") we sort the
         # entries ourselves in _rebuild_next_rows and just drive the header: make

--- a/zxnu_sdcard_explorer.py
+++ b/zxnu_sdcard_explorer.py
@@ -65,7 +65,8 @@ from PySide6.QtWidgets import (
 
 from zxnu_config import (SETTING_EXPLORERPATH, SETTING_IMAGE_EXPLORERPATH,
                          is_filetype_a_directory)
-from zxnu_workers import CompactButton, DotDotFirstProxyModel, HdfTaskWorker
+from zxnu_workers import (CompactButton, DotDotFirstProxyModel,
+                          HdfTaskWorker, bind_select_all_except_updir)
 
 # ---------------------------------------------------------------------------
 # The disk image explorer is a lazily-populated tree: the image can be listed
@@ -134,6 +135,13 @@ class SdCardExplorerPane(QWidget):
         self.treeview.setColumnWidth(0, 250)
         self.treeview.doubleClicked.connect(self._on_local_double_clicked)
         self.treeview.clicked.connect(self._on_local_clicked)
+        # Ctrl-A selects the folder's CONTENTS — never the ".." parent row
+        # pinned on top (a select-all fed into delete/drag must not smuggle
+        # the folder above in).
+        bind_select_all_except_updir(
+            self.treeview,
+            lambda ix: self.model.fileName(
+                self.proxy_model.mapToSource(ix)) == "..")
         # Context menu / key handling / drag & drop are operation-layer glue
         # and stay wired by MainWindow onto these widgets (via its aliases).
 

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -527,7 +527,14 @@ def build_sdcard_utils(
     def set_treeview_properties():
         host.treeview.setSortingEnabled(True)
         host.treeview.sortByColumn(0, Qt.SortOrder.AscendingOrder)
-        host.treeview.setSelectionMode(QAbstractItemView.SingleSelection)
+        # ExtendedSelection, NOT SingleSelection: SdCardExplorerPane builds
+        # the local tree multi-select (multi-item drags, Ctrl-A) and this
+        # refresh hook runs after every navigation — the old SingleSelection
+        # here silently downgraded the tree moments after construction,
+        # which is exactly why Ctrl-A "did nothing" on the SD Card tab.
+        # The classic NextSync tree below never opted into multi-select,
+        # so its line keeps the Qt default it always had.
+        host.treeview.setSelectionMode(QAbstractItemView.ExtendedSelection)
         host.nextsync_treeview.setSortingEnabled(True)
         host.nextsync_treeview.sortByColumn(0, Qt.SortOrder.AscendingOrder)
         host.nextsync_treeview.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -23,8 +23,8 @@ from zxnu_config import (IGNOREFILE, MAX_PAYLOAD, PORT, SYNCPOINT,
                          is_filetype_a_directory, mame_autostart_staging_dir,
                          mame_can_autostart)
 from PySide6.QtCore import (
-    QEvent, QObject, QPoint, QRect, QRunnable, QSize, QSortFilterProxyModel,
-    QTimer, Qt, Signal, Slot,
+    QEvent, QItemSelection, QItemSelectionModel, QObject, QPoint, QRect,
+    QRunnable, QSize, QSortFilterProxyModel, QTimer, Qt, Signal, Slot,
 )
 from PySide6.QtGui import QFontInfo
 # ui_tr_now translates the USER-FACING server log lines at their call sites
@@ -343,6 +343,37 @@ class DotDotFirstProxyModel(QSortFilterProxyModel):
             return True
         name = source_model.fileName(index)
         return pattern.lower() in name.lower()
+
+def bind_select_all_except_updir(view, is_updir):
+    """Make the view's Select All (Ctrl-A, or any programmatic selectAll)
+    leave the ".." parent-directory row OUT of the selection: selecting
+    "everything here" never means "and also the folder above" — a
+    selection fed into delete/copy/drag must not smuggle the parent in.
+
+    ``is_updir`` receives a column-0 view index (proxy-level where the
+    view has a proxy) and answers whether it is the ".." row. The
+    override is assigned as an instance attribute — the same duck-punch
+    pattern the drag-and-drop hooks already use; Shiboken resolves
+    virtual calls through the instance, so Qt's own Ctrl-A handling
+    lands here too. Only top-level rows under the current root are
+    checked: DotDotFirstProxyModel pins ".." there, and an expanded
+    subfolder never shows one."""
+    base_select_all = type(view).selectAll
+
+    def _select_all_except_updir():
+        base_select_all(view)
+        model = view.model()
+        root = view.rootIndex()
+        last_col = max(0, model.columnCount(root) - 1)
+        for row in range(model.rowCount(root)):
+            ix = model.index(row, 0, root)
+            if is_updir(ix):
+                view.selectionModel().select(
+                    QItemSelection(ix, model.index(row, last_col, root)),
+                    QItemSelectionModel.Deselect)
+
+    view.selectAll = _select_all_except_updir
+
 
 class WorkerSignals(QObject):
 


### PR DESCRIPTION
## Summary

Two user-reported Select-All bugs, fixed together:

- **Ctrl-A included the pinned `..` parent row** on the NextSync Remote Explorer's local and Next panes — so "select all, then delete/copy/drag" quietly carried the folder above. New `zxnu_workers.bind_select_all_except_updir` overrides the views' `selectAll` (the same instance-attribute duck-punch pattern the drag-and-drop hooks use) to deselect the updir row; bound on **both Remote Explorer panes** and the **SD Card tab's local tree**. Clicking `..` by hand still selects it — only Select All skips it.
- **On the SD Card tab Ctrl-A did nothing at all**: `set_treeview_properties` (zxnu_sdcard_ops) re-applied **SingleSelection** on every navigation/refresh, silently downgrading the ExtendedSelection `SdCardExplorerPane` asks for — which also defeated the pane's multi-item drag onto the image explorer. It now re-applies ExtendedSelection. The classic NextSync tab's tree keeps its original single-select behaviour (it never opted into multi-select).

Includes the **9.5.10 version bump** (zxnu_config + pyproject) as a separate commit.

## Tests

- New `tests/test_select_all_updir.py`: the helper on the SD-card pane's exact construction — Ctrl-A and programmatic selectAll skip `..`, hand-selection still works, and the SingleSelection-kills-Ctrl-A regression is pinned.
- `tests/test_remote_explorer_widget.py` gains a "Select All skips the '..' row" section driving the real widget's both panes via QTest.
- Full suite: **all 22 files PASS** (incl. the offscreen UI phases); `ruff check .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)