### PR TITLE
Fix the widget suite's stale-index segfault; harden the selectAll bind

### DIFF
--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -19,11 +19,18 @@ only after confirmation), the rcpy free-space precheck, sync-root handling,
 local file operations (new folder/rename/delete/copy-paste/zip round-trip)
 and drag & drop entry points."""
 import logging
+import faulthandler
 import os
 import shutil
 import sys
 import tempfile
 import time
+
+# A native crash inside Qt loses the BUFFERED stdout of this process (a CI
+# run died exactly that way, leaving no clue which check it was in); the
+# faulthandler traceback goes to stderr, which is unbuffered, so the crash
+# point survives into the log.
+faulthandler.enable()
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 # The compact-button checks print translated labels ("W górę", "Вверх"), which
@@ -1207,6 +1214,11 @@ def test_select_all_skips_updir():
              for r in range(w.next_model.rowCount())]
     check("next pane fixture shows '..' + 3 entries",
           len(names) == 4 and ".." in names, repr(names))
+    # Key events go to a SHOWN widget: this suite normally never shows its
+    # widgets, but synthesising keystrokes at a never-realised view is the
+    # kind of corner offscreen Qt is allowed to dislike.
+    w.show()
+    QApplication.processEvents()
     QTest.keyClick(w.next_view, Qt.Key_A, Qt.ControlModifier)
     sel = [ix.data(RE_PATH_ROLE)
            for ix in w.next_view.selectionModel().selectedRows(0)]
@@ -1226,16 +1238,26 @@ def test_select_all_skips_updir():
         tfile(root, n)
     os.mkdir(os.path.join(root, "sub"))
     w, calls = make_widget(local_start_dir=root)
-    lroot = w.local_view.rootIndex()
+
+    # Re-fetch the root index on EVERY poll: QFileSystemModel populates
+    # asynchronously and each directoryLoaded invalidates proxy indexes,
+    # so a root index captured once and reused across processEvents()
+    # dangles — rowCount(stale index) was an access violation that took
+    # a CI run (and its buffered stdout) with it.
+    def lrows():
+        return w.local_proxy.rowCount(w.local_view.rootIndex())
+
     deadline = time.monotonic() + 10.0
-    while (time.monotonic() < deadline
-           and w.local_proxy.rowCount(lroot) < 4):
+    while time.monotonic() < deadline and lrows() < 4:
         QApplication.processEvents()
         time.sleep(0.02)
+    lroot = w.local_view.rootIndex()
     lnames = [w.local_proxy.index(r, 0, lroot).data()
               for r in range(w.local_proxy.rowCount(lroot))]
     check("local pane fixture shows '..' + 3 entries",
           len(lnames) == 4 and ".." in lnames, repr(lnames))
+    w.show()
+    QApplication.processEvents()
     QTest.keyClick(w.local_view, Qt.Key_A, Qt.ControlModifier)
     lsel = [ix.data() for ix in w.local_view.selectionModel().selectedRows(0)]
     check("local pane Ctrl-A selects the three entries", len(lsel) == 3,

--- a/tests/test_select_all_updir.py
+++ b/tests/test_select_all_updir.py
@@ -16,10 +16,15 @@ This file exercises the helper on the SD-card local pane's exact
 construction (QFileSystemModel + DotDotFirstProxyModel + QTreeView); the
 Remote Explorer's two panes are covered on the real widget in
 test_remote_explorer_widget.py."""
+import faulthandler
 import os
 import sys
 import tempfile
 import time
+
+# stderr is unbuffered; a native Qt crash would otherwise eat the buffered
+# stdout and with it any clue of which check was running (seen once on CI).
+faulthandler.enable()
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 sys.stdout.reconfigure(encoding="utf-8", errors="replace")

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -16,6 +16,7 @@ import struct
 import tempfile
 import threading
 import time
+import weakref
 from collections import deque, namedtuple
 from zxnu_config import (IGNOREFILE, MAX_PAYLOAD, PORT, SYNCPOINT,
                          UP_DIRECTORY, VERSION3, VERSION4,
@@ -357,10 +358,21 @@ def bind_select_all_except_updir(view, is_updir):
     virtual calls through the instance, so Qt's own Ctrl-A handling
     lands here too. Only top-level rows under the current root are
     checked: DotDotFirstProxyModel pins ".." there, and an expanded
-    subfolder never shows one."""
+    subfolder never shows one.
+
+    The closure holds the view only WEAKLY: ``view.selectAll = closure``
+    capturing ``view`` strongly would make every bound view a reference
+    cycle through its own __dict__, leaving the C++/Python teardown
+    order to the cycle collector — exactly the class of
+    platform-dependent shutdown crash Shiboken widgets must not be
+    exposed to."""
     base_select_all = type(view).selectAll
+    view_ref = weakref.ref(view)
 
     def _select_all_except_updir():
+        view = view_ref()
+        if view is None:
+            return
         base_select_all(view)
         model = view.model()
         root = view.rootIndex()


### PR DESCRIPTION
## Summary

The v9.5.10 tag's CI/release failure was a **crash in the new select-all test, not in the Ctrl-A feature**: the local-pane wait loop polled `rowCount()` with a root index captured once before QFileSystemModel's async population — each `directoryLoaded` invalidates proxy indexes, so the poll dereferenced a dangling index (access violation). Timing-dependent: CI 3.13 crashed while 3.10 passed; a local 3.14 run then crashed on the identical line once `faulthandler` was armed.

- The wait loop re-fetches the root index on every poll.
- `faulthandler.enable()` stays in both test files — the crash eats buffered stdout (the CI log showed nothing from the suite), while faulthandler's stderr traceback survives and named the exact line.
- QTest key events now go to a **shown** widget.
- `bind_select_all_except_updir` holds its view via **weakref** — the strong closure made every bound view a reference cycle through its own `__dict__`.

## Tests

- Widget suite: **3 consecutive clean runs each** on Python 3.13 and 3.14 (the crash was intermittent; repetition is the point)
- `ruff check .` green

After merge: re-point the `v9.5.10` tag at the fixed main so the release workflow re-runs (the failed run produced no artifacts — the gate held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)