### PR TITLE
Download NextZXOS Image: the extracted image carries the chosen name

### DIFF
--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -85,7 +85,7 @@ DROPSRC = os.path.join(SCRATCH, "dropsrc.txt")
 DELZONE = os.path.join(SCRATCH, "delzone")
 
 PHASE = int(sys.argv[1]) if len(sys.argv) > 1 else None
-ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
 
 # Base cfg for the isolated app copy: update checks off (MAME/CSpect AND the
 # app's own GitHub release check) so no phase ever hits the network, and the
@@ -269,6 +269,24 @@ elif PHASE == 12:
     ensure_scratch(fresh=False)
     with open(CFG, "w") as f:
         f.write(BASE_CFG)
+elif PHASE == 13:
+    # REGRESSION (reported): the "Download NextZXOS Image" wizard downloaded
+    # the zip but the user saw no extracted image, no path selected, and no
+    # load — because the extracted image kept the ARCHIVE's internal path
+    # (2gb/cspect-next-2gb.img), so a renamed save produced no artifact
+    # carrying the chosen name, every download overwrote the same hidden
+    # file, and the 2 GB single-call extract froze the UI. The wizard must
+    # now extract the image NEXT TO the zip NAMED AFTER IT. The phase feeds
+    # the wizard a locally built zip (urlopen patched — no network) whose
+    # image member sits under the stock archives' internal folder layout.
+    import zipfile as _zf
+    ensure_scratch(fresh=False)
+    with open(CFG, "w") as f:
+        f.write(BASE_CFG)
+    DLZIP_SRC = os.path.join(SCRATCH, "wizard-feed.zip")
+    with _zf.ZipFile(DLZIP_SRC, "w", _zf.ZIP_DEFLATED) as z:
+        z.writestr("2gb/cspect-next-2gb.img", b"\x00" * 65536)
+        z.writestr("2gb/version.txt", "test feed")
 elif PHASE == 11:
     # NextSync Remote Explorer with pygame absent (every phase blocks pygame —
     # see _NoPygame). The retro log needs pygame; the Remote Explorer's dual
@@ -1235,10 +1253,98 @@ def inspect_phase12():
     app.quit()
 
 
+def inspect_phase13():
+    """The Download-NextZXOS-Image wizard, fed a local zip through a patched
+    urlopen and a renamed save target: the image must be extracted NEXT TO
+    the zip NAMED AFTER IT (not at the archive's internal 2gb/... path),
+    selected into the image input, and no error box may appear."""
+    from PySide6.QtWidgets import (QDialog, QFileDialog, QMessageBox,
+                                   QPushButton)
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+
+    wait_until(lambda: not getattr(win, "_emulator_scan_pending", False),
+               what="emulator scan settled")
+
+    feed = os.path.join(SCRATCH, "wizard-feed.zip")
+    save_as = os.path.join(SCRATCH, "my-renamed-download.zip")
+    expected_img = os.path.join(SCRATCH, "my-renamed-download.img")
+    for stale in (save_as, expected_img,
+                  os.path.join(SCRATCH, "2gb", "cspect-next-2gb.img")):
+        if os.path.isfile(stale):
+            os.remove(stale)
+
+    boxes = []
+    def _record(kind):
+        def fn(*a, **k):
+            boxes.append((kind, a[2] if len(a) > 2 else "?"))
+            return QMessageBox.StandardButton.Ok
+        return staticmethod(fn)
+    QMessageBox.critical = _record("critical")
+    QMessageBox.warning = _record("warning")
+    QFileDialog.getSaveFileName = staticmethod(
+        lambda *a, **k: (save_as, "Zip Archives (*.zip)"))
+
+    class _FeedResponse:
+        def __init__(self):
+            self._f = open(feed, "rb")
+            self._size = os.path.getsize(feed)
+        def __enter__(self): return self
+        def __exit__(self, *exc): self._f.close(); return False
+        def read(self, n=-1): return self._f.read(n)
+        def getheader(self, name, default=None):
+            return (str(self._size)
+                    if name.lower() == "content-length" else default)
+    import urllib.request
+    urllib.request.urlopen = lambda *a, **k: _FeedResponse()
+
+    def click_download():
+        dlg = next((w for w in app.topLevelWidgets()
+                    if isinstance(w, QDialog) and w.isVisible()
+                    and "Download NextZXOS" in w.windowTitle()), None)
+        check("wizard dialog opened", dlg is not None)
+        if dlg is None:
+            return
+        btn = next((b for b in dlg.findChildren(QPushButton)
+                    if b.text() == "Download"), None)
+        check("wizard has a Download button", btn is not None)
+        if btn is not None:
+            btn.click()
+
+    QTimer.singleShot(300, click_download)
+    win.download_nextzxos_image()
+
+    check("the zip landed at the RENAMED save path", os.path.isfile(save_as))
+    check("the image is extracted NEXT TO the zip, NAMED AFTER IT",
+          os.path.isfile(expected_img),
+          expected_img)
+    check("the archive's internal folder path is NOT recreated",
+          not os.path.isfile(os.path.join(SCRATCH, "2gb",
+                                          "cspect-next-2gb.img")))
+    check("the extracted image is selected into the image input",
+          win.imageinput.currentText()
+          and os.path.normcase(win.imageinput.currentText().strip('"'))
+          == os.path.normcase(expected_img),
+          win.imageinput.currentText())
+    check("no error box appeared", not boxes, str(boxes))
+    # The feed image is not a real FAT volume, so the automatic load is
+    # allowed to FAIL — the wizard's contract ends at "selected and load
+    # attempted". Let the async load settle so it cannot outlive the app.
+    settle_end = time.monotonic() + 1.5
+    while time.monotonic() < settle_end:
+        QCoreApplication.processEvents()
+        time.sleep(0.02)
+    app.quit()
+
+
 INSPECTORS = {1: inspect_phase1, 2: inspect_phase2, 3: inspect_phase3,
               4: inspect_phase4, 5: inspect_phase5, 6: inspect_phase6,
               7: inspect_phase7, 8: inspect_phase8, 9: inspect_phase9,
-              10: inspect_phase10, 11: inspect_phase11, 12: inspect_phase12}
+              10: inspect_phase10, 11: inspect_phase11, 12: inspect_phase12,
+              13: inspect_phase13}
 
 _orig_exec = QApplication.exec
 def _patched_exec(*_a):

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -699,8 +699,14 @@ CATALOGS = {
             "Imagen de disco extraída: {path}",
         "Extracted {count} file(s) from {name} into {folder} on the image.":
             "Extraído(s) {count} archivo(s) de {name} en {folder} en la imagen.",
+        "Extracting image... %p%":
+            "Extrayendo imagen... %p%",
         "Failed downloading NextZXOS image: {error}":
             "Error al descargar la imagen NextZXOS: {error}",
+        "Load Failed":
+            "Error de carga",
+        "The image was extracted but could not be loaded:":
+            "La imagen se extrajo pero no se pudo cargar:",
         "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
             "Error al ejecutar hdfmonkey; asegúrate de que está instalado en el mismo directorio local que zx-next-unite.",
         "Failed extracting NextZXOS image: {error}":
@@ -1789,8 +1795,14 @@ CATALOGS = {
             "Imagem de disco extraída: {path}",
         "Extracted {count} file(s) from {name} into {folder} on the image.":
             "Extraído(s) {count} ficheiro(s) de {name} para {folder} na imagem.",
+        "Extracting image... %p%":
+            "Extraindo imagem... %p%",
         "Failed downloading NextZXOS image: {error}":
             "Falha ao transferir a imagem NextZXOS: {error}",
+        "Load Failed":
+            "Falha ao carregar",
+        "The image was extracted but could not be loaded:":
+            "A imagem foi extraída mas não pôde ser carregada:",
         "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
             "Falha ao executar o hdfmonkey; certifica-te de que está instalado na mesma pasta local que o zx-next-unite.",
         "Failed extracting NextZXOS image: {error}":
@@ -2877,8 +2889,14 @@ CATALOGS = {
             "Wypakowano obraz dysku: {path}",
         "Extracted {count} file(s) from {name} into {folder} on the image.":
             "Wypakowano {count} plik(ów) z {name} do {folder} na obrazie.",
+        "Extracting image... %p%":
+            "Wypakowywanie obrazu... %p%",
         "Failed downloading NextZXOS image: {error}":
             "Nie udało się pobrać obrazu NextZXOS: {error}",
+        "Load Failed":
+            "Błąd wczytywania",
+        "The image was extracted but could not be loaded:":
+            "Obraz został wypakowany, ale nie udało się go wczytać:",
         "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
             "Nie udało się uruchomić hdfmonkey — upewnij się, że jest zainstalowany w tym samym katalogu co zx-next-unite.",
         "Failed extracting NextZXOS image: {error}":
@@ -3967,8 +3985,14 @@ CATALOGS = {
             "Образ диска распакован: {path}",
         "Extracted {count} file(s) from {name} into {folder} on the image.":
             "Извлечено файлов: {count} из {name} в {folder} на образе.",
+        "Extracting image... %p%":
+            "Извлечение образа... %p%",
         "Failed downloading NextZXOS image: {error}":
             "Не удалось скачать образ NextZXOS: {error}",
+        "Load Failed":
+            "Ошибка загрузки",
+        "The image was extracted but could not be loaded:":
+            "Образ был распакован, но не удалось его загрузить:",
         "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
             "Не удалось запустить hdfmonkey — убедитесь, что он установлен в том же каталоге, что и zx-next-unite.",
         "Failed extracting NextZXOS image: {error}":
@@ -5056,8 +5080,14 @@ CATALOGS = {
             "Obraz disku rozbalen: {path}",
         "Extracted {count} file(s) from {name} into {folder} on the image.":
             "Rozbaleno {count} souborů z {name} do {folder} na obrazu.",
+        "Extracting image... %p%":
+            "Rozbalování obrazu... %p%",
         "Failed downloading NextZXOS image: {error}":
             "Nepodařilo se stáhnout obraz NextZXOS: {error}",
+        "Load Failed":
+            "Načtení selhalo",
+        "The image was extracted but could not be loaded:":
+            "Obraz byl rozbalen, ale nepodařilo se jej načíst:",
         "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
             "Nepodařilo se spustit hdfmonkey — ujistěte se, že je nainstalován ve stejném adresáři jako zx-next-unite.",
         "Failed extracting NextZXOS image: {error}":
@@ -6148,8 +6178,14 @@ CATALOGS = {
             "Image disque extraite : {path}",
         "Extracted {count} file(s) from {name} into {folder} on the image.":
             "{count} fichier(s) extrait(s) de {name} vers {folder} sur l'image.",
+        "Extracting image... %p%":
+            "Extraction de l'image... %p%",
         "Failed downloading NextZXOS image: {error}":
             "Échec du téléchargement de l'image NextZXOS : {error}",
+        "Load Failed":
+            "Échec du chargement",
+        "The image was extracted but could not be loaded:":
+            "L'image a été extraite mais n'a pas pu être chargée :",
         "Failed executing hdfmonkey, please make sure it is installed in the same local directory as zx-next-unite.":
             "Échec de l'exécution de hdfmonkey ; vérifiez qu'il est installé dans le même dossier local que zx-next-unite.",
         "Failed extracting NextZXOS image: {error}":

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -800,22 +800,68 @@ def build_sdcard_utils(
                 download_progress.setVisible(False)
                 return
 
-            # Extract the disk image from the downloaded archive so it can be loaded
+            logging.info(f"Downloaded NextZXOS image archive to {save_path}")
+
+            # Extract the disk image from the downloaded archive so it can be
+            # loaded. The archive's own folder layout is deliberately ignored:
+            # the image lands NEXT TO the zip, NAMED AFTER IT
+            # (cspect-next-2gb-fresh.zip -> cspect-next-2gb-fresh.img) — the
+            # stock archives keep their image under a fixed internal folder
+            # (2gb/cspect-next-2gb.img), so honouring it meant a renamed
+            # download produced no artifact carrying the chosen name (the
+            # reported "it didn't extract"), and every download of the same
+            # size silently overwrote the previous one through that fixed
+            # path. Extraction is chunked with the events pumped so a 2 GB
+            # inflate shows progress instead of freezing the whole UI for its
+            # duration — the freeze is the prime suspect for the reported
+            # never-diagnosed post-extract crash, and every stage now also
+            # writes the file log so a future failure leaves a trace.
             image_to_load = save_path
             try:
                 if zipfile.is_zipfile(save_path):
-                    extract_dir = os.path.dirname(save_path)
                     with zipfile.ZipFile(save_path) as archive:
                         image_members = [
-                            name for name in archive.namelist()
-                            if name.lower().endswith((".img", ".hdf"))
+                            info for info in archive.infolist()
+                            if info.filename.lower().endswith((".img", ".hdf"))
                         ]
                         if image_members:
-                            archive.extract(image_members[0], extract_dir)
-                            image_to_load = os.path.join(extract_dir, image_members[0])
+                            member = image_members[0]
+                            target = os.path.join(
+                                os.path.dirname(save_path),
+                                os.path.splitext(os.path.basename(save_path))[0]
+                                + os.path.splitext(member.filename)[1].lower())
+                            logging.info(
+                                f"Extracting {member.filename} "
+                                f"({member.file_size} bytes) to {target}")
+                            download_progress.setValue(0)
+                            download_progress.setFormat(
+                                ui_tr_now("Extracting image... %p%"))
+                            extracted = 0
+                            with archive.open(member) as src, \
+                                    open(target, "wb") as dst:
+                                while True:
+                                    chunk = src.read(4 * 1024 * 1024)
+                                    if not chunk:
+                                        break
+                                    dst.write(chunk)
+                                    extracted += len(chunk)
+                                    if member.file_size:
+                                        download_progress.setValue(min(
+                                            int(extracted * 100 / member.file_size),
+                                            100))
+                                    QApplication.processEvents()
+                            image_to_load = target
                             add_main_log_window(ui_tr_now(
                                 "Extracted disk image: {path}").format(
                                     path=image_to_load))
+                            logging.info(f"Extracted disk image: {image_to_load}")
+                        else:
+                            # No .img/.hdf inside: fall through with the zip
+                            # itself (load_image will report it cannot read
+                            # it) — but say so in the log rather than nothing.
+                            logging.warning(
+                                f"No .img/.hdf member found in {save_path}; "
+                                "loading the archive path as-is")
             except Exception as extract_error:
                 logging.error(f"Failed extracting NextZXOS image: {extract_error}")
                 add_main_log_window(ui_tr_now(
@@ -830,30 +876,50 @@ def build_sdcard_utils(
                 cancel_button.setEnabled(True)
                 image_combo.setEnabled(True)
                 download_progress.setVisible(False)
+                download_progress.setFormat("%p%")
                 return
 
             dialog.accept()
 
-            global right_disk_image_explorer_path
-            global right_disk_image_path
+            # Selecting + loading can only fail unexpectedly from here on —
+            # and the dialog is already gone, so an uncaught exception used
+            # to leave the user staring at an unchanged window with nothing
+            # in any log (the reported symptom). Catch, log, and SAY it.
+            try:
+                global right_disk_image_explorer_path
+                global right_disk_image_path
 
-            # Select the downloaded image into the image input
-            host.imageinput.setCurrentText(normalize_sd_image_path(image_to_load))
-            configuration_dictionary[SETTING_HDDFILE] = host.imageinput.currentText()
+                # Select the downloaded image into the image input
+                logging.info(f"Selecting downloaded image: {image_to_load}")
+                host.imageinput.setCurrentText(normalize_sd_image_path(image_to_load))
+                configuration_dictionary[SETTING_HDDFILE] = host.imageinput.currentText()
 
-            right_disk_image_explorer_path = []
-            _set_right_disk_content([])
-            right_disk_image_path = ""
-            _set_right_disk_selected([])
-            image_clear_model()
+                right_disk_image_explorer_path = []
+                _set_right_disk_content([])
+                right_disk_image_path = ""
+                _set_right_disk_selected([])
+                image_clear_model()
 
-            # Now try to load it
-            def _on_loaded(success):
-                if success:
-                    save_configuration_file()
-                    if host.settings_warn_image_nearly_full_checkbox.isChecked():
-                        _warn_if_image_nearly_full(host.right_disk_image_path)
-            load_image(_on_loaded)
+                # Now try to load it
+                def _on_loaded(success):
+                    if success:
+                        logging.info(f"Downloaded image loaded: "
+                                     f"{host.right_disk_image_path}")
+                        save_configuration_file()
+                        if host.settings_warn_image_nearly_full_checkbox.isChecked():
+                            _warn_if_image_nearly_full(host.right_disk_image_path)
+                load_image(_on_loaded)
+            except Exception as select_error:
+                logging.error(
+                    f"Failed selecting/loading the downloaded image: {select_error}")
+                add_main_log_window(ui_tr_now(
+                    "Failed loading image: {path}.").format(path=image_to_load))
+                QMessageBox.critical(
+                    host,
+                    ui_tr_now("Load Failed"),
+                    ui_tr_now("The image was extracted but could not be loaded:")
+                    + f"\n{select_error}"
+                )
 
         download_button.clicked.connect(do_download)
 


### PR DESCRIPTION
Reported: the wizard downloaded the (renamed) zip but "didn't extract, didn't select, didn't load". It HAD extracted - to the archive's fixed internal path (`2gb/cspect-next-2gb.img`), so a rename produced no artifact carrying the chosen name; the select/load tail then died without a trace, right after a 2 GB single-call extract froze the UI.

- The image now lands **next to the zip, named after it** (`cspect-next-2gb-fresh.zip` -> `cspect-next-2gb-fresh.img`) - no hidden folder, no silent cross-download overwrite.
- Chunked extraction with a progress bar ("Extracting image... %p%", translated x6) and pumped events - no more frozen window.
- Every stage writes the file log; the post-extract select/load tail shows a Load Failed box (translated x6) instead of vanishing.
- New offscreen regression phase 13 drives the real wizard against a locally built lookalike zip (urlopen patched, no network).

Full suite green (22 files). Verified end-to-end on the real 2 GB archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)