### PR TITLE
Remote Explorer: the Next path moves into a typeable box under its pane; 9.5.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.11"
+version = "9.5.12"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -275,6 +275,8 @@ def test_initial_and_connection_state():
     check("starts disconnected", not w._connected
           and not w.btn_to_next.isEnabled() and not w.next_view.isEnabled())
     check("waiting label", "waiting for .sync5" in w.next_path_label.text())
+    check("Next path box empty and disabled while disconnected",
+          not w.next_path_edit.isEnabled() and w.next_path_edit.text() == "")
     check("start dir committed as sync root",
           w.sync_root() == root.replace("\\", "/")
           and calls["sync_root"] == [root.replace("\\", "/")])
@@ -282,7 +284,8 @@ def test_initial_and_connection_state():
           w.local_path_edit.text() == root.replace("\\", "/"))
 
     w.on_connected()
-    check("connect enables the pane", w._connected and w.btn_to_next.isEnabled())
+    check("connect enables the pane", w._connected and w.btn_to_next.isEnabled()
+          and w.next_path_edit.isEnabled())
     check("connect asks drives then lists /",
           drain(calls) == [("drives",), ("ls", "/")])
 
@@ -295,17 +298,21 @@ def test_initial_and_connection_state():
     check("drives logged", logged(calls, "Next drives: C M"))
 
     w.on_free_space("C", 300 * 1024 * 1024)
-    check("free space in path label", "300.0 MB free" in w.next_path_label.text()
+    check("free space in top label", "300.0 MB free" in w.next_path_label.text()
           and "#2fb344" in w.next_path_label.text())
+    check("the path lives in the bottom box, not the top label",
+          w.next_path_edit.text() == "/")
     w.on_free_space("C", None)
     check("failed free query clears the figure",
-          w.next_path_label.text() == "Next: /")
+          w.next_path_label.text() == "Next: connected")
 
     w.on_disconnected()
     check("disconnect clears pane", not w._connected
           and w.next_model.rowCount() == 0
           and not w.next_drive_combo.isEnabled()
-          and w.next_drive_combo.count() == 0)
+          and w.next_drive_combo.count() == 0
+          and w.next_path_edit.text() == ""
+          and not w.next_path_edit.isEnabled())
 
     # Old dot: no getdrives reply -> lone implicit drive, switcher disabled.
     w.on_connected()
@@ -391,7 +398,7 @@ def test_listing_and_rendering():
     w.on_listing("/GAMES", [(False, 10, "a.tap")])
     check("subdir listing pins ..", next_names(w) == ["..", "a.tap"])
     check("subdir cwd persisted", calls["remote_cwd"] == ["/GAMES"])
-    check("path label follows", w.next_path_label.text() == "Next: /GAMES")
+    check("path box follows", w.next_path_edit.text() == "/GAMES")
 
     # Colours: push a custom file colour, the existing row re-tints in place.
     w.set_item_colors({"file_name": QColor("#804020"), "bogus": QColor("red"),
@@ -432,6 +439,28 @@ def test_navigation():
     w._cwd = "/games"
     check("_in_cwd nested", w._in_cwd("/games/x.tap")
           and not w._in_cwd("/games/sub/y.tap") and not w._in_cwd("/other"))
+
+    # Typed navigation: the path box is the fourth way to move (after
+    # double-click, Up and the drive combo) — ENTER lists the typed folder.
+    calls["q"].clear()
+    w.next_path_edit.setText("games/sub")
+    w._on_next_path_edit()
+    check("typed relative path navigates absolute",
+          w._cwd == "/games/sub" and drain(calls) == [("ls", "/games/sub")])
+    w.next_path_edit.setText("M:data\\deep")
+    w._on_next_path_edit()
+    check("typed drive path normalises and navigates",
+          w._cwd == "M:/data/deep" and drain(calls) == [("ls", "M:/data/deep")])
+    w.next_path_edit.setText("D:/nope")
+    w._on_next_path_edit()
+    check("unknown drive letter refused (dot-crash guard)",
+          w._cwd == "M:/data/deep" and drain(calls) == []
+          and logged(calls, "Unknown Next drive D")
+          and w.next_path_edit.text() == "M:/data/deep")
+    w.next_path_edit.setText("   ")
+    w._on_next_path_edit()
+    check("blank entry restores the cwd",
+          drain(calls) == [] and w.next_path_edit.text() == "M:/data/deep")
 
 
 def test_drive_switching():

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.11"
+ZX_NEXT_UNITE_VERSION = "9.5.12"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -583,6 +583,10 @@ class RemoteExplorerWidget(QWidget):
         # set_idle_details_style so the panel follows them live.
         self._idle_info_color = "#a6f0a6"
         self._idle_info_pt = 12
+        # Top-bar label: the idle status while disconnected, the drive's free
+        # space while connected. The PATH itself lives in next_path_edit at
+        # the bottom of the pane since the UX pass that aligned it with the
+        # local pane's sync-root box (both panes: bar / tree / path row).
         self.next_path_label = QLabel("Next: (not connected)", self)
         next_up = CompactButton("Up", self)
         next_up.clicked.connect(self._next_up)
@@ -623,7 +627,16 @@ class RemoteExplorerWidget(QWidget):
         next_box.addLayout(next_bar)
         next_box.addWidget(self.next_view)
 
-        # Next-side toolbar: New Folder / Rename / Delete
+        # Under the tree, mirroring the local pane's sync-root row: the Next
+        # path box (type a folder, ENTER lists it) with the New Folder /
+        # Rename / Delete toolbar to its right.
+        self.next_path_edit = QLineEdit(self)
+        self.next_path_edit.setPlaceholderText("Next folder...")
+        self.next_path_edit.setToolTip(
+            "The Next folder shown above. Type a path (e.g. /games or "
+            "m:/data) and press Enter to jump to it.")
+        self.next_path_edit.setEnabled(False)
+        self.next_path_edit.returnPressed.connect(self._on_next_path_edit)
         self.btn_new_folder = QPushButton("New Folder", self)
         self.btn_new_folder.clicked.connect(self._new_folder)
         self.btn_rename = QPushButton("Rename", self)
@@ -632,10 +645,10 @@ class RemoteExplorerWidget(QWidget):
         self.btn_delete.clicked.connect(self._delete_selected)
         next_tools = QHBoxLayout()
         next_tools.setContentsMargins(0, 0, 0, 0)
+        next_tools.addWidget(self.next_path_edit, 1)
         next_tools.addWidget(self.btn_new_folder)
         next_tools.addWidget(self.btn_rename)
         next_tools.addWidget(self.btn_delete)
-        next_tools.addStretch(1)
         next_box.addLayout(next_tools)
         next_container = QWidget(self)
         next_container.setLayout(next_box)
@@ -1099,12 +1112,15 @@ class RemoteExplorerWidget(QWidget):
     def _set_connected(self, on):
         self._connected = on
         for w in (self.btn_to_next, self.btn_to_local, self.btn_new_folder,
-                  self.btn_rename, self.btn_delete, self.next_view):
+                  self.btn_rename, self.btn_delete, self.next_view,
+                  self.next_path_edit):
             w.setEnabled(on)
         if not on:
             self.next_model.removeRows(0, self.next_model.rowCount())
             self.next_path_label.setText(self._idle_status_text())
             self.next_path_label.setToolTip("")
+            self.next_path_edit.setText("")
+            self.next_path_edit.setModified(False)
             self._free_space.clear()   # a reconnect re-reads it
             self._drives = []
             self._default_drive = ""
@@ -1222,17 +1238,16 @@ class RemoteExplorerWidget(QWidget):
         return "#e03131"           # red: nearly full
 
     def _update_next_path_label(self):
-        """Path label = cwd + the cached free space of its drive (if known).
+        """Top label = the cached free space of the cwd's drive (if known);
+        bottom path box = the cwd itself (mirroring the local pane's row).
         The free-space figure is bold and traffic-light coloured (see
         _free_color) so a filling-up card is visible at a glance."""
         free = self._free_space.get(self._cwd_drive())
         if free is not None:
             # Rich text so only the free-space part is coloured; the label
-            # auto-detects HTML. &nbsp; keeps the double-space look that the
-            # plain-text form used (rich text collapses runs of spaces).
+            # auto-detects HTML.
             self.next_path_label.setText(
-                f"Next: {html.escape(self._cwd)}&nbsp;&nbsp;—&nbsp;&nbsp;"
-                f"<b><span style=\"color: {self._free_color(free)};\">"
+                f"Next: <b><span style=\"color: {self._free_color(free)};\">"
                 f"{html.escape(self._fmt_free(free))} free</span></b>")
             self.next_path_label.setToolTip(
                 f"Free space on drive {self._cwd_drive()}: {free} bytes "
@@ -1242,8 +1257,13 @@ class RemoteExplorerWidget(QWidget):
                 "· red: below 100 MB.\nRe-read after every transfer, "
                 "delete, rename or copy, so the figure tracks the card.")
         else:
-            self.next_path_label.setText(f"Next: {self._cwd}")
+            self.next_path_label.setText("Next: connected")
             self.next_path_label.setToolTip("")
+        # Never stomp a path the user is midway through typing: setText only
+        # while the box carries no uncommitted edit (isModified is cleared by
+        # setText and by _on_next_path_edit committing).
+        if not self.next_path_edit.isModified():
+            self.next_path_edit.setText(self._cwd)
 
     def _known_drives(self):
         """Every drive the combo offers: the dot-reported set plus the
@@ -1656,6 +1676,33 @@ class RemoteExplorerWidget(QWidget):
             self._cwd = _re_norm_dir(
                 posixpath.dirname(self._cwd.rstrip("/")) or "/")
             self.refresh()
+
+    def _on_next_path_edit(self):
+        """ENTER in the Next path box: jump the pane to the typed folder.
+
+        A typed drive letter is checked against the known set first —
+        merely opening a path on an unmounted drive CRASHES the dot (the
+        hardware rule '+ Drive' warns about), so an unknown letter is
+        refused with a pointer at '+ Drive' instead of being probed. A
+        folder that turns out not to exist is handled like any dead
+        listing (on_listing_failed backs off to the drive root)."""
+        if not self._connected:
+            return
+        raw = (self.next_path_edit.text() or "").strip().strip('"')
+        self.next_path_edit.setModified(False)
+        if not raw:
+            self.next_path_edit.setText(self._cwd)
+            return
+        path = _norm_remote_dir(raw)
+        drive = _re_drive_of(path)
+        known = self._known_drives()
+        if drive and known and drive not in known:
+            self._log(f"Unknown Next drive {drive}: — use '+ Drive' to add "
+                      "an extra SD reader/partition letter first.")
+            self.next_path_edit.setText(self._cwd)
+            return
+        self._cwd = path
+        self.refresh()
 
     def _next_double_clicked(self, index):
         item = self.next_model.itemFromIndex(index.siblingAtColumn(0))


### PR DESCRIPTION
UX symmetry with the local pane (both panes now read bar / tree / path row): the Next cwd used to live top-right inside the free-space label while the local sync root sat in a box under its tree. The path is now a QLineEdit under the Next pane - it follows navigation, and typing a folder (`/games`, `m:/data`, backslashes tolerated) + ENTER lists it. New Folder / Rename / Delete move to the right of the box. The top-right label keeps the idle status and the traffic-light free space.

A typed drive letter is checked against the known drives first (the '+ Drive' hardware rule: opening a path on an unmounted drive crashes the dot) - unknown letters are refused with a log pointer, never probed. Nonexistent folders fall into the existing dead-listing recovery. The box never stomps a half-typed path, and empties/disables while disconnected.

Includes the 9.5.12 version bump. Widget tests extended; full suite green (22 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)