### PR TITLE
SD Card tab: the image-history dropdown stays open when clicked; 9.5.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.12"
+version = "9.5.13"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -85,7 +85,7 @@ DROPSRC = os.path.join(SCRATCH, "dropsrc.txt")
 DELZONE = os.path.join(SCRATCH, "delzone")
 
 PHASE = int(sys.argv[1]) if len(sys.argv) > 1 else None
-ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+ALL_PHASES = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
 
 # Base cfg for the isolated app copy: update checks off (MAME/CSpect AND the
 # app's own GitHub release check) so no phase ever hits the network, and the
@@ -287,6 +287,20 @@ elif PHASE == 13:
     with _zf.ZipFile(DLZIP_SRC, "w", _zf.ZIP_DEFLATED) as z:
         z.writestr("2gb/cspect-next-2gb.img", b"\x00" * 65536)
         z.writestr("2gb/version.txt", "test feed")
+elif PHASE == 14:
+    # REGRESSION (reported): clicking the image-history dropdown arrow
+    # populated the list and instantly closed it again, reloading the
+    # already-loaded image — on Windows the opening click's own release
+    # can "activate" the current entry when the (long-path-widened) popup
+    # lands under the cursor. The fix: activating the ALREADY-LOADED image
+    # is a no-op, and when it arrives within the opening half-second the
+    # dropdown is put straight back up. The phantom itself needs real
+    # cursor geometry, so this phase drives the GUARD directly.
+    ensure_scratch(fresh=False)
+    with open(CFG, "w") as f:
+        f.write(BASE_CFG
+                + "image_history=C:/imgs/one.img|C:/imgs/two.img\n"
+                + "hddffile=C:/imgs/one.img\n")
 elif PHASE == 11:
     # NextSync Remote Explorer with pygame absent (every phase blocks pygame —
     # see _NoPygame). The retro log needs pygame; the Remote Explorer's dual
@@ -1340,11 +1354,69 @@ def inspect_phase13():
     app.quit()
 
 
+def inspect_phase14():
+    """The image-history dropdown's phantom-activation guard: activating
+    the ALREADY-LOADED entry right after the popup opened must not reload
+    and must put the popup back up; activating a DIFFERENT entry must
+    load it. The Windows phantom itself needs real cursor geometry, so the
+    guard is driven directly via the combo's activated signal."""
+    app = QApplication.instance()
+    win = find_win()
+    check("MainWindow found", win is not None)
+    if win is None:
+        app.quit(); return
+
+    wait_until(lambda: not getattr(win, "_emulator_scan_pending", False),
+               what="emulator scan settled")
+
+    combo = win.imageinput
+    # The cfg's hddffile cannot really load (no such file), so mark it as
+    # the loaded image by hand — the guard compares against this.
+    win.right_disk_image_path = "C:\\imgs\\one.img"
+    combo.setCurrentIndex(0)
+    win.diskimageexplorerpathinput.setText("(sentinel)")
+
+    # Phantom: activation of the loaded entry, popup freshly opened.
+    combo._popup_shown_at = time.monotonic()
+    combo.activated.emit(0)
+    ok = wait_until(lambda: combo.view().isVisible(), timeout=5,
+                    what="popup re-shown after phantom")
+    check("phantom activation re-opens the dropdown", ok)
+    check("phantom activation does not reload",
+          win.diskimageexplorerpathinput.text() == "(sentinel)",
+          win.diskimageexplorerpathinput.text())
+    combo.hidePopup()
+
+    # Same no-op pick long after opening: no reload AND no re-open.
+    combo._popup_shown_at = time.monotonic() - 5.0
+    combo.activated.emit(0)
+    settle_end = time.monotonic() + 0.7
+    while time.monotonic() < settle_end:
+        QCoreApplication.processEvents()
+        time.sleep(0.02)
+    check("late no-op pick neither reloads nor re-opens",
+          win.diskimageexplorerpathinput.text() == "(sentinel)"
+          and not combo.view().isVisible())
+
+    # Genuine pick of a DIFFERENT entry loads it (timing irrelevant).
+    combo._popup_shown_at = time.monotonic()
+    combo.setCurrentIndex(1)
+    combo.activated.emit(1)
+    check("picking another entry loads it",
+          win.diskimageexplorerpathinput.text() != "(sentinel)",
+          win.diskimageexplorerpathinput.text())
+    settle_end = time.monotonic() + 1.0
+    while time.monotonic() < settle_end:
+        QCoreApplication.processEvents()
+        time.sleep(0.02)
+    app.quit()
+
+
 INSPECTORS = {1: inspect_phase1, 2: inspect_phase2, 3: inspect_phase3,
               4: inspect_phase4, 5: inspect_phase5, 6: inspect_phase6,
               7: inspect_phase7, 8: inspect_phase8, 9: inspect_phase9,
               10: inspect_phase10, 11: inspect_phase11, 12: inspect_phase12,
-              13: inspect_phase13}
+              13: inspect_phase13, 14: inspect_phase14}
 
 _orig_exec = QApplication.exec
 def _patched_exec(*_a):

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.12"
+ZX_NEXT_UNITE_VERSION = "9.5.13"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -964,6 +964,20 @@ def _apply_completer_fix_to_children(widget: QWidget):
 IMAGE_DRAG_MIME = "application/x-zxnu-image-paths"
 
 
+class _ImagePathCombo(QComboBox):
+    """The SD-image path box. showPopup stamps WHEN the history dropdown
+    opened, so the activation wiring can tell a real pick from the Windows
+    "phantom activation" — the very click that opens the dropdown also
+    "activating" the current entry when the (long-path-widened) popup lands
+    under the cursor. Reported as: the history list appeared and instantly
+    vanished while the already-loaded image reloaded. See the
+    imageinput.activated wiring in MainWindow.setupUI."""
+
+    def showPopup(self):
+        self._popup_shown_at = time.monotonic()
+        super().showPopup()
+
+
 class _CompleterPopupHider(QtCore.QObject):
     """Hide a manually-shown autocomplete popup when its line edit loses focus.
 
@@ -2309,7 +2323,7 @@ class MainWindow(QMainWindow):
         self.horizontal16 = QHBoxLayout()
 
 
-        self.imageinput = QComboBox()
+        self.imageinput = _ImagePathCombo()
         self.imageinput.setEditable(True)
         self.imageinput.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
         self.imageinput.setToolTip(
@@ -2321,8 +2335,28 @@ class MainWindow(QMainWindow):
         self.imageinput.lineEdit().setPlaceholderText("SD card image path...")
         # Pressing Enter in the editable field triggers a load attempt
         self.imageinput.lineEdit().returnPressed.connect(lambda: load_image())
-        # Selecting an item from the history dropdown loads it immediately
-        self.imageinput.activated.connect(lambda _index: load_image())
+
+        # Selecting an item from the history dropdown loads it immediately —
+        # UNLESS the activation is the opening click's own echo. On Windows
+        # the click that OPENS the dropdown can also "activate" the current
+        # entry (the popup, widened by long history paths, lands under the
+        # cursor): the list flashed shut while the already-loaded image
+        # reloaded (reported). Two guards: activating the image that is
+        # ALREADY loaded is a no-op (there is nothing to load), and when
+        # that no-op arrives within the opening half-second — the phantom's
+        # signature — the dropdown is put straight back up, so the user
+        # gets the list the click asked for.
+        def _image_history_activated(index):
+            picked = normalize_sd_image_path(self.imageinput.itemText(index))
+            loaded = normalize_sd_image_path(
+                (getattr(self, "right_disk_image_path", "") or "").strip())
+            if picked and picked == loaded:
+                opened_at = getattr(self.imageinput, "_popup_shown_at", 0.0)
+                if time.monotonic() - opened_at < 0.5:
+                    QTimer.singleShot(0, self.imageinput.showPopup)
+                return
+            load_image()
+        self.imageinput.activated.connect(_image_history_activated)
         self.selectimage = QPushButton("ToDisk", self)
         self.selectimage.setText("Select NextZXOS disk Image")
         # (was `self.selectimage.toolTip = "..."` — a plain attribute that


### PR DESCRIPTION
Reported (with video): pressing the little arrow populated the history list and it immediately disappeared - and the already-loaded image reloaded. On Windows the very click that OPENS the dropdown can also "activate" the current entry: with long history paths the popup is wide enough to land under the cursor, and Qt treats the opening interaction as a pick of the current item. Reproduced deterministically with the real config; clean-room configs never trigger it (short paths keep the popup out from under the cursor).

The fix breaks the kill chain in the `activated` wiring: activating the image that is ALREADY loaded is a no-op (previously it re-ran the whole load, disabling the controls and rewriting the history model - which is what killed the popup), and when that no-op arrives within half a second of `showPopup` (the phantom's signature, stamped by the new `_ImagePathCombo` subclass) the dropdown is put straight back up. Picking any other entry loads it immediately, exactly as before.

Verified end-to-end on the real platform with the real config. New offscreen phase 14 drives the guard directly in CI. Full suite green (22 files). Includes the 9.5.13 version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)