### PR TITLE
9.5.14: the last-look UX set - reopen where and how the user left

### DIFF
--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.13"
+ZX_NEXT_UNITE_VERSION = "9.5.14"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync
@@ -350,6 +350,17 @@ SETTING_SDCARD_SPLITTER        = "sdcard_splitter_sizes"   # "top,bottom" pane h
 SETTING_GETIT_SPLITTER         = "getit_splitter_sizes"    # "top,bottom" pane heights (px) of the GetIt results ⇄ MOTD splitter
 SETTING_HELP_PYGAME_LOG        = "help_pygame_log"         # "true" => retro 8-bit pygame console on the "?" Help tab, else classic list
 SETTING_RETRO_LOG_FONT_SIZE    = "retro_log_font_size"    # int point size for the retro 8-bit log windows (SD Card + NextSync)
+# ---- the last-look UX set (9.5.14): captured at every save (so the final
+# closeEvent save carries the shutdown truth), restored before first paint —
+# the user returns to the monitor, window size and explorer layouts they
+# left. Column widths are "w1,w2,..." px strings; anything missing or
+# garbled leaves Qt's defaults untouched.
+SETTING_WINDOW_SCREEN          = "window_screen"           # QScreen.name() the window sat on at shutdown
+SETTING_WINDOW_SIZE            = "window_size"             # "WxH" px of the main window at shutdown
+SETTING_SDCARD_TREE_COLS       = "sdcard_tree_columns"     # SD Card utility: LOCAL explorer column widths
+SETTING_IMAGE_TREE_COLS        = "image_tree_columns"      # SD Card utility: IMAGE explorer column widths
+SETTING_RE_LOCAL_COLS          = "re_local_tree_columns"   # Remote Explorer: local pane column widths
+SETTING_RE_NEXT_COLS           = "re_next_tree_columns"    # Remote Explorer: Next pane column widths
 SETTING_ITCHIO_API_KEY         = "itchio_api_key"          # str: personal itch.io API key (https://itch.io/user/settings/api-keys)
 SETTING_SHOW_ITCHIO_TAB        = "show_itchio_tab"         # "false" => hide the itch.io tab (default shown when itch-dl is installed)
 SETTING_ITCHIO_VIEW_MODE       = "itchio_view_mode"        # "gallery" (default) or "table"
@@ -930,7 +941,27 @@ SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_
 SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_NEXTSYNC_REMOTE_EXPLORER, SETTING_NEXTSYNC_REMOTE_CWD, SETTING_NEXTSYNC_RE_LOCAL_SORT, SETTING_NEXTSYNC_RE_NEXT_SORT, SETTING_NEXTSYNC_EXTRA_DRIVES, SETTING_NEXTSYNC_HTTP_BRIDGE, SETTING_NEXTSYNC_HTTP_PORT, SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT, SETTING_NEXTSYNC_HTTP_VERBOSE, SETTING_NEXTSYNC_HTTP_TOKEN_ENABLED, SETTING_NEXTSYNC_HTTP_TOKEN, SETTING_SDCARD_PYGAME_LOG, SETTING_SDCARD_SPLITTER, SETTING_GETIT_SPLITTER, SETTING_HELP_PYGAME_LOG, SETTING_RETRO_LOG_FONT_SIZE,
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK, SETTING_ZXNU_UPDATE_CHECK, SETTING_DOTN_LAST_VERSION, SETTING_DELETE_TO_RECYCLE_BIN,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO, SETTING_UI_LANGUAGE,
-SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN, SETTING_WIZARD_FONT_SIZE, SETTING_WIZARD_SP_OFFERED)
+SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN, SETTING_WIZARD_FONT_SIZE, SETTING_WIZARD_SP_OFFERED,
+SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS)
+
+
+def apply_tree_column_widths(tree, pref):
+    """Apply a saved ``"w1,w2,..."`` column-width string to a QTreeView.
+
+    The restore half of the last-look UX set (9.5.14). Forgiving on
+    purpose: a missing/garbled value leaves Qt's defaults exactly as
+    before the feature existed, extra widths beyond the model's columns
+    are ignored by Qt, and widths under 24 px are skipped so a stray 0
+    can never vanish a column for good."""
+    if tree is None:
+        return
+    try:
+        widths = [int(v) for v in str(pref).split(",") if v.strip()]
+    except (TypeError, ValueError):
+        return
+    for i, w in enumerate(widths):
+        if w >= 24:
+            tree.setColumnWidth(i, w)
 
 IMAGE_BUTTONS_SIZE = 190
 DISK_ARROWS_BUTTONS_SIZE = 30

--- a/zxnu_config_io.py
+++ b/zxnu_config_io.py
@@ -26,7 +26,7 @@ import logging
 import os
 
 from PySide6.QtCore import (Qt, QTimer)
-from PySide6.QtGui import (QPixmap)
+from PySide6.QtGui import (QGuiApplication, QPixmap)
 
 from zxnu_config import *
 from zxnu_i18n import ui_tr_now
@@ -628,6 +628,48 @@ def build_config_io(
                     if not getattr(host, "_re_running", False):
                         host._nextsync_re_toggle_server()
                 QTimer.singleShot(0, _autostart_re_listener)
+
+            # ---- the last-look UX restore (9.5.14): size first, then the
+            # remembered monitor, then the explorer column widths — the
+            # window is not shown yet, so all of it lands before first
+            # paint. The Remote Explorer panes restore in the pane builder
+            # (they do not exist yet); anything missing or garbled leaves
+            # the defaults exactly as before the feature.
+            _win_pref = str(configuration_dictionary.get(
+                SETTING_WINDOW_SIZE, "")).strip()
+            if "x" in _win_pref:
+                try:
+                    _win_w, _win_h = (int(_v) for _v in
+                                      _win_pref.split("x")[:2])
+                    if _win_w >= 640 and _win_h >= 480:
+                        host.resize(_win_w, _win_h)
+                except (TypeError, ValueError):
+                    pass
+            _scr_pref = str(configuration_dictionary.get(
+                SETTING_WINDOW_SCREEN, "")).strip()
+            if _scr_pref:
+                for _scr in QGuiApplication.screens():
+                    if _scr.name() != _scr_pref:
+                        continue
+                    # Centre on the remembered monitor, clamped to it — a
+                    # monitor that shrank (or a saved size that outgrew
+                    # it) must not park the window off-screen. A monitor
+                    # that is GONE simply falls through to Qt's default
+                    # placement on the primary.
+                    _av = _scr.availableGeometry()
+                    _fit_w = min(host.width(), _av.width())
+                    _fit_h = min(host.height(), _av.height())
+                    host.resize(_fit_w, _fit_h)
+                    host.move(_av.x() + (_av.width() - _fit_w) // 2,
+                              _av.y() + (_av.height() - _fit_h) // 2)
+                    break
+            for _cols_key, _cols_attr in (
+                (SETTING_SDCARD_TREE_COLS, "treeview"),
+                (SETTING_IMAGE_TREE_COLS, "image_treeview"),
+            ):
+                apply_tree_column_widths(
+                    getattr(host, _cols_attr, None),
+                    configuration_dictionary.get(_cols_key, ""))
 
             # Restore the saved splitter positions (SD Card explorers ⇄
             # log, GetIt results ⇄ MOTD). The window is not shown yet, so

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -1966,6 +1966,48 @@ class MainWindow(QMainWindow):
                 if clean and clean not in history_items:
                     history_items.append(clean)
             configuration_dictionary[SETTING_IMAGE_HISTORY] = "|".join(history_items)
+
+            # ---- the last-look UX capture (9.5.14): the monitor, window
+            # size and explorer column widths as they stand RIGHT NOW, so
+            # the closeEvent save carries the shutdown truth and the next
+            # start restores the look the user left. The Remote Explorer
+            # widget is built lazily — while it has never been opened this
+            # run, its previously saved widths survive untouched (the keys
+            # are only overwritten when a live tree can answer).
+            try:
+                _win = self.window()
+                _handle = _win.windowHandle()
+                _scr = _handle.screen() if _handle is not None else None
+                if _scr is not None:
+                    configuration_dictionary[SETTING_WINDOW_SCREEN] = _scr.name()
+                configuration_dictionary[SETTING_WINDOW_SIZE] = (
+                    f"{_win.width()}x{_win.height()}")
+            except RuntimeError:
+                pass                    # window mid-teardown: keep saved
+
+            def _tree_cols(_tree):
+                if _tree is None or _tree.model() is None:
+                    return None
+                _hdr = _tree.header()
+                return ",".join(str(_hdr.sectionSize(_i))
+                                for _i in range(_hdr.count()))
+
+            _re_w = getattr(self, "_re_widget", None)
+            for _cols_key, _cols_tree in (
+                (SETTING_SDCARD_TREE_COLS, getattr(self, "treeview", None)),
+                (SETTING_IMAGE_TREE_COLS,
+                 getattr(self, "image_treeview", None)),
+                (SETTING_RE_LOCAL_COLS,
+                 getattr(_re_w, "local_view", None) if _re_w else None),
+                (SETTING_RE_NEXT_COLS,
+                 getattr(_re_w, "next_view", None) if _re_w else None),
+            ):
+                try:
+                    _cols_val = _tree_cols(_cols_tree)
+                except RuntimeError:
+                    _cols_val = None    # widget mid-teardown: keep saved
+                if _cols_val:
+                    configuration_dictionary[_cols_key] = _cols_val
             #save_configuration_file()
 
         # ── Emulator ops (extracted to zxnu_emulator_ops.py): the CSpect/MAME

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -825,6 +825,17 @@ def build_nextsync_pane(
             on_toast=lambda title, msg, variant="red": host._show_toast(
                 title, msg, variant=variant, duration_ms=9000))
         host._re_widget = widget
+        # The last-look UX restore (9.5.14) for these lazily-built panes:
+        # config_io's startup restore cannot reach them (they may not be
+        # created for hours, or ever), so the saved column widths apply
+        # here, the moment the trees exist. Capture stays central — the
+        # save hook reads the live trees whenever the widget exists.
+        apply_tree_column_widths(
+            widget.local_view,
+            configuration_dictionary.get(SETTING_RE_LOCAL_COLS, ""))
+        apply_tree_column_widths(
+            widget.next_view,
+            configuration_dictionary.get(SETTING_RE_NEXT_COLS, ""))
         # ---- mini log under the explorer panes (2026-08-07): tracing the
         # bridge/server activity used to require flipping to the Classic
         # tab — which, before the same-day fix, even stopped the server.


### PR DESCRIPTION
Persists at shutdown and restores before first paint:

- **Monitor**: the `QScreen.name()` the window sat on — restored by centring the window on that monitor, clamped to its available geometry (a vanished monitor falls through to Qt's primary placement; a shrunken one can never strand the window off-screen).
- **Window size**: `WxH`, applied before show.
- **Tree column widths** for all four explorer trees: SD Card utility local + image explorers (restored at startup), Remote Explorer local + Next panes (restored in the pane builder, since they're lazily created; their saved widths are only overwritten when the live trees exist at save time).

Capture rides the existing `get_pyhdfmgooey_currenttab_config()` hook so the `closeEvent` save carries the shutdown truth. Six readable `key=value` lines in hdfg.cfg; missing/garbled values leave Qt's defaults untouched. Full suite: ALL PASS (offscreen UI startup phase included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)