### PR TITLE
Per-machine remote folders: every Next comes back to where it left off

### DIFF
--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -361,6 +361,7 @@ SETTING_SDCARD_TREE_COLS       = "sdcard_tree_columns"     # SD Card utility: LO
 SETTING_IMAGE_TREE_COLS        = "image_tree_columns"      # SD Card utility: IMAGE explorer column widths
 SETTING_RE_LOCAL_COLS          = "re_local_tree_columns"   # Remote Explorer: local pane column widths
 SETTING_RE_NEXT_COLS           = "re_next_tree_columns"    # Remote Explorer: Next pane column widths
+SETTING_RE_REMOTE_CWDS         = "re_remote_cwds"          # JSON {"ip": "/last/folder"} per connected Next (multi-Next; capped at 24, oldest out)
 SETTING_ITCHIO_API_KEY         = "itchio_api_key"          # str: personal itch.io API key (https://itch.io/user/settings/api-keys)
 SETTING_SHOW_ITCHIO_TAB        = "show_itchio_tab"         # "false" => hide the itch.io tab (default shown when itch-dl is installed)
 SETTING_ITCHIO_VIEW_MODE       = "itchio_view_mode"        # "gallery" (default) or "table"
@@ -942,7 +943,7 @@ SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_P
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK, SETTING_ZXNU_UPDATE_CHECK, SETTING_DOTN_LAST_VERSION, SETTING_DELETE_TO_RECYCLE_BIN,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO, SETTING_UI_LANGUAGE,
 SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN, SETTING_WIZARD_FONT_SIZE, SETTING_WIZARD_SP_OFFERED,
-SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS)
+SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS, SETTING_RE_REMOTE_CWDS)
 
 
 def apply_tree_column_widths(tree, pref):

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -21,6 +21,7 @@ ever rebinding it first. See CLAUDE.md and the memory
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import platform
@@ -731,15 +732,46 @@ def build_nextsync_pane(
                 pass
         _re_update_start_button()
 
-    def _re_on_remote_cwd_changed(path):
+    def _re_on_remote_cwd_changed(path, addr=None):
         # The widget reports the Next-side folder it's now showing. Persist it
         # so the next (re)connect jumps straight back to it (fires only when
-        # the folder actually changes, so this stays cheap).
+        # the folder — or the machine — actually changes, so this stays
+        # cheap). Since 9.5.14 the report carries the active peer's ADDRESS:
+        # each machine gets its own entry in a JSON map, so the Next that
+        # lived in /A and the N-Go that lived in /SYS each come back to
+        # their own folder (a vanished folder fails its first listing and
+        # the widget drops to root by itself). The generic key stays as the
+        # fallback for machines never seen before.
         try:
             configuration_dictionary[SETTING_NEXTSYNC_REMOTE_CWD] = (path or "/")
+            if addr:
+                try:
+                    _map = json.loads(str(configuration_dictionary.get(
+                        SETTING_RE_REMOTE_CWDS, "") or "{}"))
+                    if not isinstance(_map, dict):
+                        _map = {}
+                except (ValueError, TypeError):
+                    _map = {}
+                _map.pop(str(addr), None)      # re-insert = newest
+                _map[str(addr)] = (path or "/")
+                while len(_map) > 24:          # keep the cfg tidy: oldest out
+                    _map.pop(next(iter(_map)))
+                configuration_dictionary[SETTING_RE_REMOTE_CWDS] = (
+                    json.dumps(_map, separators=(",", ":")))
             save_configuration_file()
         except Exception:
             pass
+
+    def _re_remote_cwd_for(addr):
+        # The restore half: this machine's remembered folder, or None so the
+        # widget falls back to the generic last-folder.
+        try:
+            _map = json.loads(str(configuration_dictionary.get(
+                SETTING_RE_REMOTE_CWDS, "") or "{}"))
+            _v = _map.get(str(addr), "") if isinstance(_map, dict) else ""
+            return _v if isinstance(_v, str) and _v else None
+        except (ValueError, TypeError):
+            return None
 
     def _re_on_sort_changed(which, value):
         # The widget reports a new column sort ("<key>:<asc|desc>") for one of
@@ -814,6 +846,7 @@ def build_nextsync_pane(
             drain=_re_drain, on_sync_root_changed=_re_on_sync_root_changed,
             remote_start_dir=remote_cwd,
             on_remote_cwd_changed=_re_on_remote_cwd_changed,
+            remote_cwd_for=_re_remote_cwd_for,
             local_sort=local_sort, next_sort=next_sort,
             on_sort_changed=_re_on_sort_changed,
             extra_drives=extra_drives,

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -271,7 +271,8 @@ class RemoteExplorerWidget(QWidget):
                  drain=None, on_sync_root_changed=None, remote_start_dir=None,
                  on_remote_cwd_changed=None, local_sort=None, next_sort=None,
                  on_sort_changed=None, on_toast=None, extra_drives=None,
-                 on_extra_drives_changed=None, emulator_entries=None):
+                 on_extra_drives_changed=None, emulator_entries=None,
+                 remote_cwd_for=None):
         super().__init__(parent)
         self._enqueue_raw = enqueue          # host closure: put one command
         self._drain_raw = drain              # host closure: empty the queue, -> count
@@ -289,7 +290,14 @@ class RemoteExplorerWidget(QWidget):
         # Persist/restore the Next-side folder across (re)connections: on connect
         # we jump back to the last folder browsed, and every listing reports the
         # new folder to the host so it can save it (see on_connected/on_listing).
-        self._on_remote_cwd_changed = on_remote_cwd_changed or (lambda p: None)
+        # Since 9.5.14 both directions are PER-MACHINE: the report carries the
+        # active peer's address, and remote_cwd_for(addr) answers with that
+        # machine's remembered folder (the generic remote_start_dir stays as
+        # the fallback for a machine never seen before).
+        self._on_remote_cwd_changed = (on_remote_cwd_changed or
+                                       (lambda p, a=None: None))
+        self._remote_cwd_for = remote_cwd_for
+        self._remote_cwd_addr = None         # last addr a folder was reported for
         self._remote_start_dir = _norm_remote_dir(remote_start_dir)
         # Per-pane sort (column + direction), restored from the config and saved
         # via on_sort_changed(which, "<key>:<asc|desc>") whenever the user clicks
@@ -1148,11 +1156,26 @@ class RemoteExplorerWidget(QWidget):
         self._update_idle_info_overlay()
 
     # ---- worker signal slots (UI thread) ------------------------------
+    def _active_addr(self):
+        """The ACTIVE peer's address, from the worker's roster (multi-Next).
+        None while no roster arrived — the worker emits the roster before
+        connected, so on_connected always has it."""
+        for _sid, _addr in self._peer_map:
+            if _sid == self._peer_active:
+                return _addr
+        return None
+
     def on_connected(self):
         self._set_connected(True)
-        # Jump straight back to the folder we were last browsing. If it's gone,
-        # the listing fails and on_ls_failed() drops us back to the root.
-        self._cwd = self._remote_start_dir or "/"
+        # Jump straight back to the folder we were last browsing. Per-machine
+        # first (9.5.14): THIS Next's remembered folder — keyed by its
+        # address, fed by the host — wins; the generic last-folder covers a
+        # machine never seen before. If the folder is gone, the listing
+        # fails and on_ls_failed() drops us back to the root.
+        _addr = self._active_addr()
+        _saved = (self._remote_cwd_for(_addr)
+                  if (_addr and self._remote_cwd_for) else None)
+        self._cwd = _saved or self._remote_start_dir or "/"
         # Ask which drives are mounted (dot v5.1+) before the first listing so
         # the drive switcher fills in as the pane appears.
         self._enqueue(("drives",))
@@ -1503,11 +1526,15 @@ class RemoteExplorerWidget(QWidget):
 
     def _remember_remote_cwd(self, path):
         """Record the current Next folder for restore-on-reconnect, notifying the
-        host (which persists it) only when it actually changes."""
+        host (which persists it, per machine since 9.5.14) only when the folder
+        — or the MACHINE it belongs to — actually changes: two Nexts sitting on
+        the same path must still each get their own entry."""
         norm = _norm_remote_dir(path)
-        if norm != self._remote_start_dir:
+        addr = self._active_addr()
+        if norm != self._remote_start_dir or addr != self._remote_cwd_addr:
             self._remote_start_dir = norm
-            self._on_remote_cwd_changed(norm)
+            self._remote_cwd_addr = addr
+            self._on_remote_cwd_changed(norm, addr)
 
     # ==================================================================
     #  column sort (persisted per pane; default Name ascending)

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -1600,9 +1600,13 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
             with plock:
                 peers[sid]['thread'] = th
             th.start()
+            # Roster BEFORE connected (9.5.14): the widget's on_connected
+            # consults the active peer's ADDRESS for its per-machine
+            # remembered folder, so the roster must already be in its
+            # hands — cross-thread queued signals preserve this order.
+            _emit_peers()
             if first:
                 sig.connected.emit()   # 0 -> 1: "a Next is available"
-            _emit_peers()
     except Exception as ex:                                   # noqa: BLE001
         # Never die silently: report, then re-raise so the failure still
         # reaches the log/crash handler.


### PR DESCRIPTION
Completes multi-Next (#274): the Remote Explorer's remembered Next-side folder becomes per-machine, keyed by peer address in a `re_remote_cwds` JSON map (capped at 24, oldest out) with the old single key kept as the fallback for never-seen machines.

- The folder report (`on_remote_cwd_changed`) carries the active peer's address; the gate also fires on a machine change so two Nexts sitting on the same path still get their own entries.
- `on_connected` (first connect *and* every combo switch) consults the per-machine entry first; a vanished folder fails its first listing and the existing `on_ls_failed` reverts to root.
- The worker emits the roster before `connected` (queued cross-thread signals preserve order), so the address is always known when the first listing fires.
- No disconnect/exit hooks: every machine's last good folder is persisted at listing time, covering leave, switch, server stop and app exit alike.

Full suite: ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)