### PR TITLE
Hotfix: _peer_map init + widget-test callback contract

### DIFF
--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -121,7 +121,10 @@ def make_widget(**kw):
         drain=kw.get("drain"),
         on_sync_root_changed=calls["sync_root"].append,
         remote_start_dir=kw.get("remote_start_dir"),
-        on_remote_cwd_changed=calls["remote_cwd"].append,
+        # (path, addr) since the per-machine folders: the widget reports the
+        # active peer's address too. The tests only assert on the PATH, so
+        # the recorder keeps storing just that.
+        on_remote_cwd_changed=lambda p, a=None: calls["remote_cwd"].append(p),
         local_sort=kw.get("local_sort"),
         next_sort=kw.get("next_sort"),
         on_sort_changed=lambda which, v: calls["sorts"].append((which, v)),

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -626,6 +626,13 @@ class RemoteExplorerWidget(QWidget):
         # peers signal (on_peers). Every other connected Next stays on the
         # line, idling, and keeps its place.
         self._peer_active = None
+        self._peer_map = []            # [(sid, addr)] — the last roster; MUST
+                                       # exist from birth: on_connected reads
+                                       # it via _active_addr, and only the
+                                       # live app guarantees a roster arrived
+                                       # first (the widget test calls
+                                       # on_connected directly — the missing
+                                       # init was CI failure #31717960490)
         self._peer_guard = False
         self.next_machine_combo = QComboBox(self)
         self.next_machine_combo.setToolTip(


### PR DESCRIPTION
Fixes CI run 31717960490 (the #277 merge): `_peer_map` was only assigned by the peers signal, so the widget test's direct `on_connected()` crashed (the live app survives because the worker emits the roster first — now the attribute exists from `__init__`); and the test harness's bare `list.append` recorder broke on the new `(path, addr)` report — it now accepts the address and keeps asserting on the path.

Full suite green, verified by grepping the summary for FAIL lines (run_all.py's exit code stays 0 through a failing suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)