### PR TITLE
9.5.15: departure-save, baton to last-connected, always-visible combo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.13"
+version = "9.5.15"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.14"
+ZX_NEXT_UNITE_VERSION = "9.5.15"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -1202,6 +1202,11 @@ class RemoteExplorerWidget(QWidget):
         if self._op_active:
             self._log("Connection ended; stopped the running operation.")
             self._end_operation()
+        # The roster died with the worker: forget it, so a fresh worker's
+        # sids can never collide with stale ones (the auto-relisten spins
+        # a new worker whose sequence restarts at 1).
+        self._peer_map = []
+        self._peer_active = None
 
     def on_peers(self, payload):
         """The worker's connected-Nexts roster (multi-Next, option B):
@@ -1216,6 +1221,21 @@ class RemoteExplorerWidget(QWidget):
         except (TypeError, ValueError):
             return
         prev = self._peer_active
+        # The baton is leaving `prev` (a user pick answered, or that Next
+        # just disconnected): persist the folder ON SCREEN under the OLD
+        # machine's address RIGHT NOW, from the roster we still hold —
+        # the listing-time save covers confirmed navigations, this covers
+        # the departure itself, so a machine that leaves mid-browse still
+        # comes back to where it was.
+        if prev is not None and active != prev and self._connected:
+            _old_addr = None
+            for _sid, _addr in self._peer_map:
+                if _sid == prev:
+                    _old_addr = _addr
+                    break
+            if _old_addr:
+                self._on_remote_cwd_changed(_norm_remote_dir(self._cwd),
+                                            _old_addr)
         self._peer_active = active
         self._peer_guard = True
         try:
@@ -1225,7 +1245,10 @@ class RemoteExplorerWidget(QWidget):
                 if sid == active:
                     self.next_machine_combo.setCurrentIndex(
                         self.next_machine_combo.count() - 1)
-            self.next_machine_combo.setVisible(len(plist) >= 2)
+            # Visible whenever ANY Next is on the line (field request: a
+            # lone machine still shows WHO the pane drives); hidden only
+            # while the roster is empty.
+            self.next_machine_combo.setVisible(len(plist) >= 1)
         finally:
             self._peer_guard = False
         if active is not None and prev is not None and active != prev:

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -1477,7 +1477,10 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                   'emit_peers': _emit_peers}
 
         while not stop_event.is_set():
-            # Reap ended sessions; hand the baton on if the active died.
+            # Reap ended sessions; hand the baton on if the active died —
+            # to the LAST-CONNECTED survivor (max sid), the machine the
+            # user most recently brought to the party (field request:
+            # min() handed it to the oldest, which read as arbitrary).
             with plock:
                 dead = [d for d, p in peers.items()
                         if p['thread'] is not None
@@ -1485,7 +1488,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
                 for d in dead:
                     del peers[d]
                 if state['active'] not in peers:
-                    state['active'] = min(peers) if peers else None
+                    state['active'] = max(peers) if peers else None
             if dead:
                 _emit_peers()
             if state['had_any'] and not peers:


### PR DESCRIPTION
Three field reports from the first real two-machine day:

- **Departure-save**: the on-screen folder is persisted under the *old* active machine's address at every baton change — user pick and disconnect alike — so a Next that leaves mid-browse comes back to where it was.
- **Baton to the last-connected survivor** (`max` sid) when the active machine dies; the combo and view follow it as before.
- **The machine combo stays visible with one Next** — it names who the pane drives.
- Lifecycle: the widget forgets its roster when the worker dies (no stale-sid collisions with a relistened worker's fresh sequence).
- Release plumbing: 9.5.14's tag was refused by the version guard (`pyproject.toml` still 9.5.13) — both version homes now say **9.5.15**; the dead v9.5.14 tag is removed and v9.5.15 supersedes it.

Full suite: ALL PASS (verified by summary grep; an earlier offscreen FAIL was a teardown-race flake under parallel load, green in isolation and in the final quiet run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)