### PR TITLE
9.5.16: keep the peer roster — per-machine folders actually work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.15"
+version = "9.5.16"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -123,8 +123,12 @@ def make_widget(**kw):
         remote_start_dir=kw.get("remote_start_dir"),
         # (path, addr) since the per-machine folders: the widget reports the
         # active peer's address too. The tests only assert on the PATH, so
-        # the recorder keeps storing just that.
-        on_remote_cwd_changed=lambda p, a=None: calls["remote_cwd"].append(p),
+        # the default recorder keeps storing just that; the multi-Next test
+        # substitutes a host-like per-address store for both halves.
+        on_remote_cwd_changed=kw.get(
+            "on_remote_cwd_changed",
+            lambda p, a=None: calls["remote_cwd"].append(p)),
+        remote_cwd_for=kw.get("remote_cwd_for"),
         local_sort=kw.get("local_sort"),
         next_sort=kw.get("next_sort"),
         on_sort_changed=lambda which, v: calls["sorts"].append((which, v)),
@@ -464,6 +468,45 @@ def test_navigation():
     w._on_next_path_edit()
     check("blank entry restores the cwd",
           drain(calls) == [] and w.next_path_edit.text() == "M:/data/deep")
+
+
+def test_multi_next_folders_follow_the_baton():
+    """Two Nexts, one pane (9.5.15): each machine's folder is keyed by its
+    ADDRESS, and every baton change — a user pick or a departure — restores
+    the incoming machine's own folder. The field bug this pins down: the
+    widget read its peer roster without ever storing it, so all machines
+    shared one folder and the survivor of a disconnect woke up in the
+    departed machine's directory."""
+    saved = {}   # the host's per-machine store: addr -> folder
+    w, calls = make_widget(
+        local_start_dir=tdir("mnx_root"),
+        remote_cwd_for=saved.get,
+        on_remote_cwd_changed=lambda p, a=None: (
+            saved.__setitem__(a, p) if a else None))
+    w.on_peers((1, [(1, "192.168.1.10")]))   # the roster precedes connected
+    connect_widget(w, calls)
+    w.on_listing("/A", [])                   # browsing the first Next
+    check("a confirmed listing is saved under the machine's address",
+          saved.get("192.168.1.10") == "/A", str(saved))
+
+    # An N-Go joins and the user picks it (the worker confirms via peers).
+    w.on_peers((2, [(1, "192.168.1.10"), (2, "192.168.1.20")]))
+    check("machine combo carries both", w.next_machine_combo.count() == 2)
+    check("the baton move re-reads the new card", ("drives",) in drain(calls))
+    w.on_drives("C", ["C"])
+    w.on_listing("/Home", [])                # browsing the N-Go
+
+    # The N-Go drops off; the worker hands the baton back to the survivor.
+    w.on_peers((1, [(1, "192.168.1.10")]))
+    check("the departing machine's folder was saved on the way out",
+          saved.get("192.168.1.20") == "/Home", str(saved))
+    check("the survivor returns to ITS folder, not the departed one's",
+          w._cwd == "/A", w._cwd)
+    check("...and the queued listing asks for it",
+          ("ls", "/A") in drain(calls))
+    check("combo shrinks to the survivor",
+          w.next_machine_combo.count() == 1
+          and w.next_machine_combo.itemData(0) == 1)
 
 
 def test_drive_switching():
@@ -1463,6 +1506,7 @@ def main():
         test_initial_and_connection_state()
         test_listing_and_rendering()
         test_navigation()
+        test_multi_next_folders_follow_the_baton()
         test_drive_switching()
         test_ls_failed_fallback()
         test_sorting()

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.15"
+ZX_NEXT_UNITE_VERSION = "9.5.16"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -1236,6 +1236,13 @@ class RemoteExplorerWidget(QWidget):
             if _old_addr:
                 self._on_remote_cwd_changed(_norm_remote_dir(self._cwd),
                                             _old_addr)
+        # KEEP the roster: _active_addr() answers from it, which is what
+        # keys every per-machine folder save and restore. The assignment
+        # must sit exactly here — after the departure-save (which resolves
+        # the OLD active sid against the roster we held until now) and
+        # before the baton-move reconnect below (whose on_connected looks
+        # up the NEW active machine's folder).
+        self._peer_map = [(sid, addr) for sid, addr in plist]
         self._peer_active = active
         self._peer_guard = True
         try:


### PR DESCRIPTION
## The bug (first two-machine field day)

Browse `/A` on a Next, connect an N-Go and browse `/Home`, then the N-Go drops: the combo hands the baton back to the surviving Next — but the pane restores `/Home`, not `/A`.

## Root cause

The 9.5.14 per-machine remote folders and the 9.5.15 departure-save both read the peer roster through `_active_addr()`, and **no commit ever stored the roster**: `on_peers` rebuilt the machine combo from the payload and dropped it, so `_peer_map` was only ever assigned `[]`. Every address lookup answered `None`, every save landed on the one generic last-folder key, and every restore fell back to it — all machines silently shared a single folder. The departure-save was a no-op for the same reason (it could not resolve the old sid in an empty map). The host's per-address JSON store was correct all along; it was never fed a real address.

## Fix

`on_peers` now keeps the roster, placed exactly between the departure-save (which resolves the OLD active sid against the roster held until now) and the baton-move reconnect (whose `on_connected` looks up the NEW machine's folder).

## Tests

New `test_multi_next_folders_follow_the_baton` scripts the exact field day — two machines, a user pick, a departure — and fails on the unfixed code with exactly the reported symptom (survivor restored `/Home`). Full suite green, verified by grepping the summary for FAIL lines.

## Notes

- This effectively activates the whole 9.5.14 feature for the first time: even single-Next reconnects only ever used the generic folder until now. The cfg's per-address map (capped at 24) starts accumulating for real.
- Version bumped in BOTH homes: `pyproject.toml` and `zxnu_config.py` say 9.5.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)