### PR TITLE
9.5.17: 'Open' in both local explorers; Remote Explorer server autostart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.16"
+version = "9.5.17"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -1130,6 +1130,38 @@ def test_local_file_operations():
           and any("Unzip complete" in t[0] for t in calls["toasts"]))
 
 
+def test_local_open_with_shell():
+    """Context-menu 'Open' on the local pane: the selected item goes to the
+    OS shell's associated application. The hand-off itself is faked — the
+    test asserts WHAT is handed over and that a refusal is reported, without
+    launching anything on the test machine."""
+    root = tdir("open_root")
+    w, calls = make_widget(local_start_dir=root)
+    page = tfile(root, "page.html", b"<html></html>")
+    opened = []
+    orig = rex.open_path_with_system_shell
+    rex.open_path_with_system_shell = lambda p: (opened.append(p), True)[1]
+    try:
+        w._local_open_selected()
+        check("no selection -> nothing handed to the shell", opened == [])
+        select_local(w, page)
+        w._local_open_selected()
+        check("Open hands the selected item to the OS shell",
+              len(opened) == 1 and samepath(opened[0], page), str(opened))
+        rex.open_path_with_system_shell = lambda p: False
+        w._local_open_selected()
+        check("a refused open is reported in the log",
+              logged(calls, "could not open"), str(calls["log"]))
+    finally:
+        rex.open_path_with_system_shell = orig
+    # The real helper's existence guard needs no OS: a vanished path answers
+    # False before any shell is involved.
+    from zxnu_config import open_path_with_system_shell
+    check("helper refuses a vanished path without touching the shell",
+          open_path_with_system_shell(os.path.join(root, "gone.html")) is False
+          and open_path_with_system_shell("") is False)
+
+
 def test_drag_and_drop():
     root = tdir("dnd_root")
     w, calls = make_widget(local_start_dir=root)
@@ -1521,6 +1553,7 @@ def main():
         test_sync_root_and_local_pane()
         test_modified_column_local_time()
         test_local_file_operations()
+        test_local_open_with_shell()
         test_drag_and_drop()
         test_arrow_pulse_and_overlay_resize()
         test_idle_status_provider()

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -565,12 +565,12 @@ def inspect_phase1():
     def spos(w):
         i = lay.indexOf(w)
         return None if i < 0 else lay.getItemPosition(i)[:2]
-    check("general-text swatch at settings (23,1)",
-          spos(win.settings_btn_color_general_text) == (24, 1), str(spos(win.settings_btn_color_general_text)))
-    check("retro-log swatch right under it (25,1)",
-          spos(win.settings_btn_color_retro_log) == (25, 1), str(spos(win.settings_btn_color_retro_log)))
-    check("retro font combo pushed to (26,1)",
-          spos(win.settings_retro_log_font_combo) == (26, 1), str(spos(win.settings_retro_log_font_combo)))
+    check("general-text swatch at settings (25,1)",
+          spos(win.settings_btn_color_general_text) == (25, 1), str(spos(win.settings_btn_color_general_text)))
+    check("retro-log swatch right under it (26,1)",
+          spos(win.settings_btn_color_retro_log) == (26, 1), str(spos(win.settings_btn_color_retro_log)))
+    check("retro font combo pushed to (27,1)",
+          spos(win.settings_retro_log_font_combo) == (27, 1), str(spos(win.settings_retro_log_font_combo)))
     check("default retro color is phosphor green",
           win.img_color_retro_log.name().lower() == "#78ff8c", win.img_color_retro_log.name())
     check("default swatch shows phosphor green",
@@ -861,6 +861,42 @@ def inspect_phase6():
     check("no-prompt checkbox above it (5,0)",
           spos(win.settings_no_prompt_on_deletion_checkbox) == (5, 0),
           str(spos(win.settings_no_prompt_on_deletion_checkbox)))
+    # The RE-autostart toggle owns row 7 (freed by shifting every row that
+    # was ≥ 7 down one — 9.5.16); the send-conflict row sits right under it.
+    ac = win.settings_re_autostart_checkbox
+    check("RE-autostart toggle at settings (7,0)", spos(ac) == (7, 0),
+          str(spos(ac)))
+    check("send-conflict combo pushed to (8,1)",
+          spos(win.settings_nextsync_send_conflict_combo) == (8, 1),
+          str(spos(win.settings_nextsync_send_conflict_combo)))
+    check("RE-autostart default off", not ac.isChecked())
+    # Ticking it WITHOUT a sync root must refuse: the box reverts to off
+    # (with a toast advising to set one) and nothing lands in the cfg.
+    ac.setChecked(True)
+    QCoreApplication.processEvents()
+    check("RE-autostart tick without a sync root reverts to off",
+          not ac.isChecked())
+    check("...and is not persisted",
+          not any(l.startswith("nextsync_re_autostart=true")
+                  for l in cfg_lines()),
+          str([l for l in cfg_lines()
+               if l.startswith("nextsync_re_autostart")]))
+    # With a sync root on record the tick sticks and persists.
+    win._re_sync_root = os.path.dirname(CFG)
+    ac.setChecked(True)
+    QCoreApplication.processEvents()
+    check("RE-autostart tick with a sync root sticks", ac.isChecked())
+    check("...and persists to cfg",
+          "nextsync_re_autostart=true" in cfg_lines(),
+          str([l for l in cfg_lines()
+               if l.startswith("nextsync_re_autostart")]))
+    win._re_sync_root = ""
+    ac.setChecked(False)
+    QCoreApplication.processEvents()
+    check("unticking persists off", "nextsync_re_autostart=false" in cfg_lines(),
+          str([l for l in cfg_lines()
+               if l.startswith("nextsync_re_autostart")]))
+
     if rb.isEnabled():
         check("cfg 'false' restored as unchecked (recycle)", not rb.isChecked())
         rb.setChecked(True)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.16"
+ZX_NEXT_UNITE_VERSION = "9.5.17"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync
@@ -378,6 +378,7 @@ SETTING_ITCHIO_ITEM_RETRO      = "itchio_item_retro"
 SETTING_FAVORITES_ITEM_RETRO   = "favorites_item_retro"
 SETTING_NEXTSYNC_PYGAME_ANIM   = "nextsync_pygame_anim"    # "false" => freeze the starfield in the NextSync retro log (default on)
 SETTING_NEXTSYNC_REMOTE_EXPLORER = "nextsync_remote_explorer"  # "true" => reopen the NextSync tab in Remote Explorer view (default off = classic sync)
+SETTING_NEXTSYNC_RE_AUTOSTART  = "nextsync_re_autostart"   # "true" => start the Remote Explorer '.sync5 -listen' server on startup (default off; needs a sync root)
 SETTING_NEXTSYNC_REMOTE_CWD    = "nextsync_remote_cwd"     # last Next-side folder browsed in the Remote Explorer, restored on reconnect (falls back to "/" if gone)
 SETTING_NEXTSYNC_RE_LOCAL_SORT = "nextsync_re_local_sort"  # Remote Explorer local pane sort, "<name|size|type>:<asc|desc>" (default "name:asc")
 SETTING_NEXTSYNC_RE_NEXT_SORT  = "nextsync_re_next_sort"   # Remote Explorer Next pane sort, "<name|size|type>:<asc|desc>" (default "name:asc")
@@ -447,6 +448,28 @@ def subprocess_no_window_kwargs(extra_flags=0, gui_app=False):
         startupinfo.wShowWindow = subprocess.SW_HIDE
         kwargs["startupinfo"] = startupinfo
     return kwargs
+
+def open_path_with_system_shell(path):
+    """Hand ``path`` to the operating system so whatever the OS associates
+    with it opens it: the default browser for a .html, the image viewer for
+    a .png, the file manager for a folder. Used by the local explorers'
+    context-menu "Open". Returns True when the hand-off happened — what the
+    launched application does afterwards is the OS's business, so there is
+    nothing more to report. False means the path is gone or the OS refused
+    (no association, no handler); the caller owns telling the user."""
+    if not path or not os.path.exists(path):
+        return False
+    try:
+        if sys.platform == "win32":
+            os.startfile(path)
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", path])
+        else:
+            subprocess.Popen(["xdg-open", path])
+        return True
+    except OSError:
+        return False
+
 def zxart_legal_status_label(code) -> str:
     """Return a human-readable label for a zxArt ``legalStatus`` code.
 
@@ -939,7 +962,7 @@ SETTING_GALLERY_ROWS_PER_PAGE, SETTING_GALLERY_COLS, SETTING_GALLERY_IMG_SIZE, S
 SETTING_ZXART_VIEW_MODE, SETTING_ZXART_LANGUAGE, SETTING_FAVORITES, SETTING_FAVORITES_VIEW_MODE,
 SETTING_ALLINONE_VIEW_MODE, SETTING_ALLINONE_PYGAME_MODE, SETTING_ALLINONE_PYGAME_ANIM, SETTING_BG_IMAGE, SETTING_CRASH_LOG_ENABLED, SETTING_MAME_COMMAND_LINE_PARAMETERS,
 SETTING_DISABLE_NO_EMULATOR_TOAST, SETTING_MAME_ROM_CHOICE, SETTING_MAME_UPDATE_CHECK, SETTING_MAME_INSTALLED_TAG, SETTING_MAME_ASPECT, SETTING_MAME_SOUND, SETTING_MAME_MOUSE, SETTING_MAME_JOYSTICK, SETTING_MAME_ESC, SETTING_MAME_FLATPAK, SETTING_MAME_FLATPAK_ROMPATH, SETTING_ALIEN_FLOYD_BG, SETTING_ALIEN_FLOYD_TAB, SETTING_ALIEN_FLOYD_HISCORE, SETTING_ALIEN_FLOYD_HISCORES,
-SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_NEXTSYNC_REMOTE_EXPLORER, SETTING_NEXTSYNC_REMOTE_CWD, SETTING_NEXTSYNC_RE_LOCAL_SORT, SETTING_NEXTSYNC_RE_NEXT_SORT, SETTING_NEXTSYNC_EXTRA_DRIVES, SETTING_NEXTSYNC_HTTP_BRIDGE, SETTING_NEXTSYNC_HTTP_PORT, SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT, SETTING_NEXTSYNC_HTTP_VERBOSE, SETTING_NEXTSYNC_HTTP_TOKEN_ENABLED, SETTING_NEXTSYNC_HTTP_TOKEN, SETTING_SDCARD_PYGAME_LOG, SETTING_SDCARD_SPLITTER, SETTING_GETIT_SPLITTER, SETTING_HELP_PYGAME_LOG, SETTING_RETRO_LOG_FONT_SIZE,
+SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_PYGAME_ANIM, SETTING_NEXTSYNC_REMOTE_EXPLORER, SETTING_NEXTSYNC_RE_AUTOSTART, SETTING_NEXTSYNC_REMOTE_CWD, SETTING_NEXTSYNC_RE_LOCAL_SORT, SETTING_NEXTSYNC_RE_NEXT_SORT, SETTING_NEXTSYNC_EXTRA_DRIVES, SETTING_NEXTSYNC_HTTP_BRIDGE, SETTING_NEXTSYNC_HTTP_PORT, SETTING_NEXTSYNC_HTTP_CONNECTION_LIMIT, SETTING_NEXTSYNC_HTTP_VERBOSE, SETTING_NEXTSYNC_HTTP_TOKEN_ENABLED, SETTING_NEXTSYNC_HTTP_TOKEN, SETTING_SDCARD_PYGAME_LOG, SETTING_SDCARD_SPLITTER, SETTING_GETIT_SPLITTER, SETTING_HELP_PYGAME_LOG, SETTING_RETRO_LOG_FONT_SIZE,
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK, SETTING_ZXNU_UPDATE_CHECK, SETTING_DOTN_LAST_VERSION, SETTING_DELETE_TO_RECYCLE_BIN,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO, SETTING_UI_LANGUAGE,
 SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN, SETTING_WIZARD_FONT_SIZE, SETTING_WIZARD_SP_OFFERED,

--- a/zxnu_config_io.py
+++ b/zxnu_config_io.py
@@ -610,13 +610,28 @@ def build_config_io(
                 finally:
                     host._re_open_restoring = False
 
+            # Settings: "Automatically start Remote Explorer server on
+            # startup". Restore the checkbox silently (its change handler
+            # saves + guards; a restore must do neither) …
+            _re_auto_pref = str(configuration_dictionary.get(
+                SETTING_NEXTSYNC_RE_AUTOSTART, "") or "").strip().lower()
+            _re_auto_on = _re_auto_pref in ("true", "1", "yes")
+            _re_auto_cb = getattr(host, "settings_re_autostart_checkbox", None)
+            if _re_auto_cb is not None:
+                _re_auto_cb.blockSignals(True)
+                _re_auto_cb.setChecked(_re_auto_on)
+                _re_auto_cb.blockSignals(False)
+
             # -start-remote-explorer-listener: the command-line switch asks
-            # for the '.sync5 -listen' server to be running from startup.
-            # Force the Remote Explorer view open (without persisting it —
-            # this run only, hence the _re_open_restoring guard) and start
-            # the server once the event loop is up, so the toasts, log
-            # pane and server closures it talks to all exist by then.
-            if _zxnu_start_re_listener() and hasattr(host, "nextsync_mode_tabs"):
+            # for the '.sync5 -listen' server to be running from startup —
+            # and since 9.5.16 the Settings autostart checkbox asks for the
+            # same thing persistently. Force the Remote Explorer view open
+            # (without persisting it — this run only, hence the
+            # _re_open_restoring guard) and start the server once the event
+            # loop is up, so the toasts, log pane and server closures it
+            # talks to all exist by then.
+            if ((_zxnu_start_re_listener() or _re_auto_on)
+                    and hasattr(host, "nextsync_mode_tabs")):
                 if host.nextsync_mode_tabs.currentIndex() != 0:
                     host._re_open_restoring = True
                     try:
@@ -625,8 +640,20 @@ def build_config_io(
                         host._re_open_restoring = False
 
                 def _autostart_re_listener():
-                    if not getattr(host, "_re_running", False):
-                        host._nextsync_re_toggle_server()
+                    if getattr(host, "_re_running", False):
+                        return
+                    # The sync root the checkbox was gated on can be gone by
+                    # now (folder deleted/renamed since). The listen guard
+                    # would refuse with only a log line — say it visibly
+                    # too, the same advisory the Settings tick shows.
+                    if not getattr(host, "_re_sync_root", ""):
+                        host._show_toast(
+                            "Remote Explorer autostart not enabled",
+                            "Define a sync root folder first, on the "
+                            "NextSync tab's Remote Explorer view.",
+                            variant="yellow", duration_ms=5000)
+                        return
+                    host._nextsync_re_toggle_server()
                 QTimer.singleShot(0, _autostart_re_listener)
 
             # ---- the last-look UX restore (9.5.14): size first, then the

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -291,7 +291,10 @@ CATALOGS = {
          'partition). Selecting a drive that is not mounted CRASHES the Next.'):
             ('Añade solo una unidad que exista de verdad en tu Next (un lector SD o '
              'partición adicional). Seleccionar una unidad no montada BLOQUEA el Next.'),
+        'Open': 'Abrir',
         'Open in {source}': 'Abrir en {source}',
+        'Open: the system could not open {name}.':
+            'Abrir: el sistema no pudo abrir {name}.',
         'Open on website (zxart.ee)': 'Abrir en el sitio web (zxart.ee)',
         'Open on website (zxinfo.dk)': 'Abrir en el sitio web (zxinfo.dk)',
         'Paste': 'Pegar',
@@ -348,6 +351,8 @@ CATALOGS = {
         "MAME ROM / system:": "ROM / sistema de MAME:",
         "MAME default launch parameters:": "Parámetros de arranque de MAME:",
         "Max connections:": "Conexiones máx.:",
+        "NextSync — Automatically start Remote Explorer server on startup":
+            "NextSync — Iniciar automáticamente el servidor del Remote Explorer al arrancar",
         "NextSync — when a sent file or directory exists locally:":
             "NextSync — si un archivo o directorio recibido ya existe localmente:",
         "Page:": "Página:",
@@ -1389,7 +1394,10 @@ CATALOGS = {
             ('Adiciona apenas uma unidade que exista mesmo no teu Next (um leitor SD '
              'ou partição adicional). Selecionar uma unidade não montada BLOQUEIA o '
              'Next.'),
+        'Open': 'Abrir',
         'Open in {source}': 'Abrir em {source}',
+        'Open: the system could not open {name}.':
+            'Abrir: o sistema não conseguiu abrir {name}.',
         'Open on website (zxart.ee)': 'Abrir no site (zxart.ee)',
         'Open on website (zxinfo.dk)': 'Abrir no site (zxinfo.dk)',
         'Paste': 'Colar',
@@ -1446,6 +1454,8 @@ CATALOGS = {
         "MAME ROM / system:": "ROM / sistema do MAME:",
         "MAME default launch parameters:": "Parâmetros de arranque do MAME:",
         "Max connections:": "Ligações máx.:",
+        "NextSync — Automatically start Remote Explorer server on startup":
+            "NextSync — Iniciar automaticamente o servidor do Remote Explorer no arranque",
         "NextSync — when a sent file or directory exists locally:":
             "NextSync — se um ficheiro ou diretório recebido já existir localmente:",
         "Page:": "Página:",
@@ -2485,7 +2495,10 @@ CATALOGS = {
          'partition). Selecting a drive that is not mounted CRASHES the Next.'):
             ('Dodawaj tylko dysk, który naprawdę istnieje w Twoim Nexcie (dodatkowy '
              'czytnik SD lub partycja). Wybranie niezamontowanego dysku ZAWIESZA Nexta.'),
+        'Open': 'Otwórz',
         'Open in {source}': 'Otwórz w {source}',
+        'Open: the system could not open {name}.':
+            'Otwórz: system nie mógł otworzyć {name}.',
         'Open on website (zxart.ee)': 'Otwórz na stronie (zxart.ee)',
         'Open on website (zxinfo.dk)': 'Otwórz na stronie (zxinfo.dk)',
         'Paste': 'Wklej',
@@ -2542,6 +2555,8 @@ CATALOGS = {
         "MAME ROM / system:": "ROM / system MAME:",
         "MAME default launch parameters:": "Parametry uruchamiania MAME:",
         "Max connections:": "Maks. połączeń:",
+        "NextSync — Automatically start Remote Explorer server on startup":
+            "NextSync — Automatycznie uruchamiaj serwer Remote Explorera przy starcie",
         "NextSync — when a sent file or directory exists locally:":
             "NextSync — gdy odebrany plik lub katalog już istnieje lokalnie:",
         "Page:": "Strona:",
@@ -3583,7 +3598,10 @@ CATALOGS = {
             ('Добавляйте только диск, который действительно есть в вашем Next '
              '(дополнительный SD-ридер или раздел). Выбор несмонтированного диска '
              'ПРИВОДИТ К СБОЮ Next.'),
+        'Open': 'Открыть',
         'Open in {source}': 'Открыть в {source}',
+        'Open: the system could not open {name}.':
+            'Открыть: система не смогла открыть {name}.',
         'Open on website (zxart.ee)': 'Открыть на сайте (zxart.ee)',
         'Open on website (zxinfo.dk)': 'Открыть на сайте (zxinfo.dk)',
         'Paste': 'Вставить',
@@ -3640,6 +3658,8 @@ CATALOGS = {
         "MAME ROM / system:": "ROM / система MAME:",
         "MAME default launch parameters:": "Параметры запуска MAME:",
         "Max connections:": "Макс. подключений:",
+        "NextSync — Automatically start Remote Explorer server on startup":
+            "NextSync — Автоматически запускать сервер Remote Explorer при запуске",
         "NextSync — when a sent file or directory exists locally:":
             "NextSync — если принятый файл или каталог уже существует локально:",
         "Page:": "Страница:",
@@ -4680,7 +4700,10 @@ CATALOGS = {
          'partition). Selecting a drive that is not mounted CRASHES the Next.'):
             ('Přidávejte jen jednotku, která na vašem Nextu opravdu existuje (další '
              'čtečka SD nebo oddíl). Výběr nepřipojené jednotky Next SHODÍ.'),
+        'Open': 'Otevřít',
         'Open in {source}': 'Otevřít v {source}',
+        'Open: the system could not open {name}.':
+            'Otevřít: systém nemohl otevřít {name}.',
         'Open on website (zxart.ee)': 'Otevřít na webu (zxart.ee)',
         'Open on website (zxinfo.dk)': 'Otevřít na webu (zxinfo.dk)',
         'Paste': 'Vložit',
@@ -4737,6 +4760,8 @@ CATALOGS = {
         "MAME ROM / system:": "ROM / systém MAME:",
         "MAME default launch parameters:": "Parametry spouštění MAME:",
         "Max connections:": "Max. připojení:",
+        "NextSync — Automatically start Remote Explorer server on startup":
+            "NextSync — Automaticky spouštět server Remote Exploreru při startu",
         "NextSync — when a sent file or directory exists locally:":
             "NextSync — když přijatý soubor či adresář už místně existuje:",
         "Page:": "Stránka:",
@@ -5778,7 +5803,10 @@ CATALOGS = {
             ("N'ajoutez qu'un lecteur qui existe vraiment sur votre Next (un lecteur "
              'SD ou une partition supplémentaire). Sélectionner un lecteur non monté '
              'FAIT PLANTER le Next.'),
+        'Open': 'Ouvrir',
         'Open in {source}': 'Ouvrir dans {source}',
+        'Open: the system could not open {name}.':
+            'Ouvrir : le système n’a pas pu ouvrir {name}.',
         'Open on website (zxart.ee)': 'Ouvrir sur le site (zxart.ee)',
         'Open on website (zxinfo.dk)': 'Ouvrir sur le site (zxinfo.dk)',
         'Paste': 'Coller',
@@ -5836,6 +5864,8 @@ CATALOGS = {
         "MAME ROM / system:": "ROM / système MAME :",
         "MAME default launch parameters:": "Paramètres de lancement de MAME :",
         "Max connections:": "Connexions max :",
+        "NextSync — Automatically start Remote Explorer server on startup":
+            "NextSync — Démarrer automatiquement le serveur du Remote Explorer au lancement",
         "NextSync — when a sent file or directory exists locally:":
             "NextSync — si un fichier ou dossier reçu existe déjà en local :",
         "Page:": "Page :",
@@ -6838,6 +6868,9 @@ _TOAST_CATALOGS = {
         "NextSync HTTP bridge started": "Passerelle HTTP NextSync démarrée",
         "NextSync HTTP bridge not started": "Passerelle HTTP NextSync non démarrée",
         "Remote Explorer NextSync server not started": "Serveur NextSync du Remote Explorer non démarré",
+        "Remote Explorer autostart not enabled": "Démarrage automatique du Remote Explorer non activé",
+        "Define a sync root folder first, on the NextSync tab's Remote Explorer view.":
+            "Définissez d'abord un dossier racine de synchronisation dans la vue Remote Explorer de l'onglet NextSync.",
         "Next connected": "Next connecté",
         "A Next is now connected to the NextSync Remote Explorer.":
             "Un Next est maintenant connecté au Remote Explorer NextSync.",
@@ -6951,6 +6984,9 @@ _TOAST_CATALOGS = {
         "NextSync HTTP bridge started": "Puente HTTP de NextSync iniciado",
         "NextSync HTTP bridge not started": "Puente HTTP de NextSync no iniciado",
         "Remote Explorer NextSync server not started": "Servidor NextSync del Remote Explorer no iniciado",
+        "Remote Explorer autostart not enabled": "Autoarranque del Remote Explorer no activado",
+        "Define a sync root folder first, on the NextSync tab's Remote Explorer view.":
+            "Define primero una carpeta raíz de sincronización en la vista Remote Explorer de la pestaña NextSync.",
         "Next connected": "Next conectado",
         "A Next is now connected to the NextSync Remote Explorer.":
             "Un Next está ahora conectado al Remote Explorer de NextSync.",
@@ -7064,6 +7100,9 @@ _TOAST_CATALOGS = {
         "NextSync HTTP bridge started": "Ponte HTTP NextSync iniciada",
         "NextSync HTTP bridge not started": "Ponte HTTP NextSync não iniciada",
         "Remote Explorer NextSync server not started": "Servidor NextSync do Remote Explorer não iniciado",
+        "Remote Explorer autostart not enabled": "Arranque automático do Remote Explorer não ativado",
+        "Define a sync root folder first, on the NextSync tab's Remote Explorer view.":
+            "Define primeiro uma pasta raiz de sincronização na vista Remote Explorer do separador NextSync.",
         "Next connected": "Next ligado",
         "A Next is now connected to the NextSync Remote Explorer.":
             "Um Next está agora ligado ao Remote Explorer do NextSync.",
@@ -7177,6 +7216,9 @@ _TOAST_CATALOGS = {
         "NextSync HTTP bridge started": "Mostek HTTP NextSync uruchomiony",
         "NextSync HTTP bridge not started": "Mostek HTTP NextSync nie został uruchomiony",
         "Remote Explorer NextSync server not started": "Serwer NextSync Remote Explorera nie został uruchomiony",
+        "Remote Explorer autostart not enabled": "Autostart Remote Explorera nie został włączony",
+        "Define a sync root folder first, on the NextSync tab's Remote Explorer view.":
+            "Najpierw wskaż folder główny synchronizacji w widoku Remote Explorer na karcie NextSync.",
         "Next connected": "Next połączony",
         "A Next is now connected to the NextSync Remote Explorer.":
             "Next jest teraz połączony z Remote Explorerem NextSync.",
@@ -7290,6 +7332,9 @@ _TOAST_CATALOGS = {
         "NextSync HTTP bridge started": "HTTP-мост NextSync запущен",
         "NextSync HTTP bridge not started": "HTTP-мост NextSync не запущен",
         "Remote Explorer NextSync server not started": "Сервер NextSync Remote Explorer не запущен",
+        "Remote Explorer autostart not enabled": "Автозапуск Remote Explorer не включён",
+        "Define a sync root folder first, on the NextSync tab's Remote Explorer view.":
+            "Сначала задайте корневую папку синхронизации в виде Remote Explorer на вкладке NextSync.",
         "Next connected": "Next подключён",
         "A Next is now connected to the NextSync Remote Explorer.":
             "Next подключён к Remote Explorer NextSync.",
@@ -7403,6 +7448,9 @@ _TOAST_CATALOGS = {
         "NextSync HTTP bridge started": "HTTP most NextSync spuštěn",
         "NextSync HTTP bridge not started": "HTTP most NextSync nebyl spuštěn",
         "Remote Explorer NextSync server not started": "Server NextSync Remote Exploreru nebyl spuštěn",
+        "Remote Explorer autostart not enabled": "Automatické spuštění Remote Exploreru nebylo zapnuto",
+        "Define a sync root folder first, on the NextSync tab's Remote Explorer view.":
+            "Nejprve nastavte kořenovou složku synchronizace v zobrazení Remote Explorer na kartě NextSync.",
         "Next connected": "Next připojen",
         "A Next is now connected to the NextSync Remote Explorer.":
             "Next je nyní připojen k Remote Exploreru NextSync.",

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -34,7 +34,7 @@ from PySide6.QtWidgets import (
 from zxnu_config import (
     DEFAULT_COLOR_UP_DIRECTORY, DEFAULT_COLOR_DIR_NAME, DEFAULT_COLOR_DIR_TYPE,
     DEFAULT_COLOR_FILE_NAME, DEFAULT_COLOR_FILE_EXT, DEFAULT_COLOR_FILE_SIZE,
-    DEFAULT_COLOR_GENERAL_TEXT, hex_to_qcolor,
+    DEFAULT_COLOR_GENERAL_TEXT, hex_to_qcolor, open_path_with_system_shell,
 )
 from zxnu_workers import (
     CompactButton, DotDotFirstProxyModel, HdfProgressDialog,
@@ -2979,6 +2979,13 @@ class RemoteExplorerWidget(QWidget):
                 emu_local.append((menu.addAction(entry.label), entry))
             if emu_local:
                 menu.addSeparator()
+        # "Open" hands the item to the OS shell: a .html opens in the
+        # browser, a folder in the file manager. The emulator entries above
+        # keep the top spot — they are the pane's own, more specific
+        # openers; this is the generic one.
+        act_open = menu.addAction(ui_tr_now("Open"))
+        act_open.setEnabled(len(sel) == 1)
+        menu.addSeparator()
         act_new = menu.addAction(ui_tr_now("New Folder…"))
         act_unzip = menu.addAction(ui_tr_now("Unzip file"))
         act_zip = menu.addAction(ui_tr_now("Zip"))
@@ -3008,7 +3015,9 @@ class RemoteExplorerWidget(QWidget):
             if chosen == act:
                 QTimer.singleShot(0, lambda e=entry, p=sel[0]: e.launch(p))
                 return
-        if chosen == act_new:
+        if chosen == act_open:
+            self._local_open_selected()
+        elif chosen == act_new:
             self._local_new_folder()
         elif chosen == act_unzip:
             self._local_unzip(sel[0])
@@ -3026,6 +3035,15 @@ class RemoteExplorerWidget(QWidget):
             self._local_delete_selected()
         elif chosen == act_ref:
             self._local_refresh()
+
+    def _local_open_selected(self):
+        """Context-menu 'Open': the selected local item goes to the OS shell
+        (its associated application, or the file manager for a folder)."""
+        sel = [p for p in self._selected_local_paths() if p]
+        if len(sel) != 1:
+            return
+        if not open_path_with_system_shell(sel[0]):
+            self._log(f"Open: the system could not open {sel[0]}.")
 
     def _local_unzip(self, zip_path):
         """Local pane 'Unzip file': extract a local .zip into its own folder

--- a/zxnu_sdcard_ops.py
+++ b/zxnu_sdcard_ops.py
@@ -1771,6 +1771,17 @@ def build_local_explorer_ops(
         is_dir = host.model.isDir(source_index)
         # A new folder lands inside a folder, or in a file's parent folder.
         new_dir_target = file_path if is_dir else os.path.dirname(file_path)
+        # "Open" hands the clicked item to the OS shell (associated app for
+        # a file, file manager for a folder). Deferred like the launchers so
+        # the menu's grab is released before anything appears on screen.
+        action_open = QAction(ui_tr_now("Open"), host.treeview)
+
+        def _open_with_shell(_p=file_path, _n=name):
+            if not open_path_with_system_shell(_p):
+                add_main_log_window(ui_tr_now(
+                    "Open: the system could not open {name}.").format(name=_n))
+        action_open.triggered.connect(
+            lambda: QTimer.singleShot(0, _open_with_shell))
         action_copy_text = QAction(ui_tr_now("Copy text to clipboard"), host.treeview)
         action_copy_path = QAction(ui_tr_now("Copy path to clipboard"), host.treeview)
         action_copy = QAction(ui_tr_now("Copy"), host.treeview)
@@ -1917,6 +1928,8 @@ def build_local_explorer_ops(
                 lambda: QTimer.singleShot(0, _local_start_re_server))
         menu.addSeparator()
 
+        menu.addAction(action_open)
+        menu.addSeparator()
         menu.addAction(action_copy_text)
         menu.addAction(action_copy_path)
         menu.addSeparator()

--- a/zxnu_settings_pane.py
+++ b/zxnu_settings_pane.py
@@ -336,7 +336,7 @@ def build_settings_pane(
     host.settings_avail_check_checkbox.stateChanged.connect(settings_avail_check_statechanged)
     _avail_check_visible = ZX_NEXT_UNITE_ZXDB_ENABLE_DOWNLOAD_BUTTONS or ZX_NEXT_UNITE_ZXART_ENABLE_DOWNLOAD_BUTTONS
     host.settings_avail_check_checkbox.setVisible(_avail_check_visible)
-    grid_tab_Settings.addWidget(host.settings_avail_check_checkbox, 8, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_avail_check_checkbox, 9, 0, 1, 2)
 
     def settings_multi_search_statechanged():
         configuration_dictionary[SETTING_MULTI_SEARCH] = "true" if host.settings_multi_search_checkbox.isChecked() else "false"
@@ -350,7 +350,7 @@ def build_settings_pane(
         "with the number of results found, e.g. ZXDB (5)."
     )
     host.settings_multi_search_checkbox.stateChanged.connect(settings_multi_search_statechanged)
-    grid_tab_Settings.addWidget(host.settings_multi_search_checkbox, 9, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_multi_search_checkbox, 10, 0, 1, 2)
 
     def settings_search_autocomplete_statechanged():
         enabled = host.settings_search_autocomplete_checkbox.isChecked()
@@ -366,7 +366,7 @@ def build_settings_pane(
         "Uncheck to disable autocomplete suggestions on all search inputs."
     )
     host.settings_search_autocomplete_checkbox.stateChanged.connect(settings_search_autocomplete_statechanged)
-    grid_tab_Settings.addWidget(host.settings_search_autocomplete_checkbox, 10, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_search_autocomplete_checkbox, 11, 0, 1, 2)
 
     # ---- Gallery (picture view) settings ----
     def _settings_gallery_anim_changed():
@@ -383,7 +383,7 @@ def build_settings_pane(
         "  • Timed: cycles continuously while the gallery is visible.\n"
         "  • None: never cycles between images (animated GIFs still play)."
     )
-    grid_tab_Settings.addWidget(gallery_anim_lbl, 11, 0)
+    grid_tab_Settings.addWidget(gallery_anim_lbl, 12, 0)
 
     host.settings_gallery_anim_combo = QComboBox()
     host.settings_gallery_anim_combo.addItem("On hover (default)", "hover")
@@ -393,7 +393,7 @@ def build_settings_pane(
     host.settings_gallery_anim_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_anim_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_anim_combo, 11, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_anim_combo, 12, 1)
 
     def _settings_gallery_rows_changed(val: int):
         val = max(GALLERY_MIN_ROWS, min(GALLERY_MAX_ROWS, int(val)))
@@ -406,14 +406,14 @@ def build_settings_pane(
         "Number of thumbnail rows shown per gallery page.\n"
         f"Range {GALLERY_MIN_ROWS}–{GALLERY_MAX_ROWS}. Default {DEFAULT_GALLERY_ROWS_PER_PAGE}."
     )
-    grid_tab_Settings.addWidget(gallery_rows_lbl, 12, 0)
+    grid_tab_Settings.addWidget(gallery_rows_lbl, 13, 0)
 
     host.settings_gallery_rows_spin = QSpinBox()
     host.settings_gallery_rows_spin.setRange(GALLERY_MIN_ROWS, GALLERY_MAX_ROWS)
     host.settings_gallery_rows_spin.setValue(DEFAULT_GALLERY_ROWS_PER_PAGE)
     host.settings_gallery_rows_spin.setToolTip(gallery_rows_lbl.toolTip())
     host.settings_gallery_rows_spin.valueChanged.connect(_settings_gallery_rows_changed)
-    grid_tab_Settings.addWidget(host.settings_gallery_rows_spin, 12, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_rows_spin, 13, 1)
 
     def _make_color_button(setting_key, color_attr, label_text, tooltip_text, grid_row,
                            switch_theme=True, on_change=None):
@@ -487,7 +487,7 @@ def build_settings_pane(
         "Number of thumbnail columns shown in the gallery grid.\n"
         "Default is 4. Choose 2 for larger tiles or 8 for more items per row."
     )
-    grid_tab_Settings.addWidget(gallery_cols_lbl, 13, 0)
+    grid_tab_Settings.addWidget(gallery_cols_lbl, 14, 0)
 
     host.settings_gallery_cols_combo = QComboBox()
     host.settings_gallery_cols_combo.addItem("2", 2)
@@ -498,7 +498,7 @@ def build_settings_pane(
     host.settings_gallery_cols_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_cols_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_cols_combo, 13, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_cols_combo, 14, 1)
 
     def _settings_gallery_img_size_changed():
         val = host.settings_gallery_img_size_combo.currentData() or DEFAULT_GALLERY_IMG_SIZE
@@ -513,7 +513,7 @@ def build_settings_pane(
         "  • Medium (default): standard size\n"
         "  • Large: double the medium height"
     )
-    grid_tab_Settings.addWidget(gallery_img_size_lbl, 14, 0)
+    grid_tab_Settings.addWidget(gallery_img_size_lbl, 15, 0)
 
     host.settings_gallery_img_size_combo = QComboBox()
     host.settings_gallery_img_size_combo.addItem("Small",          "small")
@@ -524,7 +524,7 @@ def build_settings_pane(
     host.settings_gallery_img_size_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_img_size_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_img_size_combo, 14, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_img_size_combo, 15, 1)
 
     def _settings_gallery_slideshow_changed():
         val = host.settings_gallery_slideshow_combo.currentData()
@@ -548,7 +548,7 @@ def build_settings_pane(
         "How long each screenshot is shown before the auto-advancing gallery\n"
         "slideshow moves to the next image. Default is 5 seconds."
     )
-    grid_tab_Settings.addWidget(gallery_slideshow_lbl, 15, 0)
+    grid_tab_Settings.addWidget(gallery_slideshow_lbl, 16, 0)
 
     host.settings_gallery_slideshow_combo = QComboBox()
     for _secs in GALLERY_SLIDESHOW_SECS_CHOICES:
@@ -559,45 +559,45 @@ def build_settings_pane(
     host.settings_gallery_slideshow_combo.currentIndexChanged.connect(
         lambda _i: _settings_gallery_slideshow_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_gallery_slideshow_combo, 15, 1)
+    grid_tab_Settings.addWidget(host.settings_gallery_slideshow_combo, 16, 1)
 
     settings_section_lbl = QLabel("Local file explorers & App Text Colors:")
     settings_section_lbl.setToolTip(
         "Customize the foreground color of each item type shown in the SD card\n"
         "image explorer, plus the general app text color (labels, checkboxes,\n"
         "section headers) used across the app in Classic (non-pygame) mode.")
-    grid_tab_Settings.addWidget(settings_section_lbl, 17, 0, 1, 2)
+    grid_tab_Settings.addWidget(settings_section_lbl, 18, 0, 1, 2)
 
     host.settings_btn_color_up_directory = _make_color_button(
         SETTING_COLOR_UP_DIRECTORY, "img_color_up_directory",
         "  Up Directory item",
         "Color used for the '[Up Directory..]' navigation row in the image explorer.",
-        18)
+        19)
     host.settings_btn_color_dir_name = _make_color_button(
         SETTING_COLOR_DIR_NAME, "img_color_dir_name",
         "  Directory name",
         "Color used for directory name entries in the image explorer.",
-        19)
+        20)
     host.settings_btn_color_dir_type = _make_color_button(
         SETTING_COLOR_DIR_TYPE, "img_color_dir_type",
         "  Directory type label",
         "Color used for the 'DIR' type label column of directory entries.",
-        20)
+        21)
     host.settings_btn_color_file_name = _make_color_button(
         SETTING_COLOR_FILE_NAME, "img_color_file_name",
         "  File name",
         "Color used for file name entries in the image explorer.",
-        21)
+        22)
     host.settings_btn_color_file_ext = _make_color_button(
         SETTING_COLOR_FILE_EXT, "img_color_file_ext",
         "  File extension",
         "Color used for the file extension column in the image explorer.",
-        22)
+        23)
     host.settings_btn_color_file_size = _make_color_button(
         SETTING_COLOR_FILE_SIZE, "img_color_file_size",
         "  File size",
         "Color used for the file size column in the image explorer.",
-        23)
+        24)
     host.settings_btn_color_general_text = _make_color_button(
         SETTING_COLOR_GENERAL_TEXT, "img_color_general_text",
         "  General UI text",
@@ -606,7 +606,7 @@ def build_settings_pane(
         "light desktop/White theme would otherwise make this text black and\n"
         "unreadable. The White/Dark/Automatic/High-contrast themes set this\n"
         "automatically; picking a color here switches to the Custom theme.",
-        24)
+        25)
 
     # ---- Retro log console text color (pygame log windows) ----
     def _apply_retro_log_color(color=None):
@@ -631,7 +631,7 @@ def build_settings_pane(
         "Font color for the retro 8-bit (pygame) log consoles on the\n"
         "SD Card, NextSync and Help tabs. Applies immediately. Default is\n"
         "the classic phosphor green. Independent of the Desktop Theme.",
-        25, switch_theme=False, on_change=_apply_retro_log_color)
+        26, switch_theme=False, on_change=_apply_retro_log_color)
 
     # ---- Retro log font size (SD Card + NextSync pygame log windows) ----
     def _apply_retro_log_font_size(px):
@@ -661,7 +661,7 @@ def build_settings_pane(
         "Consolas text size for the retro 8-bit (pygame) log windows on the\n"
         "SD Card and NextSync tabs. Applies immediately. Default is 13."
     )
-    grid_tab_Settings.addWidget(retro_log_font_lbl, 26, 0)
+    grid_tab_Settings.addWidget(retro_log_font_lbl, 27, 0)
 
     host.settings_retro_log_font_combo = QComboBox()
     for _px in RETRO_LOG_FONT_SIZE_CHOICES:
@@ -675,7 +675,7 @@ def build_settings_pane(
     host.settings_retro_log_font_combo.currentIndexChanged.connect(
         lambda _i: _settings_retro_log_font_changed()
     )
-    grid_tab_Settings.addWidget(host.settings_retro_log_font_combo, 26, 1)
+    grid_tab_Settings.addWidget(host.settings_retro_log_font_combo, 27, 1)
 
     def _step_retro_log_font(delta):
         """Right-click "Increase/Decrease font size" on any retro console:
@@ -694,7 +694,7 @@ def build_settings_pane(
         "Controls how visible the background image is behind the UI.\n"
         "0 = fully hidden, 100 = fully visible. Default is 5%."
     )
-    grid_tab_Settings.addWidget(bg_opacity_lbl, 27, 0)
+    grid_tab_Settings.addWidget(bg_opacity_lbl, 28, 0)
 
     bg_opacity_row = QWidget()
     bg_opacity_row_layout = QHBoxLayout(bg_opacity_row)
@@ -837,7 +837,7 @@ def build_settings_pane(
 
     bg_opacity_row_layout.addWidget(host.settings_bg_opacity_slider, 1)
     bg_opacity_row_layout.addWidget(host.settings_bg_opacity_spinbox, 0)
-    grid_tab_Settings.addWidget(bg_opacity_row, 27, 1)
+    grid_tab_Settings.addWidget(bg_opacity_row, 28, 1)
 
     # ---- Background image selector ----
     bg_image_lbl = QLabel("Background image:")
@@ -845,7 +845,7 @@ def build_settings_pane(
         "Choose a specific background image or 'Random' to cycle through\n"
         "all images in the script folder every 5 seconds."
     )
-    grid_tab_Settings.addWidget(bg_image_lbl, 28, 0)
+    grid_tab_Settings.addWidget(bg_image_lbl, 29, 0)
 
     bg_image_row = QWidget()
     bg_image_row_layout = QHBoxLayout(bg_image_row)
@@ -888,7 +888,7 @@ def build_settings_pane(
     host.settings_bg_image_preview.setToolTip("Preview of the selected background image.")
     bg_image_row_layout.addWidget(host.settings_bg_image_preview, 0)
 
-    grid_tab_Settings.addWidget(bg_image_row, 28, 1)
+    grid_tab_Settings.addWidget(bg_image_row, 29, 1)
 
     def _update_bg_image_preview(path: str):
         """Refresh the thumbnail label for the given absolute image path."""
@@ -952,7 +952,7 @@ def build_settings_pane(
     )
     host.settings_crash_log_enabled_checkbox.stateChanged.connect(
         settings_crash_log_enabled_statechanged)
-    grid_tab_Settings.addWidget(host.settings_crash_log_enabled_checkbox, 29, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_crash_log_enabled_checkbox, 30, 0, 1, 2)
 
     def settings_disable_no_emulator_toast_statechanged():
         configuration_dictionary[SETTING_DISABLE_NO_EMULATOR_TOAST] = "true" if host.settings_disable_no_emulator_toast_checkbox.isChecked() else "false"
@@ -966,7 +966,7 @@ def build_settings_pane(
         "Check this if you do not use any emulator and do not want the reminder."
     )
     host.settings_disable_no_emulator_toast_checkbox.stateChanged.connect(settings_disable_no_emulator_toast_statechanged)
-    grid_tab_Settings.addWidget(host.settings_disable_no_emulator_toast_checkbox, 30, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_disable_no_emulator_toast_checkbox, 31, 0, 1, 2)
 
     # ── NextSync HTTP bridge toggle + port ──────────────────────────
     def _http_port_widgets_set_enabled(on):
@@ -1209,7 +1209,7 @@ def build_settings_pane(
     _http_verbose_row.addWidget(host.settings_http_verbose_checkbox)
     _http_verbose_row.addStretch(1)
     _http_bridge_vbox.addLayout(_http_verbose_row)
-    grid_tab_Settings.addLayout(_http_bridge_vbox, 41, 0, 1, 2)
+    grid_tab_Settings.addLayout(_http_bridge_vbox, 42, 0, 1, 2)
     host._http_port_widgets_set_enabled = _http_port_widgets_set_enabled
 
     # ── MAME options (shown when MAME is launchable: a detected binary, or
@@ -1225,7 +1225,7 @@ def build_settings_pane(
             "This is inserted right after the MAME executable and is no longer part\n"
             "of the command-line parameters below."
         )
-        grid_tab_Settings.addWidget(mame_rom_lbl, 31, 0)
+        grid_tab_Settings.addWidget(mame_rom_lbl, 32, 0)
 
         host.settings_mame_rom_combo = QComboBox()
         for _rom_name in MAME_ROM_CHOICE:
@@ -1233,7 +1233,7 @@ def build_settings_pane(
         host.settings_mame_rom_combo.setToolTip(mame_rom_lbl.toolTip())
         host.settings_mame_rom_combo.currentIndexChanged.connect(
             lambda _i: settings_mame_rom_changed())
-        grid_tab_Settings.addWidget(host.settings_mame_rom_combo, 31, 1)
+        grid_tab_Settings.addWidget(host.settings_mame_rom_combo, 32, 1)
 
         def settings_mame_params_changed():
             configuration_dictionary[SETTING_MAME_COMMAND_LINE_PARAMETERS] = host.settings_mame_params_edit.text()
@@ -1250,7 +1250,7 @@ def build_settings_pane(
             "-mouse/-mouse_device or -joystick/-joystickprovider options typed here\n"
             "are ignored (the combos take precedence)."
         )
-        grid_tab_Settings.addWidget(mame_params_lbl, 32, 0)
+        grid_tab_Settings.addWidget(mame_params_lbl, 33, 0)
 
         host.settings_mame_params_edit = QLineEdit()
         host.settings_mame_params_edit.setText(
@@ -1258,7 +1258,7 @@ def build_settings_pane(
                 SETTING_MAME_COMMAND_LINE_PARAMETERS, MAME_DEFAULT_COMMAND_LINE))
         host.settings_mame_params_edit.setToolTip(mame_params_lbl.toolTip())
         host.settings_mame_params_edit.editingFinished.connect(settings_mame_params_changed)
-        grid_tab_Settings.addWidget(host.settings_mame_params_edit, 32, 1)
+        grid_tab_Settings.addWidget(host.settings_mame_params_edit, 33, 1)
 
         # The startup update check only exists where the app can actually
         # fetch a build (64-bit Windows / x86_64 Linux). On macOS MAME is
@@ -1285,7 +1285,7 @@ def build_settings_pane(
             )
             host.settings_mame_update_check_checkbox.stateChanged.connect(
                 lambda _s: settings_mame_update_check_changed())
-            grid_tab_Settings.addWidget(host.settings_mame_update_check_checkbox, 33, 0, 1, 2)
+            grid_tab_Settings.addWidget(host.settings_mame_update_check_checkbox, 34, 0, 1, 2)
 
     # ── Launch MAME with Flatpak (Linux) ──────────────────────────────
     # Shown on Linux regardless of whether a MAME binary was detected, so a
@@ -1353,7 +1353,7 @@ def build_settings_pane(
         host.settings_mame_flatpak_rompath_row.setVisible(_flatpak_on)
         _flatpak_layout.addWidget(host.settings_mame_flatpak_rompath_row)
 
-        grid_tab_Settings.addWidget(_flatpak_box, 33, 0, 1, 2)
+        grid_tab_Settings.addWidget(_flatpak_box, 34, 0, 1, 2)
 
     # ── CSpect default launch parameters ───────────────────────────────
     # Shown unconditionally (unlike the MAME block above, which is gated on
@@ -1375,14 +1375,14 @@ def build_settings_pane(
         "launch. Leave empty to restore the built-in default. Saved to the\n"
         "configuration file."
     )
-    grid_tab_Settings.addWidget(cspect_params_lbl, 34, 0)
+    grid_tab_Settings.addWidget(cspect_params_lbl, 35, 0)
 
     host.settings_cspect_params_edit = QLineEdit()
     host.settings_cspect_params_edit.setText(
         configuration_dictionary.get(SETTING_CUSTOM, CSPECT_DEFAULT_LAUNCH_PARAMETERS))
     host.settings_cspect_params_edit.setToolTip(cspect_params_lbl.toolTip())
     host.settings_cspect_params_edit.editingFinished.connect(settings_cspect_params_changed)
-    grid_tab_Settings.addWidget(host.settings_cspect_params_edit, 34, 1)
+    grid_tab_Settings.addWidget(host.settings_cspect_params_edit, 35, 1)
 
     # ── Unite! pygame background animation toggle ──────────────────────
     def _settings_pygame_anim_changed():
@@ -1411,7 +1411,7 @@ def build_settings_pane(
     )
     host.settings_pygame_anim_checkbox.stateChanged.connect(
         lambda _s: _settings_pygame_anim_changed())
-    grid_tab_Settings.addWidget(host.settings_pygame_anim_checkbox, 36, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_pygame_anim_checkbox, 37, 0, 1, 2)
 
     # ── NextSync retro-log starfield animation toggle ──────────────────
     def _settings_nextsync_anim_changed():
@@ -1443,7 +1443,7 @@ def build_settings_pane(
     )
     host.settings_nextsync_pygame_anim_checkbox.stateChanged.connect(
         lambda _s: _settings_nextsync_anim_changed())
-    grid_tab_Settings.addWidget(host.settings_nextsync_pygame_anim_checkbox, 39, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_nextsync_pygame_anim_checkbox, 40, 0, 1, 2)
 
     # ── Alien Floyd's: optional pygame-ce animated background everywhere ──
     # A Pink Floyd homage. When on, a pygame-ce "Alien Floyd's" animation
@@ -1498,7 +1498,7 @@ def build_settings_pane(
         "file. Requires the optional 'pygame-ce' package.")
     host.settings_alien_floyd_bg_checkbox.stateChanged.connect(
         lambda _s: _settings_alien_bg_changed())
-    grid_tab_Settings.addWidget(host.settings_alien_floyd_bg_checkbox, 37, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_alien_floyd_bg_checkbox, 38, 0, 1, 2)
 
     # ── Alien Floyd's: optional dedicated full-window tab ────────────────
     host._alien_floyd_tab_widget = None
@@ -1570,7 +1570,7 @@ def build_settings_pane(
         "configuration file. Requires the optional 'pygame-ce' package.")
     host.settings_alien_floyd_tab_checkbox.stateChanged.connect(
         lambda _s: _settings_alien_tab_changed())
-    grid_tab_Settings.addWidget(host.settings_alien_floyd_tab_checkbox, 38, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_alien_floyd_tab_checkbox, 39, 0, 1, 2)
 
     # ── itch.io: optional online tab (driven by the 'itch-dl' package) ───
     def _itchio_tab_set_visible(on):
@@ -1613,7 +1613,7 @@ def build_settings_pane(
             "configuration file. Requires the optional 'itch-dl' package.")
     host.settings_show_itchio_tab_checkbox.stateChanged.connect(
         lambda _s: _settings_itchio_tab_changed())
-    grid_tab_Settings.addWidget(host.settings_show_itchio_tab_checkbox, 40, 0, 1, 2)
+    grid_tab_Settings.addWidget(host.settings_show_itchio_tab_checkbox, 41, 0, 1, 2)
 
     # ── Onboarding Wizard (Wizzy, zxnu_wizard.py) ────────────────────────
     def _settings_wizard_changed():
@@ -1664,7 +1664,50 @@ def build_settings_pane(
     host.settings_cspect_update_check_checkbox.stateChanged.connect(
         lambda _s: settings_cspect_update_check_changed())
     grid_tab_Settings.addWidget(
-        host.settings_cspect_update_check_checkbox, 35, 0, 1, 2)
+        host.settings_cspect_update_check_checkbox, 36, 0, 1, 2)
+
+    # ── NextSync: start the Remote Explorer '.sync5 -listen' server at startup ──
+    # Row 7 — freed by shifting every row that was ≥ 7 down by one; the
+    # actual start rides the same deferred path as the
+    # -start-remote-explorer-listener command-line switch (zxnu_config_io).
+    def _settings_re_autostart_changed():
+        on = host.settings_re_autostart_checkbox.isChecked()
+        if on:
+            # Without a sync root the server could never start (the listen
+            # guard refuses) — so the tick itself is refused: revert the box
+            # unsaved and say why, visibly. The live mirror is authoritative
+            # once the Remote Explorer exists; the saved path covers the
+            # pane not having been opened yet this session.
+            _root = (getattr(host, "_re_sync_root", "") or str(
+                configuration_dictionary.get(
+                    SETTING_NEXTSYNC_EXPLORERPATH, "") or "").strip())
+            if not (_root and os.path.isdir(_root)):
+                host.settings_re_autostart_checkbox.blockSignals(True)
+                host.settings_re_autostart_checkbox.setChecked(False)
+                host.settings_re_autostart_checkbox.blockSignals(False)
+                host._show_toast(
+                    "Remote Explorer autostart not enabled",
+                    "Define a sync root folder first, on the NextSync tab's "
+                    "Remote Explorer view.",
+                    variant="yellow", duration_ms=5000)
+                return
+        configuration_dictionary[SETTING_NEXTSYNC_RE_AUTOSTART] = (
+            "true" if on else "false")
+        if not host._initialising:
+            save_configuration_file()
+
+    host.settings_re_autostart_checkbox = QCheckBox(
+        "NextSync — Automatically start Remote Explorer server on startup")
+    host.settings_re_autostart_checkbox.setChecked(False)   # default off
+    host.settings_re_autostart_checkbox.setToolTip(
+        "Start the NextSync Remote Explorer '.sync5 -listen' server\n"
+        "automatically when the application opens, so a Next can connect\n"
+        "without you pressing Start first. Needs a sync root folder (set it\n"
+        "on the NextSync tab's Remote Explorer view). Off by default.\n"
+        "Saved to the configuration file.")
+    host.settings_re_autostart_checkbox.stateChanged.connect(
+        lambda _s: _settings_re_autostart_changed())
+    grid_tab_Settings.addWidget(host.settings_re_autostart_checkbox, 7, 0, 1, 2)
 
     # ── NextSync: what to do when a received file/dir already exists locally ──
     def _settings_nextsync_send_conflict_changed():
@@ -1681,7 +1724,7 @@ def build_settings_pane(
         "  • Overwrite: always replace the local file.\n"
         "  • Ignore: never touch existing local files."
     )
-    grid_tab_Settings.addWidget(nextsync_send_conflict_lbl, 7, 0)
+    grid_tab_Settings.addWidget(nextsync_send_conflict_lbl, 8, 0)
 
     host.settings_nextsync_send_conflict_combo = QComboBox()
     host.settings_nextsync_send_conflict_combo.addItem("Prompt (default)", "prompt")
@@ -1690,7 +1733,7 @@ def build_settings_pane(
     host.settings_nextsync_send_conflict_combo.setToolTip(nextsync_send_conflict_lbl.toolTip())
     host.settings_nextsync_send_conflict_combo.currentIndexChanged.connect(
         lambda _i: _settings_nextsync_send_conflict_changed())
-    grid_tab_Settings.addWidget(host.settings_nextsync_send_conflict_combo, 7, 1)
+    grid_tab_Settings.addWidget(host.settings_nextsync_send_conflict_combo, 8, 1)
 
     # ── Unite! search result sort / render preference ──────────────────
     def _settings_search_sort_changed():
@@ -1720,7 +1763,7 @@ def build_settings_pane(
         "  • Classic: ZXDB and zxArt items are preferred to the top, with\n"
         "    GetIt content placed at the end."
     )
-    grid_tab_Settings.addWidget(search_sort_lbl, 16, 0)
+    grid_tab_Settings.addWidget(search_sort_lbl, 17, 0)
 
     host.settings_search_sort_combo = QComboBox()
     host.settings_search_sort_combo.addItem("GetIt first class (default)", SEARCH_SORT_GETIT_FIRST)
@@ -1729,7 +1772,7 @@ def build_settings_pane(
     host.settings_search_sort_combo.setToolTip(search_sort_lbl.toolTip())
     host.settings_search_sort_combo.currentIndexChanged.connect(
         lambda _i: _settings_search_sort_changed())
-    grid_tab_Settings.addWidget(host.settings_search_sort_combo, 16, 1)
+    grid_tab_Settings.addWidget(host.settings_search_sort_combo, 17, 1)
 
     # "Open config file" — moved here from the SD-card tab. Opens hdfg.cfg in
     # the system text editor so advanced users can hand-edit settings. Placed
@@ -1737,7 +1780,7 @@ def build_settings_pane(
     # width rather than stretching across both columns.
     host.button_open_config_file = QPushButton("Open config file", host)
     host.button_open_config_file.clicked.connect(open_cspect_configuration_file)
-    grid_tab_Settings.addWidget(host.button_open_config_file, 42, 0, 1, 2, Qt.AlignLeft)
+    grid_tab_Settings.addWidget(host.button_open_config_file, 43, 0, 1, 2, Qt.AlignLeft)
 
     grid_tab_Settings.setColumnStretch(2, 1)
     zxnextunite_Settings_tab.setLayout(grid_tab_Settings)


### PR DESCRIPTION
## 'Open' context-menu entry (both local explorers)

Right-clicking an item in the Remote Explorer's local pane or the SD Card tab's local explorer now offers **Open**: the item is handed to the OS shell so its associated application opens it — the browser for a `.html`, the image viewer for a `.png`, the file manager for a folder. One shared helper (`open_path_with_system_shell` in `zxnu_config.py`) carries the `os.startfile` / `open` / `xdg-open` dispatch the gallery panes already used; a refused open is reported in the log. The emulator "Start … with file" entries keep the top spot — they are the pane's own, more specific openers.

## Settings: "NextSync — Automatically start Remote Explorer server on startup"

New persisted checkbox (default **off**) at row 7 of the Settings grid, right above "NextSync — when a sent…". When on, startup rides the same deferred path as the `-start-remote-explorer-listener` command-line switch: the Remote Explorer view is forced open (unpersisted, this run only) and the `.sync5 -listen` server starts once the event loop is up.

**Sync-root guard:** ticking the box with no sync root defined is refused on the spot — the checkbox reverts to off (nothing saved) and a yellow 5-second toast advises defining a sync root folder on the NextSync tab's Remote Explorer view. A sync root that vanished between sessions gets the same toast at startup, but keeps the preference (an unplugged drive must not silently erase it).

Every settings row that was ≥ 7 shifted down exactly one; the offscreen suite's hardcoded grid assertions moved with them (two stale check labels corrected) and new checks pin rows 7/8, the off default, the refusal path and both persistence directions.

## i18n

- "Open" + its failure line, and the new checkbox label: all six main catalogs.
- Toast title/body: all six `_TOAST_CATALOGS` (the i18n tripwire enforces these and passes).

## Tests

Full suite green including all 14 offscreen phases; new coverage: `test_local_open_with_shell` (widget suite) and the settings-phase checks above. Version bumped in BOTH homes: `pyproject.toml` and `zxnu_config.py` say 9.5.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)