### PR TITLE
9.5.18: friendly machine names in the Remote Explorer combo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.17"
+version = "9.5.18"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -129,6 +129,8 @@ def make_widget(**kw):
             "on_remote_cwd_changed",
             lambda p, a=None: calls["remote_cwd"].append(p)),
         remote_cwd_for=kw.get("remote_cwd_for"),
+        machine_name_for=kw.get("machine_name_for"),
+        on_machine_name_changed=kw.get("on_machine_name_changed"),
         local_sort=kw.get("local_sort"),
         next_sort=kw.get("next_sort"),
         on_sort_changed=lambda which, v: calls["sorts"].append((which, v)),
@@ -507,6 +509,61 @@ def test_multi_next_folders_follow_the_baton():
     check("combo shrinks to the survivor",
           w.next_machine_combo.count() == 1
           and w.next_machine_combo.itemData(0) == 1)
+
+
+def test_machine_names_follow_the_address():
+    """The machine combo's friendly names (9.5.18): the round ✎ button
+    names the machine the combo shows, the host persists addr -> name, and
+    every entry of that ADDRESS — this session's or a later one's, any
+    session id — greets by name: "10.0.0.185 #1 - N-Go"."""
+    names = {}   # the host's store
+    w, calls = make_widget(
+        local_start_dir=tdir("mnames_root"),
+        machine_name_for=names.get,
+        on_machine_name_changed=lambda a, n: (
+            names.__setitem__(a, n) if n else names.pop(a, None)))
+    w.on_peers((1, [(1, "10.0.0.185"), (2, "10.0.0.185")]))
+    connect_widget(w, calls)
+    check("unnamed machines show addr #sid",
+          w.next_machine_combo.itemText(0) == "10.0.0.185 #1"
+          and w.next_machine_combo.itemText(1) == "10.0.0.185 #2",
+          str([w.next_machine_combo.itemText(i) for i in range(2)]))
+    check("the ✎ name button rides along with the combo",
+          not w.next_machine_name_btn.isHidden())
+
+    # Name the active machine; BOTH sessions of that address adopt it.
+    _w0 = w.next_machine_combo.sizeHint().width()
+    FakeInput.queue = [("  N-Go  ", True)]
+    w._on_machine_name_edit()
+    check("name saved for the ADDRESS (whitespace collapsed)",
+          names.get("10.0.0.185") == "N-Go", str(names))
+    check("the combo re-measures for the longer label (no clipping)",
+          w.next_machine_combo.sizeHint().width() > _w0,
+          f"{_w0} -> {w.next_machine_combo.sizeHint().width()}")
+    check("every session of the address shows the name",
+          w.next_machine_combo.itemText(0) == "10.0.0.185 #1 - N-Go"
+          and w.next_machine_combo.itemText(1) == "10.0.0.185 #2 - N-Go",
+          str([w.next_machine_combo.itemText(i) for i in range(2)]))
+
+    # A cancelled dialog changes nothing.
+    FakeInput.queue = []
+    w._on_machine_name_edit()
+    check("cancel keeps the name", names.get("10.0.0.185") == "N-Go")
+
+    # The machine reconnects later under a fresh session id: the name is
+    # keyed by address, so the new roster greets it by name at once.
+    w.on_peers((7, [(7, "10.0.0.185")]))
+    check("a later session id keeps the friendly name",
+          w.next_machine_combo.itemText(0) == "10.0.0.185 #7 - N-Go",
+          w.next_machine_combo.itemText(0))
+
+    # An empty name removes it.
+    FakeInput.queue = [("", True)]
+    w._on_machine_name_edit()
+    check("empty name forgets it",
+          "10.0.0.185" not in names
+          and w.next_machine_combo.itemText(0) == "10.0.0.185 #7",
+          w.next_machine_combo.itemText(0))
 
 
 def test_drive_switching():
@@ -1539,6 +1596,7 @@ def main():
         test_listing_and_rendering()
         test_navigation()
         test_multi_next_folders_follow_the_baton()
+        test_machine_names_follow_the_address()
         test_drive_switching()
         test_ls_failed_fallback()
         test_sorting()

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.17"
+ZX_NEXT_UNITE_VERSION = "9.5.18"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync
@@ -379,6 +379,7 @@ SETTING_FAVORITES_ITEM_RETRO   = "favorites_item_retro"
 SETTING_NEXTSYNC_PYGAME_ANIM   = "nextsync_pygame_anim"    # "false" => freeze the starfield in the NextSync retro log (default on)
 SETTING_NEXTSYNC_REMOTE_EXPLORER = "nextsync_remote_explorer"  # "true" => reopen the NextSync tab in Remote Explorer view (default off = classic sync)
 SETTING_NEXTSYNC_RE_AUTOSTART  = "nextsync_re_autostart"   # "true" => start the Remote Explorer '.sync5 -listen' server on startup (default off; needs a sync root)
+SETTING_RE_MACHINE_NAMES       = "nextsync_re_machine_names"  # JSON {address: friendly name} for the Remote Explorer's machine combo ("10.0.0.185 #1 - N-Go")
 SETTING_NEXTSYNC_REMOTE_CWD    = "nextsync_remote_cwd"     # last Next-side folder browsed in the Remote Explorer, restored on reconnect (falls back to "/" if gone)
 SETTING_NEXTSYNC_RE_LOCAL_SORT = "nextsync_re_local_sort"  # Remote Explorer local pane sort, "<name|size|type>:<asc|desc>" (default "name:asc")
 SETTING_NEXTSYNC_RE_NEXT_SORT  = "nextsync_re_next_sort"   # Remote Explorer Next pane sort, "<name|size|type>:<asc|desc>" (default "name:asc")
@@ -966,7 +967,7 @@ SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_P
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK, SETTING_ZXNU_UPDATE_CHECK, SETTING_DOTN_LAST_VERSION, SETTING_DELETE_TO_RECYCLE_BIN,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO, SETTING_UI_LANGUAGE,
 SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN, SETTING_WIZARD_FONT_SIZE, SETTING_WIZARD_SP_OFFERED,
-SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS, SETTING_RE_REMOTE_CWDS)
+SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS, SETTING_RE_REMOTE_CWDS, SETTING_RE_MACHINE_NAMES)
 
 
 def apply_tree_column_widths(tree, pref):

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -283,6 +283,9 @@ CATALOGS = {
         'Increase font size (now {px}px)': 'Aumentar tamaño de letra (ahora {px}px)',
         'More like this': 'Más como esto',
         'New directory name in': 'Nombre del nuevo directorio en',
+        'Name this Next': 'Nombrar este Next',
+        'Friendly name for {addr} (empty removes it):':
+            'Nombre descriptivo para {addr} (vacío lo elimina):',
         'New folder in {path}:': 'Nueva carpeta en {path}:',
         'New Folder…': 'Nueva carpeta…',
         'New name for the {kind}:': 'Nuevo nombre para {kind}:',
@@ -1385,6 +1388,9 @@ CATALOGS = {
         'Increase font size (now {px}px)': 'Aumentar tamanho da letra (agora {px}px)',
         'More like this': 'Mais como este',
         'New directory name in': 'Nome do novo diretório em',
+        'Name this Next': 'Dar nome a este Next',
+        'Friendly name for {addr} (empty removes it):':
+            'Nome amigável para {addr} (vazio remove-o):',
         'New folder in {path}:': 'Nova pasta em {path}:',
         'New Folder…': 'Nova pasta…',
         'New name for the {kind}:': 'Novo nome para {kind}:',
@@ -2487,6 +2493,9 @@ CATALOGS = {
         'Increase font size (now {px}px)': 'Zwiększ rozmiar czcionki (teraz {px}px)',
         'More like this': 'Więcej podobnych',
         'New directory name in': 'Nazwa nowego katalogu w',
+        'Name this Next': 'Nazwij tego Nexta',
+        'Friendly name for {addr} (empty removes it):':
+            'Przyjazna nazwa dla {addr} (pusta ją usuwa):',
         'New folder in {path}:': 'Nowy folder w {path}:',
         'New Folder…': 'Nowy folder…',
         'New name for the {kind}:': 'Nowa nazwa ({kind}):',
@@ -3589,6 +3598,9 @@ CATALOGS = {
         'Increase font size (now {px}px)': 'Увеличить размер шрифта (сейчас {px}px)',
         'More like this': 'Похожие',
         'New directory name in': 'Имя нового каталога в',
+        'Name this Next': 'Назовите этот Next',
+        'Friendly name for {addr} (empty removes it):':
+            'Понятное имя для {addr} (пустое удаляет его):',
         'New folder in {path}:': 'Новая папка в {path}:',
         'New Folder…': 'Новая папка…',
         'New name for the {kind}:': 'Новое имя ({kind}):',
@@ -4692,6 +4704,9 @@ CATALOGS = {
         'Increase font size (now {px}px)': 'Zvětšit velikost písma (nyní {px}px)',
         'More like this': 'Další podobné',
         'New directory name in': 'Název nového adresáře v',
+        'Name this Next': 'Pojmenovat tento Next',
+        'Friendly name for {addr} (empty removes it):':
+            'Přátelský název pro {addr} (prázdný jej odstraní):',
         'New folder in {path}:': 'Nová složka v {path}:',
         'New Folder…': 'Nová složka…',
         'New name for the {kind}:': 'Nový název ({kind}):',
@@ -5794,6 +5809,9 @@ CATALOGS = {
         'Increase font size (now {px}px)': 'Augmenter la taille de police (actuellement {px}px)',
         'More like this': 'Plus comme ceci',
         'New directory name in': 'Nom du nouveau répertoire dans',
+        'Name this Next': 'Nommer ce Next',
+        'Friendly name for {addr} (empty removes it):':
+            'Nom convivial pour {addr} (vide le supprime) :',
         'New folder in {path}:': 'Nouveau dossier dans {path} :',
         'New Folder…': 'Nouveau dossier…',
         'New name for the {kind}:': 'Nouveau nom pour {kind} :',

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -773,6 +773,42 @@ def build_nextsync_pane(
         except (ValueError, TypeError):
             return None
 
+    def _re_machine_name_for(addr):
+        # The machine combo's friendly name for an address (9.5.18), or
+        # None — same JSON-map shape as the per-machine folders above.
+        try:
+            _map = json.loads(str(configuration_dictionary.get(
+                SETTING_RE_MACHINE_NAMES, "") or "{}"))
+            _v = _map.get(str(addr), "") if isinstance(_map, dict) else ""
+            return _v if isinstance(_v, str) and _v else None
+        except (ValueError, TypeError):
+            return None
+
+    def _re_on_machine_name_changed(addr, name):
+        # The ✎ button's report: remember (or forget, on empty) the name
+        # for this address. Mirrors the per-machine folder map: re-insert
+        # = newest, capped so the cfg stays tidy.
+        if not addr:
+            return
+        try:
+            try:
+                _map = json.loads(str(configuration_dictionary.get(
+                    SETTING_RE_MACHINE_NAMES, "") or "{}"))
+                if not isinstance(_map, dict):
+                    _map = {}
+            except (ValueError, TypeError):
+                _map = {}
+            _map.pop(str(addr), None)
+            if name:
+                _map[str(addr)] = str(name)
+                while len(_map) > 24:          # oldest out
+                    _map.pop(next(iter(_map)))
+            configuration_dictionary[SETTING_RE_MACHINE_NAMES] = (
+                json.dumps(_map, separators=(",", ":")))
+            save_configuration_file()
+        except Exception:
+            pass
+
     def _re_on_sort_changed(which, value):
         # The widget reports a new column sort ("<key>:<asc|desc>") for one of
         # its panes; persist it so both panes reopen sorted the same way.
@@ -847,6 +883,8 @@ def build_nextsync_pane(
             remote_start_dir=remote_cwd,
             on_remote_cwd_changed=_re_on_remote_cwd_changed,
             remote_cwd_for=_re_remote_cwd_for,
+            machine_name_for=_re_machine_name_for,
+            on_machine_name_changed=_re_on_machine_name_changed,
             local_sort=local_sort, next_sort=next_sort,
             on_sort_changed=_re_on_sort_changed,
             extra_drives=extra_drives,

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -272,7 +272,8 @@ class RemoteExplorerWidget(QWidget):
                  on_remote_cwd_changed=None, local_sort=None, next_sort=None,
                  on_sort_changed=None, on_toast=None, extra_drives=None,
                  on_extra_drives_changed=None, emulator_entries=None,
-                 remote_cwd_for=None):
+                 remote_cwd_for=None, machine_name_for=None,
+                 on_machine_name_changed=None):
         super().__init__(parent)
         self._enqueue_raw = enqueue          # host closure: put one command
         self._drain_raw = drain              # host closure: empty the queue, -> count
@@ -297,6 +298,16 @@ class RemoteExplorerWidget(QWidget):
         self._on_remote_cwd_changed = (on_remote_cwd_changed or
                                        (lambda p, a=None: None))
         self._remote_cwd_for = remote_cwd_for
+        # Friendly machine names (9.5.18): machine_name_for(addr) answers
+        # the saved name for an ADDRESS (None/"" = none) and the ✎ button
+        # reports edits through on_machine_name_changed(addr, name) — the
+        # host persists the map, so a machine that reconnects (whatever
+        # session id the new worker deals it) greets by name in the combo:
+        # "10.0.0.185 #1 - N-Go". Keyed by address on purpose: session ids
+        # restart at 1 with every worker and would forget the name.
+        self._machine_name_for = machine_name_for or (lambda a: None)
+        self._on_machine_name_changed = (on_machine_name_changed or
+                                         (lambda a, n: None))
         self._remote_cwd_addr = None         # last addr a folder was reported for
         self._remote_start_dir = _norm_remote_dir(remote_start_dir)
         # Per-pane sort (column + direction), restored from the config and saved
@@ -641,11 +652,30 @@ class RemoteExplorerWidget(QWidget):
             "re-reads the chosen machine's drives and listing.")
         self.next_machine_combo.setVisible(False)
         self.next_machine_combo.activated.connect(self._on_machine_pick)
+        # Re-measure on EVERY content change, not just the first show (the
+        # Qt default): a freshly assigned " - <name>" must widen the combo
+        # right away, not sit clipped until the next restart (9.5.18 field
+        # report).
+        self.next_machine_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToContents)
+        # The small round ✎ next to the machine combo (9.5.18): name the
+        # machine the combo shows. Hidden/shown together with the combo.
+        self.next_machine_name_btn = QPushButton("✎", self)
+        self.next_machine_name_btn.setFixedSize(18, 18)
+        self.next_machine_name_btn.setStyleSheet(
+            "QPushButton { border-radius: 9px; border: 1px solid #888; }")
+        self.next_machine_name_btn.setToolTip(
+            "Give this Next a friendly name (shown in the machine list, "
+            "remembered for its address across sessions). Empty removes "
+            "the name.")
+        self.next_machine_name_btn.setVisible(False)
+        self.next_machine_name_btn.clicked.connect(self._on_machine_name_edit)
         next_bar = QHBoxLayout()
         next_bar.setContentsMargins(0, 0, 0, 0)
         next_bar.addWidget(next_up)
         next_bar.addWidget(refresh)
         next_bar.addWidget(self.next_machine_combo)
+        next_bar.addWidget(self.next_machine_name_btn)
         next_bar.addWidget(self.next_drive_combo)
         next_bar.addWidget(self.next_drive_add)
         next_bar.addWidget(self.next_path_label, 1)
@@ -1248,20 +1278,64 @@ class RemoteExplorerWidget(QWidget):
         try:
             self.next_machine_combo.clear()
             for sid, addr in plist:
-                self.next_machine_combo.addItem(f"{addr} #{sid}", sid)
+                self.next_machine_combo.addItem(
+                    self._machine_label(sid, addr), sid)
                 if sid == active:
                     self.next_machine_combo.setCurrentIndex(
                         self.next_machine_combo.count() - 1)
             # Visible whenever ANY Next is on the line (field request: a
             # lone machine still shows WHO the pane drives); hidden only
-            # while the roster is empty.
+            # while the roster is empty. The ✎ name button rides along.
             self.next_machine_combo.setVisible(len(plist) >= 1)
+            self.next_machine_name_btn.setVisible(len(plist) >= 1)
         finally:
             self._peer_guard = False
         if active is not None and prev is not None and active != prev:
             # The baton moved: this pane now drives a DIFFERENT machine.
             self._set_connected(False)     # drop the old card's listing
             self.on_connected()            # drives + listing of the new one
+
+    def _machine_label(self, sid, addr):
+        """One combo entry: "addr #sid", plus " - Name" when the host
+        remembers a friendly name for that address."""
+        name = self._machine_name_for(addr) or ""
+        base = f"{addr} #{sid}"
+        return f"{base} - {name}" if name else base
+
+    def _on_machine_name_edit(self):
+        """The ✎ button: name (or rename) the machine the combo currently
+        shows. The name is keyed by the machine's ADDRESS and persisted by
+        the host, so it survives reconnects and restarts whatever session
+        id the machine is dealt next. An empty name removes it."""
+        ix = self.next_machine_combo.currentIndex()
+        sid = self.next_machine_combo.itemData(ix)
+        addr = None
+        for _sid, _addr in self._peer_map:
+            if _sid == sid:
+                addr = _addr
+                break
+        if not addr:
+            return
+        name, ok = QInputDialog.getText(
+            self, ui_tr_now("Name this Next"),
+            ui_tr_now("Friendly name for {addr} (empty removes it):").format(
+                addr=addr),
+            text=self._machine_name_for(addr) or "")
+        if not ok:
+            return
+        # Collapse whitespace and cap the length: the combo shares its row
+        # with the drive switcher, and " - <name>" must leave it room.
+        name = " ".join(str(name).split())[:24].strip()
+        self._on_machine_name_changed(addr, name)
+        # Relabel in place — every session of that address adopts the name
+        # (two '.sync5 -L' sessions from one machine share one entry name).
+        for i in range(self.next_machine_combo.count()):
+            _s = self.next_machine_combo.itemData(i)
+            for _sid, _addr in self._peer_map:
+                if _sid == _s and _addr == addr:
+                    self.next_machine_combo.setItemText(
+                        i, self._machine_label(_s, _addr))
+                    break
 
     def _on_machine_pick(self, index):
         """User picked a Next in the machine combo: hand the baton over.


### PR DESCRIPTION
## What

A small round ✎ button next to the Remote Explorer's machine combo names the machine the combo shows: `10.0.0.185 #1` becomes `10.0.0.185 #1 - N-Go`.

- **Keyed by address, not session id** — ids restart at 1 with every worker, so an id-keyed name would be forgotten on each reconnect. An address-keyed name greets the machine whatever session id it's dealt next; two sessions from one address share one name.
- **Persisted** as a JSON `{address: name}` map (`nextsync_re_machine_names`, capped at 24, registered in `CONFIG_FILE_SETTINGS`) — the exact shape of the per-machine folders map.
- Names collapse whitespace, cap at 24 chars; empty removes. Prompt is pre-filled with the current name; dialog strings in all six catalogs.
- **Combo resize fix**: `AdjustToContents` — the Qt default only measures on first show, so a freshly assigned name sat clipped (field report). Now every relabel re-measures.

## Tests

`test_machine_names_follow_the_address`: unnamed display, naming via the scripted dialog, both same-address sessions adopting the name, cancel, a later session id inheriting it, empty-clears, and the size-hint growth assert (fails on the old policy). Full suite green including all 14 offscreen phases. Version bumped in both homes: 9.5.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)