### PR TITLE
9.5.19: SD Card tab mirrors the Remote Explorer's bottom bars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.18"
+version = "9.5.19"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -415,25 +415,47 @@ def inspect_phase1():
     def pos(widget):
         i = grid.indexOf(widget)
         return None if i < 0 else grid.getItemPosition(i)[:2]
-    check("local path row at grid (0,0)", pos(win.local_path_row_container) == (0, 0), str(pos(win.local_path_row_container)))
-    check("image path row at grid (0,2)", pos(win.image_path_row_container) == (0, 2), str(pos(win.image_path_row_container)))
+    # The Remote Explorer mirroring (9.5.19): nav bars above the trees,
+    # the path boxes BELOW them, the image buttons at the very bottom.
+    check("local nav bar at grid (0,0)", pos(win.local_nav_row_container) == (0, 0), str(pos(win.local_nav_row_container)))
+    check("image nav bar at grid (0,2)", pos(win.image_nav_row_container) == (0, 2), str(pos(win.image_nav_row_container)))
+    _lnav = win.local_nav_row_container.layout()
+    check("local nav = Up|Refresh",
+          _lnav.indexOf(win.local_explorer_up_button) == 0
+          and _lnav.indexOf(win.local_explorer_refresh_button) == 1)
+    _inav = win.image_nav_row_container.layout()
+    check("image nav = Up|Refresh",
+          _inav.indexOf(win.image_explorer_up_button) == 0
+          and _inav.indexOf(win.image_explorer_refresh_button) == 1)
+    check("local path row at grid (2,0)", pos(win.local_path_row_container) == (2, 0), str(pos(win.local_path_row_container)))
+    check("image path row at grid (2,2)", pos(win.image_path_row_container) == (2, 2), str(pos(win.image_path_row_container)))
     _lrow = win.local_path_row_container.layout()
-    check("local row = Up|Refresh|label|path box",
-          _lrow.indexOf(win.local_explorer_up_button) == 0
-          and _lrow.indexOf(win.local_explorer_refresh_button) == 1
-          and _lrow.indexOf(win.localexplorerlabel) == 2
-          and _lrow.indexOf(win.local_file_explorer_path) == 3)
+    check("local path row = label|path box",
+          _lrow.indexOf(win.localexplorerlabel) == 0
+          and _lrow.indexOf(win.local_file_explorer_path) == 1)
     check("local label text", win.localexplorerlabel.text() == "Local path: ",
           win.localexplorerlabel.text())
     _irow = win.image_path_row_container.layout()
-    check("image row = Up|Refresh|label|path box",
-          _irow.indexOf(win.image_explorer_up_button) == 0
-          and _irow.indexOf(win.image_explorer_refresh_button) == 1
-          and _irow.indexOf(win.diskimageexplorerlabel) == 2
-          and _irow.indexOf(win.diskimageexplorerpathinput) == 3)
+    check("image path row = label|path box|buttons (one bottom row)",
+          _irow.indexOf(win.diskimageexplorerlabel) == 0
+          and _irow.indexOf(win.diskimageexplorerpathinput) == 1
+          and _irow.indexOf(win.imageexplorerbuttonscontainer) == 2)
+    check("path box owns the row's slack (stretch 1, buttons 0)",
+          _irow.stretch(1) == 1 and _irow.stretch(2) == 0,
+          f"{_irow.stretch(1)}/{_irow.stretch(2)}")
+    check("buttons keep natural width (no 190px minimum)",
+          win.button_new_folder.minimumWidth() < 100
+          and win.button_rename.minimumWidth() < 100
+          and win.button_delete_files.minimumWidth() < 100)
+    check("button cluster flush against the box (no spacer labels, no margins)",
+          win.imageexplorerbuttons.indexOf(win.hiddenspacelabel1) == -1
+          and win.imageexplorerbuttons.indexOf(win.hiddenspacelabel2) == -1
+          and win.imageexplorerbuttons.contentsMargins().left() == 0)
     check("local explorer at grid (1,0)", pos(win.treeview) == (1, 0), str(pos(win.treeview)))
     check("image explorer at grid (1,2)", pos(win.image_explorer_container) == (1, 2), str(pos(win.image_explorer_container)))
-    check("image buttons at grid (2,2)", pos(win.imageexplorerbuttonscontainer) == (2, 2), str(pos(win.imageexplorerbuttonscontainer)))
+    check("button cluster no longer a grid row of its own",
+          pos(win.imageexplorerbuttonscontainer) is None,
+          str(pos(win.imageexplorerbuttonscontainer)))
     check("old widgets out of top row",
           win.horizontal2.indexOf(win.diskimageexplorerlabel) == -1
           and win.horizontal2.indexOf(win.diskimageexplorerpathinput) == -1)

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.18"
+ZX_NEXT_UNITE_VERSION = "9.5.19"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -2538,6 +2538,8 @@ class MainWindow(QMainWindow):
         self.local_explorer_up_button = _pane.local_explorer_up_button
         self.local_explorer_refresh_button = _pane.local_explorer_refresh_button
         self.local_path_row_container = _pane.local_path_row_container
+        self.local_nav_row_container = _pane.local_nav_row_container
+        self.image_nav_row_container = _pane.image_nav_row_container
         self.image_explorer_up_button = _pane.image_explorer_up_button
         self.image_explorer_refresh_button = _pane.image_explorer_refresh_button
         self.diskimageexplorerlabel = _pane.diskimageexplorerlabel
@@ -2861,19 +2863,24 @@ class MainWindow(QMainWindow):
 
         self.imageexplorerbuttonscontainer = QWidget()
         self.imageexplorerbuttons = QHBoxLayout()
+        # Flush against the path box since the one-row mirroring (9.5.19):
+        # no layout margins, and the two historical spacer labels stay OUT
+        # of the layout -- their literal runs of spaces were the visible
+        # gap between the box and the buttons (field report #3).
+        self.imageexplorerbuttons.setContentsMargins(0, 0, 0, 0)
 
         self.hiddenspacelabel1 = QLabel()
         self.hiddenspacelabel1.setText("      ")
-        self.imageexplorerbuttons.addWidget(self.hiddenspacelabel1)
 
         self.button_new_folder = QPushButton("NewFolder", self)
         self.button_new_folder.setText("New Folder")
-        self.button_new_folder.setMinimumWidth(IMAGE_BUTTONS_SIZE)
+        # Natural width since the 9.5.19 one-row mirroring: the trio sits
+        # right of the image path box, and the box owns the slack -- the
+        # 190px minimums starved it to a sliver (field report).
         self.button_new_folder.clicked.connect(image_newfolder)
 
         self.button_rename = QPushButton("Rename", self)
         self.button_rename.setText("Rename")
-        self.button_rename.setMinimumWidth(IMAGE_BUTTONS_SIZE)
         self.button_rename.clicked.connect(image_rename_dialog)
 
         self.download_and_install_hdfmonkey_button = QPushButton("Download & install HDF Monkey", self)
@@ -2884,11 +2891,9 @@ class MainWindow(QMainWindow):
 
         self.hiddenspacelabel2 = QLabel()
         self.hiddenspacelabel2.setText("       ")
-        self.imageexplorerbuttons.addWidget(self.hiddenspacelabel2)
 
         self.button_delete_files = QPushButton("DeleteFiles", self)
         self.button_delete_files.setText("Delete")
-        self.button_delete_files.setMinimumWidth(IMAGE_BUTTONS_SIZE)
         self.button_delete_files.clicked.connect(delete_files_button_show_confirmation_buttons)
 
         self.imageexplorerbuttons.addWidget(self.button_new_folder)
@@ -2932,9 +2937,10 @@ class MainWindow(QMainWindow):
 
         self.imageexplorerbuttonscontainer.setLayout(self.imageexplorerbuttons)
 
-        # Place the New Folder / Delete Files buttons directly beneath the disk
-        # image explorer (grid row 2, right column).
-        self.sdcard_explorer_grid.addWidget(self.imageexplorerbuttonscontainer, 2, 2)
+        # The New Folder / Rename / Delete cluster joins the image path row,
+        # right of the path box -- ONE bottom row, the Remote Explorer's
+        # exact arrangement (9.5.19 mirroring).
+        self.image_path_row_container.layout().addWidget(self.imageexplorerbuttonscontainer)
 
         # Add Log Window
         # Optional retro 8-bit pygame log for the SD Card tab, mirroring the one on

--- a/zxnu_sdcard_explorer.py
+++ b/zxnu_sdcard_explorer.py
@@ -186,9 +186,12 @@ class SdCardExplorerPane(QWidget):
         image_explorer_vbox.addWidget(self.image_usage_gauge)
 
     def _build_grid(self, transfer_buttons_container, image_buttons_container):
-        # Path row above the explorers: editable boxes showing the local
-        # folder / in-image target folder, each with Up / Refresh buttons
-        # mirroring the Remote Explorer's top bars.
+        # Two bars per explorer, mirroring the NextSync Remote Explorer
+        # (9.5.19 field request — the two tabs read the same now): the
+        # Up / Refresh buttons stay in a nav bar ABOVE each tree, and the
+        # editable path box sits in its own row directly BELOW the tree —
+        # the image-side one right above the New Folder / Rename / Delete
+        # buttons, exactly where the Remote Explorer keeps its Next path.
         self.local_file_explorer_path = QLineEdit()
         self.local_file_explorer_path.setPlaceholderText("Local folder path...")
         self.local_file_explorer_path.setClearButtonEnabled(True)
@@ -208,11 +211,16 @@ class SdCardExplorerPane(QWidget):
         self.localexplorerlabel = QLabel()
         self.localexplorerlabel.setText("Local path: ")
 
+        self.local_nav_row_container = QWidget()
+        local_nav_row = QHBoxLayout(self.local_nav_row_container)
+        local_nav_row.setContentsMargins(0, 0, 0, 0)
+        local_nav_row.addWidget(self.local_explorer_up_button)
+        local_nav_row.addWidget(self.local_explorer_refresh_button)
+        local_nav_row.addStretch(1)
+
         self.local_path_row_container = QWidget()
         local_path_row = QHBoxLayout(self.local_path_row_container)
         local_path_row.setContentsMargins(0, 0, 0, 0)
-        local_path_row.addWidget(self.local_explorer_up_button)
-        local_path_row.addWidget(self.local_explorer_refresh_button)
         local_path_row.addWidget(self.localexplorerlabel)
         local_path_row.addWidget(self.local_file_explorer_path, 1)
 
@@ -238,33 +246,43 @@ class SdCardExplorerPane(QWidget):
         )
         self.diskimageexplorerpathinput.editingFinished.connect(self._on_image_path_edited)
 
+        self.image_nav_row_container = QWidget()
+        image_nav_row = QHBoxLayout(self.image_nav_row_container)
+        image_nav_row.setContentsMargins(0, 0, 0, 0)
+        image_nav_row.addWidget(self.image_explorer_up_button)
+        image_nav_row.addWidget(self.image_explorer_refresh_button)
+        image_nav_row.addStretch(1)
+
         self.image_path_row_container = QWidget()
         image_path_row = QHBoxLayout(self.image_path_row_container)
         image_path_row.setContentsMargins(0, 0, 0, 0)
-        image_path_row.addWidget(self.image_explorer_up_button)
-        image_path_row.addWidget(self.image_explorer_refresh_button)
         image_path_row.addWidget(self.diskimageexplorerlabel)
         image_path_row.addWidget(self.diskimageexplorerpathinput, 1)
 
-        # 3-column grid; the two explorer columns share the stretch equally so
-        # each path row matches its explorer's width, and the New Folder /
-        # Delete buttons sit directly under the disk image explorer.
+        # 3-column grid; the two explorer columns share the stretch equally
+        # so each bar matches its explorer's width. Rows: nav bars, trees,
+        # then ONE bottom row per side — the image side's carries the path
+        # box AND the New Folder / Rename / Delete buttons together, the
+        # Remote Explorer's exact bottom row.
         self.sdcard_explorer_grid = QGridLayout(self)
         self.sdcard_explorer_grid.setContentsMargins(0, 0, 0, 0)
-        self.sdcard_explorer_grid.addWidget(self.local_path_row_container, 0, 0)
-        self.sdcard_explorer_grid.addWidget(self.image_path_row_container, 0, 2)
+        self.sdcard_explorer_grid.addWidget(self.local_nav_row_container, 0, 0)
+        self.sdcard_explorer_grid.addWidget(self.image_nav_row_container, 0, 2)
         self.sdcard_explorer_grid.addWidget(self.treeview, 1, 0)
         self.sdcard_explorer_grid.addWidget(self.image_explorer_container, 1, 2)
+        self.sdcard_explorer_grid.addWidget(self.local_path_row_container, 2, 0)
+        self.sdcard_explorer_grid.addWidget(self.image_path_row_container, 2, 2)
         self.sdcard_explorer_grid.setColumnStretch(0, 1)
         self.sdcard_explorer_grid.setColumnStretch(2, 1)
         self.sdcard_explorer_grid.setRowStretch(1, 1)
         # The centre transfer-buttons column (1,1) and the New Folder /
-        # Delete row (2,2) are operation-wired widgets: when not handed in
-        # here, MainWindow slots them into this grid once it has built them.
+        # Rename / Delete cluster are operation-wired widgets: when not
+        # handed in here, MainWindow adds them once it has built them (the
+        # button cluster goes INTO the image path row, right of the box).
         if transfer_buttons_container is not None:
             self.sdcard_explorer_grid.addWidget(transfer_buttons_container, 1, 1)
         if image_buttons_container is not None:
-            self.sdcard_explorer_grid.addWidget(image_buttons_container, 2, 2)
+            image_path_row.addWidget(image_buttons_container)
 
     # ------------------------------------------------- local explorer: nav --
     def update_root_drive(self, _index=None):


### PR DESCRIPTION
## What

The SD Card Utility's path boxes move to the bottom of each explorer, mirroring the NextSync Remote Explorer exactly (field request, refined over four hardware rounds):

- Up/Refresh stay in slim nav bars **above** each tree.
- Each labeled path box sits in its own row directly **under** its tree.
- The image side's New Folder / Rename / Delete cluster joins that row — **flush** against the box (legacy spacer labels out of the layout, zero margins), **natural widths** (the 190px minimums starved the box), the box owning all the slack.

## Tests

The offscreen suite pins the arrangement: named grid rows, the one-bottom-row order, stretch ownership, and flushness. MainWindow gained aliases for the two new nav containers — their absence crashed phase 1 with an `AttributeError` whose lingering Qt process masqueraded as a hang. Full suite green including all 14 offscreen phases. Version bumped in both homes: 9.5.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)