### PR TITLE
Test: poll the silent-peer verdict — the emit-after-start race dies

### DIFF
--- a/tests/test_bridge_stall.py
+++ b/tests/test_bridge_stall.py
@@ -242,7 +242,13 @@ def test_silent_peer_is_reaped():
         dot.sendall(b"Poll")
         check("silent: a poll is answered while alive",
               len(rx_payload(dot)) >= 1)
-        check("silent: session reports connected", state["connected"] is True)
+        # The accept loop starts the session thread BEFORE it emits
+        # connected, so the poll reply above can beat the signal on a
+        # loaded machine (CI run 31823405610) — and a missed True here
+        # would also let the wait below return vacuously before the
+        # silence limit ever fired. Poll for the verdict instead.
+        check("silent: session reports connected",
+              wait_until(lambda: state["connected"] is True, timeout=10.0))
 
         # ...and now the Next "loses power": no FIN, no RST, just silence.
         t0 = time.time()


### PR DESCRIPTION
Post-merge run 31823405610 flaked on the listen worker's silent-peer scenario. Root cause (found and verified in a dedicated session): the accept loop starts the session thread **before** emitting `connected` — on a loaded runner the session answers the first Poll before the emit is scheduled, the test's instant check reads False, and the cascade makes "dead peer noticed" pass vacuously at 0.0 s with the log line unwritten.

Fix: the `connected` verdict is polled via the file's own `wait_until` (up to 10 s), race documented in place. **No product code changed** — the emit ordering is harmless in the app; polling is the pattern for any future post-handshake assertion.

Verified: 11 consecutive green runs, plus a deterministic reproduction (inserted 1 s scheduling gap) that shows the exact CI failure signature with the old check and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)