### PR TITLE
HTTP bridge: sessions - ?session=N drives a seated Next, the baton stays put

### DIFF
--- a/nextsync/sync/server/HTTP_BRIDGE.md
+++ b/nextsync/sync/server/HTTP_BRIDGE.md
@@ -63,8 +63,9 @@ console error. Stop the other program or pick another port.
 
 Every route answers **plain text** (easy to show or parse on a Next); append
 `&json=1` (or send `Accept: application/json`) for JSON. Failures use real
-HTTP status codes: `400` bad arguments, `501` unsupported, `502` the Next
-said no, `503` no Next connected, `504` timed out.
+HTTP status codes: `400` bad arguments, `410` the selected session is gone
+(see `/sessions`), `501` unsupported, `502` the Next said no, `503` no Next
+connected, `504` timed out.
 
 Remote paths accept an optional drive prefix (`m:/backup`) exactly like every
 other NextSync command. URL-encode special characters (space = `%20`).
@@ -166,9 +167,57 @@ connected: yes
 current: C
 drives: C M
 partitions: 2
+inflight: 0
+sessions: 2
+active: 1
 ```
 `listening` = the -listen server is running; `connected` = a Next is actually
-in `.sync5 -listen`; `partitions` = number of mounted drives.
+in `.sync5 -listen`; `partitions` = number of mounted drives. The trailing
+`sessions:`/`active:` lines appear only on a multi-session host (the app) —
+they are appended LAST so parsers of the original shape never notice them;
+`current`/`drives` always describe the **active** session.
+
+### `GET /sessions` — the seated Nexts, and driving a specific one
+
+The app's Remote Explorer seats up to **four** `-listen` Nexts at once (its
+combo box picks the one the UI drives). `/sessions` lists them:
+
+```
+curl "http://localhost/sessions"
+.http -h 192.168.1.10 -u /sessions -f sessions.txt
+```
+```
+OK active: 1 count: 2 max: 4
+1	10.0.0.185 #1 - Next
+2	10.0.0.42 #2 - N-Go
+```
+One line per seat: the **sid** (a number, never reused for the whole app
+run), a TAB, then the exact label the app's combo shows. With `&json=1`
+each entry is `{sid, addr, name, label, active}`.
+
+**Every op route** (`/ls`, `/get`, `/put`, `/mkdir`, `/rmdir`, `/rmtree`,
+`/rm`, `/ren`, `/rcpy`, `/rfsize`, `/free`, `/drives`, `/sum`) then accepts a
+session selector — `&session=<sid>`, or the `ZXNEXTUNITE-BRIDGE-SESSION`
+request header (the query param wins when both are present):
+
+```
+curl "http://localhost/ls?path=/games&session=2"
+```
+
+Targeted requests are delivered on that session's own queue: they **never
+move the app's active selection**, so driving Next #2 over HTTP does not
+yank the Remote Explorer pane away from Next #1. Without a selector the
+request goes to the active session — exactly the pre-session behaviour.
+
+A selector naming a seat that has left answers **HTTP 410** ("session N is
+gone"): re-fetch `/sessions` and pick again. A stale sid can never silently
+drive a different machine — sids are minted once per app run. `/forceexit`
+takes no selector: it ends **every** seated session (the stop is a
+broadcast). The standalone `nextsync5.py` host is single-session: its
+`/sessions` reports one synthetic seat (sid 1) while a Next is connected.
+
+> Note: with token protection on, `/sessions` needs the token header too —
+> the roster (LAN addresses + your machine names) is worth protecting.
 
 ### `GET /drives` — mounted drive letters
 

--- a/nextsync5.py
+++ b/nextsync5.py
@@ -630,7 +630,7 @@ _listen_cli_started = False
 # Live -listen session state for the HTTP bridge's /status route (see -http):
 # 'active' flips with the session, 'current'/'drives' cache the last getdrives
 # reply of this session.
-_listen_state = {'active': False, 'current': '', 'drives': None}
+_listen_state = {'active': False, 'current': '', 'drives': None, 'addr': ''}
 
 def _listen_queue():
     """The shared -listen command queue (created on first use). Both the
@@ -720,11 +720,19 @@ def listen_session(conn, stats, _test_commands=None):
     # quit, the Next hanging up, or a socket error unwinding through us.
     _listen_state['active'] = True
     try:
+        # The peer address feeds /sessions' synthetic single entry (this
+        # host has no roster; the bridge shows one seat, sid 1). Mock conns
+        # in the test harness have no peername - degrade to ''.
+        _listen_state['addr'] = conn.getpeername()[0]
+    except (OSError, AttributeError, IndexError):
+        _listen_state['addr'] = ''
+    try:
         _listen_session_inner(conn, stats, _test_commands)
     finally:
         _listen_state['active'] = False
         _listen_state['current'] = ''
         _listen_state['drives'] = None
+        _listen_state['addr'] = ''
 
 def _listen_session_inner(conn, stats, _test_commands=None):
     global _in_transfer
@@ -1150,7 +1158,8 @@ def _start_http_bridge(port):
     def state():
         return {'listening': True, 'connected': _listen_state['active'],
                 'current': _listen_state['current'],
-                'drives': _listen_state['drives']}
+                'drives': _listen_state['drives'],
+                'addr': _listen_state['addr']}
 
     bridge = _zb.NextSyncHttpBridge(
         _zb.QueueBridgeHost(enqueue, make_cmd, state), port=port,

--- a/tests/test_http_bridge.py
+++ b/tests/test_http_bridge.py
@@ -291,6 +291,19 @@ def phase_b():
     j = json.loads(body)
     check("B /ls", st == 200 and len(j["entries"]) == 2, j)
 
+    # No roster on this host: /sessions synthesizes the one seat (sid 1),
+    # session=1 is accepted, anything else can only be stale -> 410.
+    st, body = http(HTTP_B, "/sessions?json=1")
+    j = json.loads(body)
+    check("B /sessions synthetic seat", st == 200 and j["count"] == 1
+          and j["max"] == 1 and j["active"] == 1
+          and j["sessions"][0]["sid"] == 1, j)
+    st, body = http(HTTP_B, "/ls?path=/&session=1&json=1")
+    j = json.loads(body)
+    check("B /ls session=1", st == 200 and len(j["entries"]) == 2, j)
+    st, body = http(HTTP_B, "/ls?path=/&session=2")
+    check("B stale sid -> 410", st == 410, (st, body))
+
     st, body = http(HTTP_B, "/get?path=boot.bas")
     check("B /get", st == 200 and body == filebytes, len(body))
 
@@ -325,6 +338,10 @@ def phase_b():
     st, body = http(HTTP_B, "/status?json=1")
     j = json.loads(body)
     check("B /status after quit", st == 200 and not j["connected"], j)
+    st, body = http(HTTP_B, "/sessions?json=1")
+    j = json.loads(body)
+    check("B /sessions after quit empty", st == 200 and j["count"] == 0
+          and j["active"] is None, j)
 
     bridge.stop()
     srv.close()
@@ -340,6 +357,181 @@ def http_h(port, path, headers=None):
             return r.status, r.read()
     except urllib.error.HTTPError as e:
         return e.code, e.read()
+
+
+# =====================================================================
+#  Phase SESSIONS: /sessions + session-targeted ops over the app worker
+# =====================================================================
+WORKER_S = 2051
+HTTP_S = 18086
+
+
+def phase_sessions():
+    """Multi-session bridge: GET /sessions lists the seated Nexts with the
+    combo's exact labels, ?session=N (or the header; the param wins)
+    targets one seat WITHOUT moving the baton, a malformed selector is
+    400, a departed sid is 410, and the sid counter survives the routine
+    worker restart — so a stale id can only ever mean "gone", never
+    "another machine"."""
+    print("=== phase SESSIONS: /sessions + session-targeted ops ===")
+    from zxnu_http_bridge import BRIDGE_SESSION_HEADER
+
+    app = QCoreApplication.instance() or QCoreApplication(sys.argv)  # noqa: F841
+    sig = RemoteExplorerSignals()
+    state = {"connected": False}
+    roster_seen = {"last": (None, [])}
+    sig.connected.connect(lambda: state.update(connected=True),
+                          Qt.DirectConnection)
+    sig.disconnected.connect(lambda: state.update(connected=False),
+                             Qt.DirectConnection)
+    sig.peers.connect(lambda p: roster_seen.update(last=p),
+                      Qt.DirectConnection)
+
+    cmd_q = queue.Queue()
+    stop = threading.Event()
+    control = {"seq": 0}                     # ONE dict across both workers
+    names = {"127.0.0.1": "Next"}            # the pane's address-keyed names
+
+    def make_cmd(op, a1, a2, reply):
+        if op == "ls":
+            return ("ls", a1, reply)
+        if op == "drives":
+            return ("drives", reply)
+        if op == "forceexit":
+            return ("quit", reply)
+        return None
+
+    def enqueue(cmd):
+        cmd_q.put(cmd)
+        return True
+
+    def state_fn():
+        return {"listening": True, "connected": state["connected"],
+                "current": "", "drives": None}
+
+    # Mirrors zxnu_nextsync_pane's wiring over the worker's control surface.
+    def sessions_fn():
+        r = control.get("roster")
+        active, plist = r() if r is not None else (None, [])
+        return (active, [(s, a, names.get(a, "")) for s, a in plist],
+                control.get("max_peers", 4))
+
+    def enqueue_to(sid, cmd):
+        fn = control.get("enqueue_to")
+        return bool(fn is not None and fn(sid, cmd))
+
+    bridge = NextSyncHttpBridge(
+        QueueBridgeHost(enqueue, make_cmd, state_fn,
+                        sessions=sessions_fn, enqueue_to=enqueue_to),
+        port=HTTP_S)
+    okd, err = bridge.start()
+    check("S bridge started", okd, err)
+
+    t = threading.Thread(target=run_remote_listen_server,
+                         args=(sig, cmd_q, stop, WORKER_S),
+                         kwargs={"control": control}, daemon=True)
+    t.start()
+    time.sleep(0.3)
+
+    def seat(entries, filebytes=b"x"):
+        s = socket.create_connection(("127.0.0.1", WORKER_S), timeout=10)
+        threading.Thread(target=mock_next,
+                         args=(s, entries, filebytes, {}, {}),
+                         daemon=True).start()
+        return s
+
+    def roster_size():
+        return len(roster_seen["last"][1])
+
+    s1 = seat([(False, 111, "one.txt")])
+    check("S first Next seated", wait_until(lambda: roster_size() == 1))
+    s2 = seat([(False, 222, "two.txt")])
+    check("S second Next seated", wait_until(lambda: roster_size() == 2))
+
+    st, body = http(HTTP_S, "/sessions?json=1")
+    j = json.loads(body)
+    check("S /sessions json", st == 200 and j["ok"] and j["count"] == 2
+          and j["active"] == 1 and j["max"] == 4
+          and [x["sid"] for x in j["sessions"]] == [1, 2], j)
+    check("S /sessions labels", j["sessions"][0]["label"]
+          == "127.0.0.1 #1 - Next"
+          and j["sessions"][0]["active"] is True
+          and j["sessions"][1]["active"] is False, j["sessions"])
+
+    st, body = http(HTTP_S, "/sessions")
+    lines = body.decode().splitlines()
+    check("S /sessions text", st == 200
+          and lines[0] == "OK active: 1 count: 2 max: 4"
+          and lines[1] == "1\t127.0.0.1 #1 - Next"
+          and lines[2] == "2\t127.0.0.1 #2 - Next", lines)
+
+    # Targeting: the benched session answers, the baton never moves.
+    st, body = http(HTTP_S, "/ls?path=/&session=2")
+    check("S /ls session=2 -> the benched Next", st == 200
+          and b"two.txt" in body and b"one.txt" not in body, body)
+    st, body = http(HTTP_S, "/ls?path=/")
+    check("S /ls unselected -> still the active Next", st == 200
+          and b"one.txt" in body, body)
+    check("S baton untouched", roster_seen["last"][0] == 1,
+          roster_seen["last"])
+
+    st, body = http_h(HTTP_S, "/ls?path=/",
+                      {BRIDGE_SESSION_HEADER: "2"})
+    check("S header selector", st == 200 and b"two.txt" in body, body)
+    st, body = http_h(HTTP_S, "/ls?path=/&session=1",
+                      {BRIDGE_SESSION_HEADER: "2"})
+    check("S param beats header", st == 200 and b"one.txt" in body, body)
+
+    st, body = http(HTTP_S, "/ls?path=/&session=abc")
+    check("S malformed selector -> 400", st == 400
+          and b"bad session selector" in body, (st, body))
+    st, body = http(HTTP_S, "/ls?path=/&session=99")
+    check("S unknown sid -> 410", st == 410 and b"gone" in body, (st, body))
+
+    st, body = http(HTTP_S, "/status?json=1")
+    j = json.loads(body)
+    check("S /status json roster fields", st == 200
+          and j["sessions"] == 2 and j["active"] == 1, j)
+    st, body = http(HTTP_S, "/status")
+    text = body.decode()
+    check("S /status text additive", "connected: yes" in text
+          and "sessions: 2" in text and "active: 1" in text, text)
+
+    # Departure: the reaper prunes the seat, its sid answers 410 forever.
+    s2.close()
+    check("S departed Next reaped", wait_until(lambda: roster_size() == 1))
+    st, body = http(HTTP_S, "/ls?path=/&session=2")
+    check("S departed sid -> 410", st == 410, (st, body))
+
+    # Restart: the last Next leaves, the worker returns (the pane would
+    # auto-relisten); a new worker over the SAME control dict must keep
+    # counting — the next seat is #3, and the old sids stay 410.
+    s1.close()
+    check("S last-leave ends the worker",
+          wait_until(lambda: not state["connected"]))
+    t.join(timeout=5)
+    check("S worker returned", not t.is_alive())
+    t2 = threading.Thread(target=run_remote_listen_server,
+                          args=(sig, cmd_q, stop, WORKER_S),
+                          kwargs={"control": control}, daemon=True)
+    t2.start()
+    time.sleep(0.3)
+    s3 = seat([(False, 333, "three.txt")])
+    check("S reseated", wait_until(lambda: roster_size() == 1
+                                   and state["connected"]))
+    st, body = http(HTTP_S, "/sessions?json=1")
+    j = json.loads(body)
+    check("S sid continuity across restart", st == 200 and j["count"] == 1
+          and j["sessions"][0]["sid"] == 3 and j["active"] == 3, j)
+    st, body = http(HTTP_S, "/ls?path=/&session=3")
+    check("S /ls new sid", st == 200 and b"three.txt" in body, body)
+    st, body = http(HTTP_S, "/ls?path=/&session=1")
+    check("S pre-restart sid stays 410", st == 410, (st, body))
+
+    stop.set()
+    s3.close()
+    bridge.stop()
+    t2.join(timeout=5)
 
 
 def phase_token():
@@ -433,6 +625,8 @@ def main():
     phase_a()
     print()
     phase_b()
+    print()
+    phase_sessions()
     print()
     phase_token()
     print()

--- a/zxnu_http_bridge.py
+++ b/zxnu_http_bridge.py
@@ -30,6 +30,25 @@ Wire-up contract (all a host must provide — see :class:`QueueBridgeHost`):
 * ``state() -> dict``   {'listening': bool, 'connected': bool,
   'current': str, 'drives': list|None}.
 
+Multi-session hosts (the app seats up to four ``-listen`` Nexts) may also
+provide two OPTIONAL callables:
+
+* ``sessions() -> (active_sid, [(sid, addr, name), …], max_peers)``   the
+  live roster snapshot (names may be "");
+* ``enqueue_to(sid, cmd) -> bool``   put one command tuple on THAT
+  session's own queue (False when the sid is gone) — delivery must not
+  move the host's notion of the active session.
+
+With those provided, every op route accepts a session selector
+(``?session=N`` or the ``ZXNEXTUNITE-BRIDGE-SESSION`` header; the query
+param wins) and ``GET /sessions`` lists the roster. No selector = the
+active session, exactly the pre-session behaviour. A selector naming a
+session that is gone answers HTTP 410 — never a silent retarget: sids are
+minted once per app run and never reused, so a stale id can only mean
+"that Next left". Hosts without the callables stay single-session:
+/sessions synthesizes one entry (sid 1) from ``state()`` (plus its
+``addr`` key when provided), and only ``session=1`` is accepted.
+
 The host's command executor must then fill ``reply`` with a result dict —
 and, by convention, a command carrying a reply is SILENT: it reports only
 through the reply, never through the host's usual UI signals/prints, so
@@ -65,6 +84,21 @@ DEFAULT_PORT = 80          # .http's default; HTTP only (no TLS on the Next)
 # zxnu_config.NEXTSYNC_BRIDGE_TOKEN_HEADER (this module stays stdlib-only so it
 # does not import the app's config).
 BRIDGE_TOKEN_HEADER = "ZXNEXTUNITE-BRIDGE-TOKEN"
+
+# HTTP header carrying the optional session selector (ZXNextRemote sends the
+# header rather than &session= so deep paths keep their whole 250-char query
+# budget). The query param, when both are present, wins: explicit beats
+# ambient.
+BRIDGE_SESSION_HEADER = "ZXNEXTUNITE-BRIDGE-SESSION"
+
+
+def session_label(sid, addr, name=""):
+    """THE session label, one composer for every surface: the Remote
+    Explorer's machine dropdown, /sessions, and ZXNextRemote's title line
+    all show exactly this string — "10.0.0.185 #1 - Next" (the " - name"
+    tail only when the machine has a friendly name)."""
+    base = f"{addr} #{sid}"
+    return f"{base} - {name}" if name else base
 
 
 def flask_available():
@@ -145,10 +179,13 @@ class QueueBridgeHost:
     bytes) and put (write the request body to a temp file the executor can
     stream)."""
 
-    def __init__(self, enqueue, make_cmd, state):
+    def __init__(self, enqueue, make_cmd, state, sessions=None,
+                 enqueue_to=None):
         self._enqueue = enqueue
         self._make_cmd = make_cmd
         self._state = state
+        self._sessions = sessions
+        self._enqueue_to = enqueue_to
         self._lock = threading.Lock()
 
     def state(self):
@@ -158,11 +195,40 @@ class QueueBridgeHost:
             return {"listening": False, "connected": False,
                     "current": "", "drives": None, "error": str(ex)}
 
-    def run(self, op, a1="", a2="", body=None, timeout=None):
-        """Run one canonical bridge op against the connected Next. Returns the
-        executor's result dict; on bridge-level failures the dict carries
-        ``ok: False`` plus an ``http`` status suggestion (501/503/504)."""
+    def roster(self):
+        """(active_sid, [(sid, addr, name), …], max_peers) or None when this
+        host has no session roster (nextsync5's single-session console)."""
+        if self._sessions is None:
+            return None
+        try:
+            active, rows, maxp = self._sessions()
+            return (active,
+                    [(int(s), str(a), str(n or "")) for s, a, n in rows],
+                    int(maxp))
+        except Exception:                            # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _gone(session):
+        return {"ok": False, "http": 410,
+                "error": f"session {session} is gone - "
+                         "GET /sessions for the live list"}
+
+    def run(self, op, a1="", a2="", body=None, timeout=None, session=None):
+        """Run one canonical bridge op against the connected Next — the
+        active session by default, ``session=<sid>`` to target a seated one
+        (delivered on that session's own queue; the active/baton state is
+        never touched). Returns the executor's result dict; on bridge-level
+        failures the dict carries ``ok: False`` plus an ``http`` status
+        suggestion (410/501/503/504)."""
         st = self.state()
+        if session is not None and self._enqueue_to is None:
+            # Single-session host: sid 1 IS the one session; anything else
+            # can only be stale. (Validated before the connected gate so a
+            # stale id answers 410, not 503, when nothing is connected.)
+            if session != 1:
+                return self._gone(session)
+            session = None
         if not st.get("connected"):
             return {"ok": False, "http": 503,
                     "error": "no Next is connected in '.sync5 -L' (-l or -listen) mode"}
@@ -187,7 +253,13 @@ class QueueBridgeHost:
                 if cmd is None:
                     return {"ok": False, "http": 501,
                             "error": f"'{op}' is not supported by this server"}
-                if not self._enqueue(cmd):
+                if session is not None:
+                    # Targeted delivery. No roster pre-check: enqueue_to
+                    # validates the sid under the worker's own lock, so the
+                    # check and the put cannot straddle a departure.
+                    if not self._enqueue_to(session, cmd):
+                        return self._gone(session)
+                elif not self._enqueue(cmd):
                     return {"ok": False, "http": 503,
                             "error": "the -listen session is not running"}
                 res = reply.wait(timeout)
@@ -256,6 +328,10 @@ class NextSyncHttpBridge:
         "NextSync HTTP bridge - drive the Next connected in '.sync5 -L' (-l or -listen)\n"
         "Routes (text by default; append &json=1 for JSON):\n"
         "  GET  /status                     server + Next state, partitions\n"
+        "  GET  /sessions                   list the seated -listen Nexts\n"
+        "       (every op route below also takes &session=<sid> — or the\n"
+        "       ZXNEXTUNITE-BRIDGE-SESSION header — to target one seated\n"
+        "       Next; no selector = the active one; a departed sid = 410)\n"
         "  GET  /drives                     mounted drive letters\n"
         "  GET  /free?drive=C               free space on a partition\n"
         "  GET  /ls?path=/games             directory listing\n"
@@ -529,6 +605,33 @@ class NextSyncHttpBridge:
                     status=401, mimetype="application/json")
             return Response(f"ERR {msg}\n", status=401, mimetype="text/plain")
 
+        # ---- session selector (after the token guard: an unauthorised
+        # request never learns whether its sid parses) ---------------------
+        @app.before_request
+        def _resolve_session():        # noqa: ANN202
+            v = ((request.args.get("session") or "").strip()
+                 or (request.headers.get(BRIDGE_SESSION_HEADER) or "").strip())
+            if not v:
+                request.environ["zxnu.session"] = None
+                return None
+            try:
+                n = int(v, 10)
+                if n <= 0:
+                    raise ValueError
+            except ValueError:
+                msg = f"bad session selector '{v}' (want a positive integer)"
+                if (request.args.get("json") in ("1", "true", "yes")
+                        or "application/json"
+                        in (request.headers.get("Accept") or "")):
+                    return Response(
+                        json.dumps({"ok": False, "error": msg,
+                                    "status": 400}) + "\n",
+                        status=400, mimetype="application/json")
+                return Response(f"ERR {msg}\n", status=400,
+                                mimetype="text/plain")
+            request.environ["zxnu.session"] = n
+            return None
+
         # ---- in-flight tracking (always) + -v tracing --------------------
         # Registered unconditionally: the live count and the stall watchdog
         # are diagnostics you want available the moment something wedges,
@@ -606,9 +709,28 @@ class NextSyncHttpBridge:
             return answer({"ok": False, "error": err, "status": status},
                           [f"ERR {err}"], status)
 
+        def sid_now():
+            """This request's session selector (already validated by the
+            before_request guard), or None for the active session."""
+            return request.environ.get("zxnu.session")
+
+        def skey(path):
+            """Cache key for per-session state: sids are never reused within
+            an app run, so (sid, path) can't alias across machines. None
+            (the active session) is its own bucket — it may move between
+            machines mid-flight, which is exactly the pre-session behaviour
+            those callers opted into."""
+            return (sid_now(), path)
+
         def run(op, a1="", a2="", body=None):
-            self._log(f"HTTP bridge: {op} {a1} {a2}".rstrip())
-            return self._adapter.run(op, a1, a2, body=body)
+            sid = sid_now()
+            self._log(f"HTTP bridge: {op} {a1} {a2}".rstrip()
+                      + (f" [session {sid}]" if sid is not None else ""))
+            if sid is None:
+                # No selector -> the pre-session call shape, so adapters
+                # (and test fakes) that never learned the kwarg still work.
+                return self._adapter.run(op, a1, a2, body=body)
+            return self._adapter.run(op, a1, a2, body=body, session=sid)
 
         def need(*names):
             """Fetch required query args (supporting aliases per name tuple);
@@ -635,10 +757,50 @@ class NextSyncHttpBridge:
         def _help():
             return Response(self.ROUTES_HELP, mimetype="text/plain")
 
+        def adapter_roster():
+            # getattr, not a straight call: adapters predating (or ignoring)
+            # the session surface — tests ship minimal fakes — stay valid.
+            fn = getattr(self._adapter, "roster", None)
+            return fn() if fn is not None else None
+
+        # ---- sessions -------------------------------------------------
+        @app.route("/sessions")
+        def _sessions():
+            r = adapter_roster()
+            if r is None:
+                # Single-session host (nextsync5's console): synthesize the
+                # one seat from state() so every client sees the same shape.
+                st = self._adapter.state()
+                if st.get("connected"):
+                    rows = [(1, str(st.get("addr") or ""), "")]
+                    active = 1
+                else:
+                    rows, active = [], None
+                maxp = 1
+            else:
+                active, rows, maxp = r
+            return answer(
+                {"ok": True, "active": active, "count": len(rows),
+                 "max": maxp,
+                 "sessions": [{"sid": s, "addr": a, "name": n,
+                               "label": session_label(s, a, n),
+                               "active": s == active}
+                              for s, a, n in rows]},
+                [f"OK active: {active if active is not None else '-'} "
+                 f"count: {len(rows)} max: {maxp}"]
+                + [f"{s}\t{session_label(s, a, n)}" for s, a, n in rows])
+
         # ---- status ---------------------------------------------------
         @app.route("/status")
         def _status():
             st = self._adapter.state()
+            roster = adapter_roster()
+            # The drives/current pair below describes the ACTIVE session;
+            # when the baton moves the cached answer is another machine's.
+            active_now = roster[0] if roster else None
+            if (self._drives_cache is not None
+                    and self._drives_cache.get("sid") != active_now):
+                self._drives_cache = None
             drives = st.get("drives")
             if not st.get("connected"):
                 self._drives_cache = None
@@ -649,6 +811,7 @@ class NextSyncHttpBridge:
                     res = self._adapter.run("drives", timeout=15.0)
                     if res and res.get("ok"):
                         self._drives_cache = {
+                            "sid": active_now,
                             "current": res.get("current", ""),
                             "drives": list(res.get("letters") or [])}
                 if self._drives_cache is not None:
@@ -668,6 +831,15 @@ class NextSyncHttpBridge:
                        "inflight": len(busy),
                        "busy": [{"seconds": round(s, 1), "request": r}
                                 for s, r in busy]}
+            # Additive multi-session lines (roster hosts only): appended
+            # LAST so strict line-order parsers of the original shape —
+            # ZXNextRemote strstr's "connected: yes" — never notice them.
+            extra = []
+            if roster is not None:
+                payload["sessions"] = len(roster[1])
+                payload["active"] = active_now
+                extra = [f"sessions: {len(roster[1])}",
+                         f"active: {active_now if active_now is not None else '-'}"]
             return answer(payload, [
                 f"listening: {'yes' if listening else 'no'}",
                 f"connected: {'yes' if connected else 'no'}",
@@ -675,7 +847,7 @@ class NextSyncHttpBridge:
                 f"drives: {' '.join(drives) if drives else '-'}",
                 f"partitions: {parts}",
                 f"inflight: {len(busy)}",
-            ] + [f"busy: {s:.0f}s {r}" for s, r in busy])
+            ] + [f"busy: {s:.0f}s {r}" for s, r in busy] + extra)
 
         # ---- drives / free -------------------------------------------
         @app.route("/drives")
@@ -762,7 +934,7 @@ class NextSyncHttpBridge:
                 return bad("off/len out of range")
             with self._get_cache_lock:
                 c = self._get_cache
-                data = c["data"] if (off and c["path"] == path) else None
+                data = c["data"] if (off and c["path"] == skey(path)) else None
             if data is None:
                 # A fresh file (off=0) — or an evicted cache: relay anew.
                 res = run("get", path)
@@ -770,12 +942,12 @@ class NextSyncHttpBridge:
                     return fail(res, f"get {path}")
                 data = res.get("data") or b""
                 with self._get_cache_lock:
-                    self._get_cache = {"path": path, "data": data}
+                    self._get_cache = {"path": skey(path), "data": data}
             chunk = bytes(data[off:off + ln])
             done = off + ln >= len(data)
             if done:
                 with self._get_cache_lock:
-                    if self._get_cache["path"] == path:
+                    if self._get_cache["path"] == skey(path):
                         self._get_cache = {"path": None, "data": b""}
             elif off and not self._verbose:
                 # ~90 mid-file slices would bury the console: only the
@@ -808,15 +980,15 @@ class NextSyncHttpBridge:
                 return bad(f"size {total} exceeds the chunked-upload cap "
                            f"of {self.MAX_SPOOL} bytes")
             with self._spool_lock:
-                sp = self._put_spool.get(path)
+                sp = self._put_spool.get(skey(path))
                 if sp is None or sp["size"] != total:
                     sp = {"size": total, "data": bytearray(), "chunks": 0}
-                    self._put_spool[path] = sp
+                    self._put_spool[skey(path)] = sp
                 sp["data"] += body
                 sp["chunks"] += 1
                 got, chunks = len(sp["data"]), sp["chunks"]
                 if got > total:
-                    del self._put_spool[path]
+                    del self._put_spool[skey(path)]
                     return bad(f"append overflow: got {got} of {total} "
                                "declared bytes - upload dropped, send it "
                                "again from the first chunk")
@@ -826,7 +998,7 @@ class NextSyncHttpBridge:
                          "bytes": got, "size": total, "chunks": chunks},
                         [f"OK append {path} ({got}/{total} bytes)"])
                 data = bytes(sp["data"])
-                del self._put_spool[path]
+                del self._put_spool[skey(path)]
             res = run("put", path, body=data)
             if not res.get("ok"):
                 return fail(res, f"put {path}")
@@ -853,7 +1025,7 @@ class NextSyncHttpBridge:
             with self._spool_lock:
                 # A plain put overwrites: also discard any half-done chunked
                 # upload spooled for the same path.
-                self._put_spool.pop(path, None)
+                self._put_spool.pop(skey(path), None)
             res = run("put", path, body=body)
             if not res.get("ok"):
                 return fail(res, f"put {path}")

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -475,6 +475,13 @@ def build_nextsync_pane(
     # the worker's signals with DirectConnection (plain field writes from
     # the worker thread — no Qt event loop involvement needed).
     host._re_bridge_state = {"connected": False, "current": "", "drives": None}
+    # The worker's control surface, ONE dict for the whole app run: the
+    # worker seeds its sid counter from control['seq'] (so sids never
+    # restart across the routine last-Next-leaves/relisten cycle — a stale
+    # HTTP session id must mean "gone", never "another machine") and
+    # installs 'roster'/'enqueue_to'/'max_peers' for the bridge's
+    # session-targeted routes each time it starts.
+    host._re_control = {"seq": 0}
 
     def _re_bridge_make_cmd(op, a1, a2, reply):
         # Canonical bridge op -> the worker's command-tuple dialect, with
@@ -515,6 +522,29 @@ def build_nextsync_pane(
                 "current": st["current"] or "",
                 "drives": list(st["drives"]) if st["drives"] else None}
 
+    def _re_bridge_sessions():
+        # Roster snapshot for GET /sessions: worker sids + addresses,
+        # decorated with the same address-keyed friendly names the Remote
+        # Explorer combo shows. Reading the name map from an HTTP thread is
+        # safe: it is a plain dict-backed config read, never written here.
+        roster = host._re_control.get('roster')
+        active, plist = roster() if roster is not None else (None, [])
+        if not host._re_running:
+            active, plist = None, []
+        return (active,
+                [(sid, addr, _re_machine_name_for(addr) or "")
+                 for sid, addr in plist],
+                int(host._re_control.get('max_peers', 4)))
+
+    def _re_bridge_enqueue_to(sid, cmd):
+        # Targeted delivery for ?session=N — the session's own queue, the
+        # baton untouched. The worker's closure validates sid under its
+        # roster lock; False (gone / not running) maps to HTTP 410.
+        fn = host._re_control.get('enqueue_to')
+        if fn is None or not host._re_running:
+            return False
+        return bool(fn(sid, cmd))
+
     def _nextsync_http_bridge_start():
         if host._re_bridge is not None and host._re_bridge.running:
             return
@@ -537,7 +567,9 @@ def build_nextsync_pane(
             SETTING_NEXTSYNC_HTTP_TOKEN) or "").strip()
         host._re_bridge = NextSyncHttpBridge(
             QueueBridgeHost(_re_bridge_enqueue, _re_bridge_make_cmd,
-                            _re_bridge_session_state),
+                            _re_bridge_session_state,
+                            sessions=_re_bridge_sessions,
+                            enqueue_to=_re_bridge_enqueue_to),
             port=port, connection_limit=conn_limit,
             auth_token=_token if (_token_on and _token) else None,
             verbose=(configuration_dictionary.get(
@@ -1222,6 +1254,7 @@ def build_nextsync_pane(
         host._re_thread = threading.Thread(
             target=run_remote_listen_server,
             args=(host._re_sig, host._re_queue, host._re_stop),
+            kwargs={"control": host._re_control},
             daemon=True)
         host._re_thread.start()
         host._re_running = True

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -17,6 +17,7 @@ import posixpath
 import shutil
 import tempfile
 
+from zxnu_http_bridge import session_label   # stdlib-only at import
 from zxnu_i18n import ui_tr_now
 
 from PySide6.QtCore import (
@@ -1297,10 +1298,11 @@ class RemoteExplorerWidget(QWidget):
 
     def _machine_label(self, sid, addr):
         """One combo entry: "addr #sid", plus " - Name" when the host
-        remembers a friendly name for that address."""
-        name = self._machine_name_for(addr) or ""
-        base = f"{addr} #{sid}"
-        return f"{base} - {name}" if name else base
+        remembers a friendly name for that address. Delegates to the ONE
+        composer (zxnu_http_bridge.session_label, stdlib-only) so the
+        combo, GET /sessions and ZXNextRemote's title line can never
+        drift apart."""
+        return session_label(sid, addr, self._machine_name_for(addr) or "")
 
     def _on_machine_name_edit(self):
         """The ✎ button: name (or rename) the machine the combo currently

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -675,11 +675,14 @@ def _re_session(sid, conn, addr, my_q, sig, cmd_queue, stop_event, shared,
     command queue; every other session merely answers its Next's polls
     with the idle reply, so the link stays warm while the user works a
     different machine -- the Next itself never knows it is benched.
-    ``my_q`` carries session-directed commands (today: the broadcast
-    "quit"); a ("select_next", sid) popped from the shared queue moves
-    the baton and is answered with an idle. Each session owns its owed
-    bridge sinks, its put/rmtree state and its silence timer, exactly as
-    the single session always did.
+    ``my_q`` carries session-directed commands: the broadcast "quit" and
+    the HTTP bridge's session-TARGETED ops (?session=N), which run here
+    even while this session is benched -- targeted traffic never moves
+    the baton, so it cannot yank the Remote Explorer pane. A
+    ("select_next", sid) popped from the shared queue moves the baton
+    and is answered with an idle. Each session owns its owed bridge
+    sinks, its put/rmtree state and its silence timer, exactly as the
+    single session always did.
     """
     peers = shared['peers']
     plock = shared['lock']
@@ -1339,6 +1342,19 @@ def _re_session(sid, conn, addr, my_q, sig, cmd_queue, stop_event, shared,
         # Clean exits owe answers too -- a "quit" mid-transfer, the Next
         # dropping the link, or the user stopping the server.
         _fail_owed("the -listen session ended before the command finished")
+        # Session-TARGETED commands still queued (never taken) would
+        # otherwise strand their HTTP callers for the full bridge timeout:
+        # fail them now, with the 410 the bridge maps to "session gone".
+        while True:
+            try:
+                c = my_q.get_nowait()
+            except queue.Empty:
+                break
+            r = c[-1] if c and isinstance(c[-1], BridgeReply) else None
+            if r is not None:
+                r.put({'ok': False, 'http': 410,
+                       'error': f"session {sid} is gone - "
+                                "GET /sessions for the live list"})
         try:
             conn.close()
         except OSError:
@@ -1346,7 +1362,7 @@ def _re_session(sid, conn, addr, my_q, sig, cmd_queue, stop_event, shared,
 
 
 def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
-                             max_payload=512):
+                             max_payload=512, control=None):
     # max_payload is 512, not the protocol's 1024 cap: ZXNextRemote's bench
     # testing found Next CLONES (N-Go) corrupt >512-byte continuous UART
     # bursts at the Medium/Fast rates — deterministically, close checksums —
@@ -1465,7 +1481,16 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
         # session pops the shared queue directly on every poll.
         peers = {}                     # sid -> {'addr', 'q', 'thread'}
         plock = threading.Lock()
-        state = {'active': None, 'seq': 0, 'had_any': False}
+        # The sid counter is seeded from (and written back to) the caller's
+        # ``control`` dict so it SURVIVES worker restarts: the worker returns
+        # whenever the last Next leaves and the pane relistens with a fresh
+        # one, and a restarting counter would let a remote client's cached
+        # "session=1" silently drive a DIFFERENT machine. Sids are therefore
+        # unique for the whole app run, and a stale sid can only mean "that
+        # Next left" (the bridge answers 410), never "someone else".
+        control = control if control is not None else {}
+        state = {'active': None, 'seq': int(control.get('seq', 0)),
+                 'had_any': False}
 
         def _emit_peers():
             with plock:
@@ -1475,6 +1500,28 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
 
         shared = {'peers': peers, 'lock': plock, 'state': state,
                   'emit_peers': _emit_peers}
+
+        # ---- the control surface (HTTP bridge -> this worker) ----------
+        # Both closures take plock themselves, so a bridge thread's check
+        # and delivery cannot straddle a departure. After this worker
+        # returns, ``peers`` is empty and they degrade to False/[] until a
+        # relisten installs fresh ones over the same dict.
+        def _roster():
+            with plock:
+                return (state['active'],
+                        [(s, p['addr']) for s, p in sorted(peers.items())])
+
+        def _enqueue_to(sid, cmd):
+            with plock:
+                p = peers.get(sid)
+                if p is None:
+                    return False
+                p['q'].put(cmd)
+                return True
+
+        control['roster'] = _roster
+        control['enqueue_to'] = _enqueue_to
+        control['max_peers'] = RE_MAX_PEERS
 
         while not stop_event.is_set():
             # Reap ended sessions; hand the baton on if the active died —
@@ -1589,6 +1636,7 @@ def run_remote_listen_server(sig, cmd_queue, stop_event, port=2048,
             with plock:
                 state['seq'] += 1
                 sid = state['seq']
+                control['seq'] = sid   # persists across worker restarts
                 my_q = queue.Queue()
                 first = not peers
                 peers[sid] = {'addr': addr[0], 'q': my_q, 'thread': None}


### PR DESCRIPTION
## Summary
The HTTP bridge becomes multi-session-aware (companion to ZXNextRemote''s `zxr13`):

- **`GET /sessions`** lists the seated `-listen` Nexts: sid + the combo''s exact label, now composed by ONE shared helper (`session_label`) so the widget, the route and ZXNextRemote''s title can never drift.
- **Every op route takes a session selector** - `&session=N` or the `ZXNEXTUNITE-BRIDGE-SESSION` header (param wins). Targeted commands ride the seat''s own queue: the active/baton state is never touched, so HTTP driving Next #2 cannot yank the Remote Explorer pane off Next #1.
- **Identity is the load-bearing piece**: the sid counter lives in the pane''s control dict and survives the routine last-Next-leaves/relisten worker restart - sids are unique per app run, so a stale id can only mean "gone": answered **HTTP 410**, never a silent retarget onto a different machine (fatal with `/rm`-class verbs). A dying session also drains its queue and 410s never-taken targeted commands instead of stranding their HTTP callers for the full 45/270 s timeout.
- Put spool + ranged-get cache are session-keyed; `/status` gains additive `sessions:`/`active:` lines (appended last - strict line parsers never notice) and its drives cache invalidates on a baton move; `nextsync5.py` stays single-session with a synthetic seat (sid 1).

## Verification
- `test_http_bridge.py`: new SESSIONS phase (targeting, header vs param, 400/410, baton untouched, reap, sid continuity across a worker restart) + synthetic-seat checks in phase B - ALL PASS.
- `test_listen_busy.py`, `test_remote_explorer_widget.py`, `test_bridge_stall.py` - ALL PASS.
- `HTTP_BRIDGE.md` documents `/sessions`, the selector and the 410 contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)