### PR TITLE
9.5.20: the bridge learns its seats - the multi-session release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.19"
+version = "9.5.20"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.19"
+ZX_NEXT_UNITE_VERSION = "9.5.20"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync


### PR DESCRIPTION
Version bump (pyproject.toml + zxnu_config.py, the release.yml tag-match pair) for the multi-session HTTP bridge shipped in #287. Tag v9.5.20 follows the merge; the draft release then carries GET /sessions + session targeting to packaged-release users. Companion: ZXNextRemote 0.9.11 (jclauzel/ZXNextRemote#56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)