### PR TITLE
build_dotn.ps1: the dot could not be built from a clone

### DIFF
--- a/nextsync/sync/z88dk/build_dotn.ps1
+++ b/nextsync/sync/z88dk/build_dotn.ps1
@@ -170,7 +170,22 @@ Write-Host "Building syncdev (dotN)..."
 $rc = Invoke-Zcc @("+zxn", "-startup=30", "-clib=sdcc_iy", "-SO3",
     "--max-allocs-per-node200000", "--opt-code-size", "@zproject.lst",
     "-o", "syncdev", "-pragma-include:zpragma.inc",
-    "-subtype=dotn", "-Cz--clean", "-create-app", "-m")
+    "-subtype=dotn", "-Cz--clean", "-create-app", "-m",
+    # -Ca-I<z88dk>\lib\crt\newlib: WITHOUT THIS THE DOT DOES NOT BUILD.
+    # lib/crt/newlib/clib_stubs.inc pulls the dynamic-printf body in with a
+    # RELATIVE include - "../../../libsrc/newlib/stdio/z80/asm_vfprintf_
+    # unlocked[_iy].asm" - and z80asm resolves that against the CURRENT
+    # WORKING DIRECTORY, not against the file doing the including. Our cwd
+    # is <repo>\nextsync\sync\z88dk, so it looked for <repo>\libsrc and
+    # failed with "file not found". Adding the crt directory to the
+    # assembler include path gives the ../../../ the base it expects,
+    # which lands on the real <z88dk>\libsrc. Verified byte-identical to
+    # running the same build from a dir three levels under C:\z88dk.
+    #
+    # Only the dot hits this. ZXNextRemote links -startup=31 (the empty
+    # device model, no stdio driver) so the printf branch is never taken;
+    # the dot is -startup=30 and pulls it in.
+    ("-Ca-I" + (Join-Path $Z88dkDir "lib\crt\newlib")))
 if ($rc -ne 0) { throw "zcc build failed (exit $rc)." }
 if (-not (Test-Path syncdev)) { throw "build produced no 'syncdev' file." }
 


### PR DESCRIPTION
Building the dotN from the repo has been failing outright:

```
clib_stubs.inc:54: error: file not found:
    ../../../libsrc/newlib/stdio/z80/asm_vfprintf_unlocked.asm
```

**The file is not missing.** `lib/crt/newlib/clib_stubs.inc` pulls the dynamic-printf body in with a *relative* include, and `z80asm` resolves that against the **current working directory** rather than against the file doing the including. Our cwd is `<repo>\nextsync\sync\z88dk`, so `../../../libsrc` lands on `<repo>\libsrc`, which does not exist.

Building the identical tree from a directory three levels under `C:\z88dk` — where the same relative path happens to resolve — succeeds first time. That is what pinned the cause down.

## The fix

Hand `z80asm` the crt directory as an include path, so the `../../../` gets the base it expects and lands on the real `<z88dk>\libsrc`. One argument on the link.

Output is **byte-identical** to the from-inside-z88dk build (sha256 `29a62169…`), so this is a path fix rather than a behaviour change.

Only the dot hits this. ZXNextRemote links `-startup=31` — the empty device model with no stdio driver — so the printf branch is never taken; the dot is `-startup=30` and pulls it in.

## Scope: build fix only

`syncdev` is deliberately **not** rebuilt in this PR. The shipped `nextsync/sync/server/dot/syncdev` is still the 13 Aug binary from the old local z88dk, and `release.yml` ships that committed file verbatim (`cp … package/sync5`) — it has never compiled the dot itself.

Rebuilding with the current nightly is a real improvement:

| metric | shipped (old) | nightly 20260810 | |
|---|---|---|---|
| stack headroom | **162 B** | **560 B** | +398 |
| `__bss_dot_tail` | `$3EE8` | `$3EB1` | margin to `$3F0F`: 39 → 94 B |
| `__code_dot_tail` | `$3D9F` | `$3D68` | −55 B |
| allocation mask | — | `0x30` ✓ | the N-Go check passes |

The headroom number is the one that matters: `build_dotn.ps1`'s own comment records that 5.7.1 ran clean at 156 bytes and 5.7.2 broke at 46 — so the shipped dot sits **six bytes above the hardware-proven floor**, on exactly the failure mode that turned the `-anim` flock to static.

But it changes the binary, and the dot is the wire-facing component with no automated coverage. That re-release is a separate, hardware-tested decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
