### PR TITLE
9.5.21: pyproject.toml version, missed in the bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.20"
+version = "9.5.21"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
The `v9.5.21` tag build failed its very first gate:

```
::error::Tag v9.5.21 does not match version=9.5.20 in pyproject.toml
         - the PyPI publish uses that.
```

`release.yml` requires **three** things to agree before it builds anything: the tag, `ZX_NEXT_UNITE_VERSION` in `zxnu_config.py`, and `version` in `pyproject.toml`. `b30d6dfb` moved the first two and missed this one, so the workflow stopped at the verify step — `test`, `build` and `release` all skipped, and no draft appeared.

Nothing else was wrong: the test suite passed on `main` independently, and the committed `syncdev` already carries the `NextSync 5.7.4` banner.

After this merges the `v9.5.21` tag needs deleting and re-pushing to re-fire the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)