### PR TITLE
9.5.22: starfield idle panel, Ctrl+wheel explorer zoom, named OSP upload refusals

### DIFF
--- a/nextsync5.py
+++ b/nextsync5.py
@@ -189,12 +189,39 @@ def recv_block(conn):
         return 'BADCS'
     return (payload, pktno)
 
-def is_fail_block(data):
-    """True if data is the framed 1-byte 'F' status block a dotN pushes when a put
-    fails (couldn't create the file, or the transfer gave up):
-    [0x00 0x06]['F'][0x46][0x46][pktno] (0x46/0x46 is the checksum of 'F')."""
-    return (len(data) >= 6 and data[0] == 0x00 and data[1] == 0x06
-            and data[2:3] == b'F' and data[3] == 0x46 and data[4] == 0x46)
+# ZX Next Remote's OS-protection refusal marker + explanation. Kept in sync
+# with zxnu_workers.RE_OSP_MARK/RE_OSP_ERROR by hand: this script must stay
+# runnable standalone (no Qt, zxnu_http_bridge optional), so it cannot import
+# the app module that owns them.
+OSP_MARK = b"OSP"
+OSP_ERROR = (
+    "os-protected: write access is blocked in the remote operating "
+    "system. If the far side is ZX Next Remote, check its \"OS protection\" "
+    "setting and customise the restricted directory list if appropriate."
+)
+
+
+def fail_block_payload(data):
+    """The verified payload of a framed 'F' status block, else None.
+
+    A dotN pushes the classic 1-byte b"F" when a put fails (couldn't create
+    the file, or the transfer gave up); ZX Next Remote can mark WHY with a
+    suffix — b"FOSP" when its OS protection refused the write. Framing is
+    [len_hi len_lo][payload][cs0][cs1][pktno] with len = payload + 5;
+    trailing bytes after the frame are tolerated, like the byte-exact
+    matcher this replaces. Older dots send nothing at all - they just stop
+    pulling and go back to "Poll" (handled in that branch)."""
+    if len(data) < 6 or data[0] != 0x00:
+        return None
+    total = (data[0] << 8) | data[1]
+    if total < 6 or len(data) < total or data[2:3] != b'F':
+        return None
+    payload = bytes(data[2:total - 3])
+    c0 = c1 = 0
+    for x in payload:
+        c0 = (c0 ^ x) & 0xff
+        c1 = (c1 + c0) & 0xff
+    return payload if (data[total - 3] == c0 and data[total - 2] == c1) else None
 
 def sanitize_incoming_path(root, name):
     """Map a filename reported by the Next to a safe path under root.
@@ -776,14 +803,25 @@ def _listen_session_inner(conn, stats, _test_commands=None):
             break
 
         # A newer dotN pushes an explicit 'F' status block when a put fails; ack it
-        # (so its send_block_rt doesn't burn retries) and report the failure. Older
-        # dots just stop pulling and go back to "Poll" (handled in that branch).
-        if is_fail_block(data):
+        # (so its send_block_rt doesn't burn retries) and report the failure —
+        # ZX Next Remote marks an OS-protection refusal as 'F'+OSP so the report
+        # (and a bridge caller's HTTP status: 401, like every other blocked
+        # write) can say WHY. Older dots just stop pulling and go back to "Poll"
+        # (handled in that branch).
+        fail_payload = fail_block_payload(data)
+        if fail_payload is not None:
             sendpacket(conn, b"Ok", 0)
             if pending_put is not None:
-                print(f'{timestamp()} | *** put {pending_put[0]}: FAILED on the Next ***')
-                _reply_fill(pending_put[1], {'ok': False,
-                                             'error': 'put failed on the Next'})
+                if fail_payload[1:1 + len(OSP_MARK)] == OSP_MARK:
+                    print(f'{timestamp()} | *** put {pending_put[0]}: BLOCKED '
+                          'by the remote OS protection ***')
+                    _reply_fill(pending_put[1], {'ok': False,
+                                                 'error': OSP_ERROR,
+                                                 'http': 401})
+                else:
+                    print(f'{timestamp()} | *** put {pending_put[0]}: FAILED on the Next ***')
+                    _reply_fill(pending_put[1], {'ok': False,
+                                                 'error': 'put failed on the Next'})
                 pending_put = None
                 _in_transfer = False
                 put_data = b''; put_ofs = 0; put_pkt = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.21"
+version = "9.5.22"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -11,6 +11,7 @@ import os, sys, socket, threading, tempfile, shutil, time, io, contextlib
 # imports for the optional -w/-http web server).
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import nextsync5 as ns
+from zxnu_http_bridge import BridgeReply
 
 if os.environ.get("TL_DEBUG"):
     _orig_sp = ns.sendpacket
@@ -104,6 +105,10 @@ def mock_next(sock, fake_entries, fake_file, captured):
             push(b'E', pkt); pkt += 1
             push(b'B', pkt)
         elif op == b'P':                            # put: pull the file the server sends
+            if arg.startswith("/sys"):              # OS-protected put refusal:
+                push(b'FOSP', 0)                     # marked 'F'+OSP (push asserts the ack)
+                captured.setdefault('put_osp', []).append(arg)
+                continue
             if arg.startswith("/locked"):           # simulate a put the Next rejects
                 push(b'F', 0)                        # 'F' status; server must ack 'O'
                 captured['put_fail'] = arg
@@ -167,6 +172,7 @@ def main():
     fake_entries = [(1, 0, "GAMES"), (0, 1234, "boot.bas"), (0, 49152, "screen.scr")]
     fake_file = b"Hello from the ZX Spectrum Next!\r\n" * 4
     captured = {}
+    bridge_reply = BridgeReply()   # rides the second protected put below
 
     srv, nxt = socket.socketpair()
     for s in (srv, nxt):
@@ -185,6 +191,8 @@ def main():
         ("put", putfile, "c:/uploads/upload.bin"),  # explicit remote name
         ("put", putfile, "/ho/"),                   # dir remote -> keep basename
         ("put", putfile, "/locked/up.bin"),         # put that fails with 'F'
+        ("put", putfile, "/sys/up.bin"),            # OS-protected -> 'F'+OSP
+        ("put", putfile, "/sys/up2.bin", bridge_reply),  # same, bridge flavour
         ("rm", "/games/old.tap", ""),
         ("rmdir", "/games/tmp", ""),
         ("psize", "m:", ""),                        # free space, exact bytes
@@ -290,6 +298,20 @@ def main():
         print("FAIL rfsizeF: 'F' reply not reported"); ok = False
     # A put the Next rejects ('F') must be reported (and the block acked, or the
     # mock's push() assert would have failed and torn the session down).
+    # OS-protected puts: the console names the OS protection, the bridge
+    # reply carries the 401 + os-protected explanation, and both marked
+    # blocks were acked (push asserted it) so the far side stops retrying.
+    if ("put /sys/up.bin: BLOCKED by the remote OS protection" in server_out
+            and captured.get('put_osp') == ["/sys/up.bin", "/sys/up2.bin"]):
+        print("PASS putOSP : marked refusal named on the console + acked")
+    else:
+        print("FAIL putOSP :", captured.get('put_osp')); ok = False
+    br_res = bridge_reply.wait(5)
+    if (br_res and br_res.get('http') == 401
+            and "os-protected" in str(br_res.get('error', ''))):
+        print("PASS putOSPb: bridge reply is 401 os-protected")
+    else:
+        print("FAIL putOSPb:", br_res); ok = False
     if "put /locked/up.bin: FAILED" in server_out and captured.get('put_fail') == "/locked/up.bin":
         print("PASS putF   : put 'F' reported + acked")
     else:

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -39,11 +39,14 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from PySide6.QtCore import QItemSelectionModel, QMimeData, QPointF, Qt, QUrl
-from PySide6.QtGui import QColor, QDropEvent
+from PySide6.QtCore import (QItemSelectionModel, QMimeData, QPoint,
+                            QPointF, Qt, QUrl)
+from PySide6.QtGui import QColor, QDropEvent, QWheelEvent
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QMessageBox
 
+from zxnu_config import TREE_FONT_MIN_PT
+from zxnu_workers import bind_tree_font_zoom
 import zxnu_remote_explorer as rex
 from zxnu_remote_explorer import (RemoteExplorerWidget, RE_PATH_ROLE,
                                   _ext_type_text, _human_size, _norm_remote_dir,
@@ -1429,6 +1432,44 @@ def test_select_all_skips_updir():
     check("local pane Ctrl-A leaves '..' out", ".." not in lsel, repr(lsel))
 
 
+def test_font_zoom():
+    """Ctrl + mouse-wheel zooms a bound explorer tree's item font (the
+    shared zxnu_workers.bind_tree_font_zoom used by all four explorer
+    panes): one point per notch, clamped, persisted per change; a plain
+    wheel is left alone (it must keep scrolling)."""
+    w, _calls = make_widget(local_start_dir=tdir("zoom_root"))
+    saved = []
+    bind_tree_font_zoom(w.next_view, saved.append)
+
+    def wheel(dy, ctrl=True):
+        ev = QWheelEvent(QPointF(20, 20), QPointF(20, 20), QPoint(),
+                         QPoint(0, dy), Qt.NoButton,
+                         Qt.ControlModifier if ctrl else Qt.NoModifier,
+                         Qt.NoScrollPhase, False)
+        QApplication.sendEvent(w.next_view.viewport(), ev)
+        return ev
+
+    base = w.next_view.font().pointSize()
+    wheel(120)
+    check("Ctrl+wheel-up grows the font by one point",
+          w.next_view.font().pointSize() == base + 1 and saved == [base + 1])
+    wheel(120, ctrl=False)
+    check("a plain wheel changes nothing (left to the scroll machinery)",
+          w.next_view.font().pointSize() == base + 1 and saved == [base + 1])
+    # Trackpad-style partial deltas only add up to a step at a full notch.
+    wheel(60)
+    check("half a notch does nothing yet",
+          w.next_view.font().pointSize() == base + 1)
+    wheel(60)
+    check("the second half completes the step",
+          w.next_view.font().pointSize() == base + 2)
+    for _ in range(40):
+        wheel(-120)
+    check("wheel-down clamps at the minimum",
+          w.next_view.font().pointSize() == TREE_FONT_MIN_PT
+          and saved[-1] == TREE_FONT_MIN_PT)
+
+
 def test_os_protection_stops_and_explains():
     """A remote WRITE refused by the far side's OS protection (a ZXNextRemote
     listener, 0.9.0) must STOP the batch and toast the actionable message —
@@ -1620,6 +1661,7 @@ def main():
         test_emulator_start_from_next()
         test_select_all_skips_updir()
         test_os_protection_stops_and_explains()
+        test_font_zoom()
     finally:
         shutil.rmtree(TMP, ignore_errors=True)
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")

--- a/tests/test_remote_listen.py
+++ b/tests/test_remote_listen.py
@@ -6,6 +6,7 @@ import os, sys, socket, threading, queue, tempfile, shutil, time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from PySide6.QtCore import QCoreApplication, Qt
+from zxnu_http_bridge import BridgeReply
 from zxnu_workers import RemoteExplorerSignals, run_remote_listen_server
 
 PORT = 2049
@@ -117,6 +118,14 @@ def mock_next(sock, entries, filebytes, cap, fs, send_listen=True):
                 push(b'N' + len(filebytes).to_bytes(4, "big") + bytes([len(name)]) + name.encode(), 0)
                 push(b'D' + filebytes, 1); push(b'E', 2); push(b'B', 3)
         elif op == b'P':
+            if arg.startswith("/sys"):
+                # A protecting ZXNextRemote (put_plain=0) refuses the put with
+                # the MARKED 'F'+"OSP" status block so the controller can say
+                # WHY; it still expects the server's "Ok" ack like any 'F'.
+                settle(); sock.sendall(frame(b'FOSP', 0))
+                assert rx_payload(sock)[0:1] == b'O'
+                cap.setdefault('put_osp', []).append(arg)
+                continue
             if arg.startswith("/locked"):
                 # Simulate a put the Next can't create: push an 'F' status block
                 # (like the dotN's listen_status(0)) and expect the server's "Ok".
@@ -244,6 +253,7 @@ def main():
 
     cmd_q = queue.Queue()
     stop = threading.Event()
+    bp = BridgeReply()   # rides the second protected put below
     # "ls /gone" sits between real commands on purpose: if the 'F' (opendir-fail)
     # reply were mishandled it would desync the stream and break everything after.
     for c in [("mkdir", "/ho"), ("ls", "/"), ("ls", "/gone"),
@@ -269,6 +279,8 @@ def main():
               ("mkdir", "/sys/evil"),               # protected mkdir -> OSP
               ("rm", "/sys/config/boot"),           # protected rm    -> OSP
               ("rename", "/games/x", "/sys/x"),     # protected dst   -> OSP
+              ("put", putfile, "/sys/up.bin"),      # protected put -> 'F'+OSP
+              ("put", putfile, "/sys/up2.bin", bp), # same, bridge flavour -> 401
               ("ls", "/"),                          # proves the stream survived
               ("quit",)]:
         cmd_q.put(c)
@@ -399,11 +411,28 @@ def main():
     # normal failure. The trailing ls "/" still succeeded, proving the OSP 'F'
     # blocks did not desync the stream.
     if (got['osp'] == [("mkdir", "/sys/evil"), ("rm", "/sys/config/boot"),
-                       ("rename", "/games/x")]
+                       ("rename", "/games/x"), ("put", "/sys/up.bin")]
             and not any(o[2] and str(o[2]).startswith("/sys") for o in got['ops'])):
         print("PASS osprot:", got['osp'])
     else:
         print("FAIL osprot:", got['osp'], "ops:", got['ops']); ok = False
+    # A protected PUT: ZXNextRemote (put_plain=0) refuses with the MARKED
+    # 'F'+OSP block. UI path: os_protected("put", path) and never a plain
+    # put_done(False); bridge path: the same 401 + explanation every other
+    # blocked write gets. Both blocks were acked (cap) so the far side
+    # stops retrying, and the trailing ls proves the stream stayed in sync.
+    if (cap.get('put_osp') == ["/sys/up.bin", "/sys/up2.bin"]
+            and not any(p.startswith("/sys") for _okf, p in got['puts'])):
+        print("PASS osprot-put: os_protected('put'), marked blocks acked")
+    else:
+        print("FAIL osprot-put:", got['osp'], got['puts'], cap.get('put_osp'))
+        ok = False
+    br_res = bp.wait(5)
+    if (br_res and br_res.get('http') == 401
+            and "os-protected" in str(br_res.get('error', ''))):
+        print("PASS osprot-put-bridge: 401 os-protected reply")
+    else:
+        print("FAIL osprot-put-bridge:", br_res); ok = False
     if got['listing'] and got['listing'][0] == "/":
         print("PASS osprot-sync: stream survived the OSP refusals")
     else:

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.21"
+ZX_NEXT_UNITE_VERSION = "9.5.22"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync
@@ -361,6 +361,10 @@ SETTING_SDCARD_TREE_COLS       = "sdcard_tree_columns"     # SD Card utility: LO
 SETTING_IMAGE_TREE_COLS        = "image_tree_columns"      # SD Card utility: IMAGE explorer column widths
 SETTING_RE_LOCAL_COLS          = "re_local_tree_columns"   # Remote Explorer: local pane column widths
 SETTING_RE_NEXT_COLS           = "re_next_tree_columns"    # Remote Explorer: Next pane column widths
+SETTING_SDCARD_TREE_FONT       = "sdcard_tree_font"        # SD Card utility: LOCAL explorer item font pt (Ctrl+wheel zoom; "" = default)
+SETTING_IMAGE_TREE_FONT        = "image_tree_font"         # SD Card utility: IMAGE explorer item font pt (Ctrl+wheel zoom)
+SETTING_RE_LOCAL_FONT          = "re_local_tree_font"      # Remote Explorer: local pane item font pt (Ctrl+wheel zoom)
+SETTING_RE_NEXT_FONT           = "re_next_tree_font"       # Remote Explorer: Next pane item font pt (Ctrl+wheel zoom)
 SETTING_RE_REMOTE_CWDS         = "re_remote_cwds"          # JSON {"ip": "/last/folder"} per connected Next (multi-Next; capped at 24, oldest out)
 SETTING_ITCHIO_API_KEY         = "itchio_api_key"          # str: personal itch.io API key (https://itch.io/user/settings/api-keys)
 SETTING_SHOW_ITCHIO_TAB        = "show_itchio_tab"         # "false" => hide the itch.io tab (default shown when itch-dl is installed)
@@ -967,7 +971,8 @@ SETTING_NEXTSYNC_SEND_CONFLICT, SETTING_NEXTSYNC_PYGAME_MODE, SETTING_NEXTSYNC_P
 SETTING_ITCHIO_API_KEY, SETTING_SHOW_ITCHIO_TAB, SETTING_ITCHIO_VIEW_MODE, SETTING_CSPECT_UPDATE_CHECK, SETTING_ZXNU_UPDATE_CHECK, SETTING_DOTN_LAST_VERSION, SETTING_DELETE_TO_RECYCLE_BIN,
 SETTING_GETIT_ITEM_RETRO, SETTING_ZXDB_ITEM_RETRO, SETTING_ZXART_ITEM_RETRO, SETTING_ITCHIO_ITEM_RETRO, SETTING_FAVORITES_ITEM_RETRO, SETTING_UI_LANGUAGE,
 SETTING_WIZARD_ENABLED, SETTING_WIZARD_INTRO_SHOWN, SETTING_WIZARD_FONT_SIZE, SETTING_WIZARD_SP_OFFERED,
-SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS, SETTING_RE_REMOTE_CWDS, SETTING_RE_MACHINE_NAMES)
+SETTING_WINDOW_SCREEN, SETTING_WINDOW_SIZE, SETTING_SDCARD_TREE_COLS, SETTING_IMAGE_TREE_COLS, SETTING_RE_LOCAL_COLS, SETTING_RE_NEXT_COLS, SETTING_RE_REMOTE_CWDS, SETTING_RE_MACHINE_NAMES,
+SETTING_SDCARD_TREE_FONT, SETTING_IMAGE_TREE_FONT, SETTING_RE_LOCAL_FONT, SETTING_RE_NEXT_FONT)
 
 
 def apply_tree_column_widths(tree, pref):
@@ -987,6 +992,32 @@ def apply_tree_column_widths(tree, pref):
     for i, w in enumerate(widths):
         if w >= 24:
             tree.setColumnWidth(i, w)
+
+
+# Ctrl+wheel explorer font zoom: the clamp both halves agree on (the live
+# zoom in zxnu_workers.bind_tree_font_zoom and the restore below).
+TREE_FONT_MIN_PT = 6
+TREE_FONT_MAX_PT = 28
+
+
+def apply_tree_font_pt(tree, pref):
+    """Apply a saved item font size (pt) to an explorer QTreeView.
+
+    The restore half of the Ctrl+wheel font zoom (the live half is
+    zxnu_workers.bind_tree_font_zoom). Forgiving like
+    apply_tree_column_widths: a missing/garbled/out-of-range value leaves
+    the widget's default font untouched. The header inherits the view
+    font, so it follows by itself."""
+    if tree is None:
+        return
+    try:
+        pt = int(str(pref).strip())
+    except (TypeError, ValueError):
+        return
+    if TREE_FONT_MIN_PT <= pt <= TREE_FONT_MAX_PT:
+        f = tree.font()
+        f.setPointSize(pt)
+        tree.setFont(f)
 
 IMAGE_BUTTONS_SIZE = 190
 DISK_ARROWS_BUTTONS_SIZE = 30

--- a/zxnu_config_io.py
+++ b/zxnu_config_io.py
@@ -697,6 +697,16 @@ def build_config_io(
                 apply_tree_column_widths(
                     getattr(host, _cols_attr, None),
                     configuration_dictionary.get(_cols_key, ""))
+            # The Ctrl+wheel font zoom's restore half (same trees; the
+            # Remote Explorer pair restores at its lazy construction in
+            # zxnu_nextsync_pane, like its column widths).
+            for _font_key, _font_attr in (
+                (SETTING_SDCARD_TREE_FONT, "treeview"),
+                (SETTING_IMAGE_TREE_FONT, "image_treeview"),
+            ):
+                apply_tree_font_pt(
+                    getattr(host, _font_attr, None),
+                    configuration_dictionary.get(_font_key, ""))
 
             # Restore the saved splitter positions (SD Card explorers ⇄
             # log, GetIt results ⇄ MOTD). The window is not shown yet, so

--- a/zxnu_main.py
+++ b/zxnu_main.py
@@ -2549,6 +2549,18 @@ class MainWindow(QMainWindow):
         self.sdcard_explorer_container = _pane
         self._image_recolor_all = _pane.image_recolor_all
 
+        # Ctrl+wheel font zoom on both SD Card explorers (the restore half
+        # runs in load_configuration_file, next to the column widths).
+        def _sd_tree_font_persist(_key):
+            def _p(_pt):
+                configuration_dictionary[_key] = str(_pt)
+                save_configuration_file()
+            return _p
+        bind_tree_font_zoom(self.treeview,
+                            _sd_tree_font_persist(SETTING_SDCARD_TREE_FONT))
+        bind_tree_font_zoom(self.image_treeview,
+                            _sd_tree_font_persist(SETTING_IMAGE_TREE_FONT))
+
         # Operation-layer wiring onto the pane's local tree: the context menu
         # dispatches into the transfer/delete/rename/zip flows kept here.
         self.treeview.setContextMenuPolicy(Qt.CustomContextMenu)

--- a/zxnu_nextsync_pane.py
+++ b/zxnu_nextsync_pane.py
@@ -645,16 +645,13 @@ def build_nextsync_pane(
                 "file_size":    host.img_color_file_size,
                 "general_text": host.img_color_general_text,
             })
-            # The idle host/IP panel follows the retro (Consolas) log colour
-            # and font-size settings — floored at 12pt for readability.
+            # The idle host/IP panel follows the retro (Consolas) log
+            # COLOUR setting only; its font size stays at the widget's
+            # normal 10pt — inheriting the log font size blew the block up
+            # until it overlapped the pane's header/footer (reverted).
             col = (configuration_dictionary.get(SETTING_COLOR_RETRO_LOG)
                    or "").strip() or "#33ff33"
-            try:
-                pt = int(configuration_dictionary.get(SETTING_RETRO_LOG_FONT_SIZE)
-                         or DEFAULT_RETRO_LOG_FONT_SIZE)
-            except (TypeError, ValueError):
-                pt = DEFAULT_RETRO_LOG_FONT_SIZE
-            widget.set_idle_details_style(col, max(12, pt))
+            widget.set_idle_details_style(col)
         except Exception:
             pass
     host._re_apply_item_colors = _re_apply_item_colors
@@ -748,7 +745,8 @@ def build_nextsync_pane(
                               "the address:",
                               f"    .sync5 {addr}",
                               "then start the remote session any time with:",
-                              "    .sync5 -L   (-l or -listen)"]
+                              "    .sync5 -L   (-l or -listen)",
+                              "or a ZX Next Remote listener."]
             _re_ip_info_cache["text"] = "\n".join(lines)
             _re_ip_info_cache["t"] = now
         return _re_ip_info_cache["text"]
@@ -939,6 +937,23 @@ def build_nextsync_pane(
         apply_tree_column_widths(
             widget.next_view,
             configuration_dictionary.get(SETTING_RE_NEXT_COLS, ""))
+        # Ctrl+wheel font zoom on both panes: restored here like the column
+        # widths above; every applied change persists immediately.
+        def _re_tree_font_persist(_key):
+            def _p(_pt):
+                configuration_dictionary[_key] = str(_pt)
+                save_configuration_file()
+            return _p
+        apply_tree_font_pt(
+            widget.local_view,
+            configuration_dictionary.get(SETTING_RE_LOCAL_FONT, ""))
+        apply_tree_font_pt(
+            widget.next_view,
+            configuration_dictionary.get(SETTING_RE_NEXT_FONT, ""))
+        bind_tree_font_zoom(widget.local_view,
+                            _re_tree_font_persist(SETTING_RE_LOCAL_FONT))
+        bind_tree_font_zoom(widget.next_view,
+                            _re_tree_font_persist(SETTING_RE_NEXT_FONT))
         # ---- mini log under the explorer panes (2026-08-07): tracing the
         # bridge/server activity used to require flipping to the Classic
         # tab — which, before the same-day fix, even stopped the server.

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -12,8 +12,10 @@ through RemoteExplorerSignals and are applied here on the UI thread.
 
 import html
 import logging
+import math
 import os
 import posixpath
+import random
 import shutil
 import tempfile
 
@@ -24,7 +26,8 @@ from PySide6.QtCore import (
     Qt, QDir, QEvent, QModelIndex, QMimeData, QUrl, QSize, QTimer,
 )
 from PySide6.QtGui import (
-    QColor, QDrag, QKeySequence, QStandardItem, QStandardItemModel,
+    QColor, QDrag, QKeySequence, QPainter, QStandardItem,
+    QStandardItemModel,
 )
 from PySide6.QtWidgets import (
     QAbstractItemView, QComboBox, QFileSystemModel, QGridLayout, QHBoxLayout,
@@ -255,6 +258,164 @@ def _norm_remote_dir(p):
     if not p.startswith("/"):
         p = "/" + p
     return posixpath.normpath(p)
+
+
+class IdleStarfieldOverlay(QWidget):
+    """The idle-details panel shown over the empty Next pane while
+    disconnected: a soft 8-bit starfield (chunky parallax pixel stars plus
+    the occasional comet) painted behind the host/IP guidance text.
+
+    Replaces the transparent QLabel the pane used before, whose text sat
+    directly over the disabled Next tree and collided with its header row
+    and footer buttons — this widget paints its own deep-space backdrop, so
+    nothing bleeds through. It keeps the tiny API the pane drives
+    (text()/setText(), set_label_stylesheet) and stays mouse-transparent
+    like the label it replaces. Stars are plain bright dots ON PURPOSE —
+    never the Sinclair rainbow stripes (trade-dress rule; see the sprite
+    conventions in zxnu_wizard.py).
+    """
+
+    _TICK_MS = 40                     # 25 fps — a soft drift, cheap to paint
+    _BACKDROP = (6, 9, 26, 238)       # deep-space blue-black, near opaque
+    # Bright 8-bit dot palette, weighted towards white so the field reads as
+    # stars with just a sprinkle of colour.
+    _STAR_COLORS = (
+        (245, 245, 245), (245, 245, 245), (245, 245, 245),
+        (140, 224, 255), (255, 224, 140), (170, 170, 255), (255, 140, 224),
+    )
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # Purely informational, like the label it replaces: never intercept
+        # the pane's mouse events.
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self._label = QLabel(self)
+        self._label.setAlignment(Qt.AlignCenter)
+        self._label.setWordWrap(True)
+        self._label.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(12, 12, 12, 12)
+        lay.addWidget(self._label)
+        self._stars = []          # dicts: x/y px, size, speed, colour, twinkle
+        self._comets = []         # dicts: x/y, vx/vy, trail [(x, y), ...]
+        self._frame = 0
+        self._next_comet_at = self._comet_delay()
+        self._timer = QTimer(self)
+        self._timer.setInterval(self._TICK_MS)
+        self._timer.timeout.connect(self._tick)
+
+    # ---- the tiny API the pane drives (QLabel-compatible) ----------------
+
+    def text(self):
+        return self._label.text()
+
+    def setText(self, text):
+        self._label.setText(text)
+
+    def set_label_stylesheet(self, css):
+        self._label.setStyleSheet(css)
+
+    # ---- animation lifecycle: only tick while actually on screen ---------
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._timer.start()
+
+    def hideEvent(self, event):
+        # The NextSync tab going to the back hides this child too — stop
+        # burning frames until it comes forward again.
+        super().hideEvent(event)
+        self._timer.stop()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._sync_star_count()
+
+    # ---- the field --------------------------------------------------------
+
+    def _comet_delay(self):
+        return random.randint(160, 400)           # ~6-16 s between comets
+
+    def _make_star(self, anywhere):
+        w = max(1, self.width())
+        size = random.choice((1, 1, 1, 2, 2, 3))  # mostly tiny: depth illusion
+        return {
+            "x": float(random.randrange(w) if anywhere
+                       else w + random.randint(0, 24)),
+            "y": float(random.randrange(max(1, self.height()))),
+            "size": size,
+            # Bigger (nearer) stars drift faster: cheap parallax.
+            "speed": (0.10 + 0.16 * size) * random.uniform(0.75, 1.3),
+            "color": random.choice(self._STAR_COLORS),
+            "phase": random.uniform(0.0, 2 * math.pi),
+            "rate": random.uniform(0.03, 0.10),   # twinkle speed, rad/frame
+        }
+
+    def _sync_star_count(self):
+        """Keep the star density proportional to the pane area (resize adds
+        or culls stars instead of reseeding, so nothing visibly jumps)."""
+        if self.width() <= 0 or self.height() <= 0:
+            return
+        want = max(24, min(140, (self.width() * self.height()) // 4200))
+        while len(self._stars) < want:
+            self._stars.append(self._make_star(anywhere=True))
+        del self._stars[want:]
+
+    def _spawn_comet(self):
+        h = max(2, self.height())
+        return {
+            "x": float(self.width() + 8),
+            "y": float(random.randint(h // 12, h // 2)),
+            "vx": -random.uniform(3.0, 5.0),
+            "vy": random.uniform(0.6, 1.6),
+            "trail": [],
+        }
+
+    def _tick(self):
+        self._frame += 1
+        w, h = self.width(), self.height()
+        for s in self._stars:
+            s["x"] -= s["speed"]
+            if s["x"] < -3:           # wrapped: re-enter on the right edge
+                s["x"] = w + random.randint(0, 24)
+                s["y"] = float(random.randrange(max(1, h)))
+        if self._frame >= self._next_comet_at and len(self._comets) < 2:
+            self._comets.append(self._spawn_comet())
+            self._next_comet_at = self._frame + self._comet_delay()
+        for c in self._comets:
+            c["trail"].insert(0, (c["x"], c["y"]))
+            del c["trail"][14:]
+            c["x"] += c["vx"]
+            c["y"] += c["vy"]
+        self._comets = [c for c in self._comets
+                        if c["x"] > -40 and c["y"] < h + 40]
+        self.update()
+
+    def paintEvent(self, event):
+        p = QPainter(self)
+        # Chunky pixels on purpose: no antialiasing anywhere.
+        p.setPen(Qt.NoPen)
+        p.setBrush(QColor(*self._BACKDROP))
+        p.drawRoundedRect(self.rect(), 8, 8)
+        for s in self._stars:
+            r, g, b = s["color"]
+            # Soft twinkle: each star breathes on its own phase and rate.
+            base = 120 + 36 * s["size"]
+            a = int(base * (0.6 + 0.4 * math.sin(s["phase"]
+                                                 + s["rate"] * self._frame)))
+            p.fillRect(int(s["x"]), int(s["y"]), s["size"], s["size"],
+                       QColor(r, g, b, max(0, min(255, a))))
+        for c in self._comets:
+            # Tail first (newest chunk brightest), then the head over it.
+            n = len(c["trail"])
+            for i, (tx, ty) in enumerate(c["trail"]):
+                fade = 1.0 - (i + 1) / (n + 1)
+                sz = 2 if i < 5 else 1
+                p.fillRect(int(tx), int(ty), sz, sz,
+                           QColor(150, 220, 255, int(200 * fade)))
+            p.fillRect(int(c["x"]) - 1, int(c["y"]) - 1, 3, 3,
+                       QColor(255, 255, 255, 235))
+        p.end()
 
 
 class RemoteExplorerWidget(QWidget):
@@ -598,11 +759,13 @@ class RemoteExplorerWidget(QWidget):
         # '.sync5' is the one thing they need while setting the link up.
         self._idle_details_provider = None
         self._idle_info_overlay = None
-        # Style for the idle-details overlay; the host pushes the user's
-        # retro-log (Consolas) colour + font-size settings through
-        # set_idle_details_style so the panel follows them live.
+        # Style for the idle-details overlay's text; the host pushes the
+        # user's retro-log (Consolas) COLOUR through set_idle_details_style
+        # so it follows the setting live. The size stays at the pane's
+        # normal 10pt — inheriting the log font size blew the block up until
+        # it overlapped the pane's header and footer (reverted).
         self._idle_info_color = "#a6f0a6"
-        self._idle_info_pt = 12
+        self._idle_info_pt = 10
         # Top-bar label: the idle status while disconnected, the drive's free
         # space while connected. The PATH itself lives in next_path_edit at
         # the bottom of the pane since the UX pass that aligned it with the
@@ -1122,7 +1285,8 @@ class RemoteExplorerWidget(QWidget):
 
     def _update_idle_info_overlay(self):
         """Show the idle-details text over the (empty, disabled) Next pane
-        while disconnected; remove it when connected or without text."""
+        while disconnected — on the animated 8-bit starfield
+        (IdleStarfieldOverlay); remove it when connected or without text."""
         text = ""
         if not self._connected and self._idle_details_provider is not None:
             try:
@@ -1135,15 +1299,12 @@ class RemoteExplorerWidget(QWidget):
                 self._idle_info_overlay = None
             return
         if self._idle_info_overlay is None:
-            lbl = QLabel(self.next_container)
-            lbl.setAlignment(Qt.AlignCenter)
-            # Purely informational: never intercept the pane's mouse events.
-            lbl.setAttribute(Qt.WA_TransparentForMouseEvents, True)
-            lbl.setStyleSheet(self._idle_info_stylesheet())
-            lbl.setGeometry(self.next_container.rect())
-            lbl.show()
-            lbl.raise_()
-            self._idle_info_overlay = lbl
+            ov = IdleStarfieldOverlay(self.next_container)
+            ov.set_label_stylesheet(self._idle_info_stylesheet())
+            ov.setGeometry(self.next_container.rect())
+            ov.show()
+            ov.raise_()
+            self._idle_info_overlay = ov
         self._idle_info_overlay.setText(text)
 
     def _idle_info_stylesheet(self):
@@ -1160,7 +1321,8 @@ class RemoteExplorerWidget(QWidget):
         if point_size:
             self._idle_info_pt = int(point_size)
         if self._idle_info_overlay is not None:
-            self._idle_info_overlay.setStyleSheet(self._idle_info_stylesheet())
+            self._idle_info_overlay.set_label_stylesheet(
+                self._idle_info_stylesheet())
 
     def refresh_idle_status(self):
         """Re-evaluate the idle status (host state changed: sync root set,
@@ -1722,7 +1884,8 @@ class RemoteExplorerWidget(QWidget):
     )
 
     def on_os_protected(self, op, path):
-        """A remote WRITE (mkdir/rmdir/rm/rename/copy) was refused by the far
+        """A remote WRITE (mkdir/rmdir/rm/rename/copy — or an upload: a
+        put refused with the marked 'F'+OSP block) was refused by the far
         side's OS protection. Retrying — or grinding through the rest of a
         batch — would only repeat the refusal, so stop the operation and say
         exactly what to check: the block is on the OTHER machine's settings,

--- a/zxnu_workers.py
+++ b/zxnu_workers.py
@@ -19,6 +19,7 @@ import time
 import weakref
 from collections import deque, namedtuple
 from zxnu_config import (IGNOREFILE, MAX_PAYLOAD, PORT, SYNCPOINT,
+                         TREE_FONT_MAX_PT, TREE_FONT_MIN_PT,
                          UP_DIRECTORY, VERSION3, VERSION4,
                          cspect_can_autostart, emulator_offers_autostart,
                          is_filetype_a_directory, mame_autostart_staging_dir,
@@ -37,6 +38,65 @@ from PySide6.QtWidgets import (
     QDialog, QFileSystemModel, QHBoxLayout, QLabel, QLayout, QProgressBar,
     QPushButton, QVBoxLayout,
 )
+
+
+class _TreeFontZoomFilter(QObject):
+    """Event filter behind bind_tree_font_zoom: Ctrl + mouse-wheel over an
+    explorer tree (or its header) grows/shrinks the view's item font one
+    point per notch. Trackpad deltas are accumulated until a full 120-unit
+    notch, so a soft two-finger scroll can't race through sizes."""
+
+    def __init__(self, tree, persist):
+        super().__init__(tree)
+        self._tree = tree
+        self._persist = persist
+        self._acc = 0
+
+    def eventFilter(self, obj, ev):
+        if ev.type() != QEvent.Type.Wheel or not (
+                ev.modifiers() & Qt.ControlModifier):
+            return False
+        self._acc += ev.angleDelta().y()
+        steps = int(self._acc / 120)
+        if steps:
+            self._acc -= steps * 120
+            f = self._tree.font()
+            cur = f.pointSize()
+            if cur <= 0:                      # pixel-sized font: resolve it
+                cur = QFontInfo(f).pointSize()
+            new = max(TREE_FONT_MIN_PT, min(TREE_FONT_MAX_PT, cur + steps))
+            if new != cur:
+                f.setPointSize(new)
+                self._tree.setFont(f)
+                if self._persist is not None:
+                    try:
+                        self._persist(new)
+                    except Exception:
+                        logging.exception("tree font zoom: persist failed")
+        return True          # consume: a Ctrl+wheel never also scrolls
+
+
+def bind_tree_font_zoom(tree, persist=None):
+    """Ctrl + mouse-wheel zooms an explorer QTreeView's item font live.
+
+    Wheel-up grows, wheel-down shrinks, clamped to
+    TREE_FONT_MIN_PT..TREE_FONT_MAX_PT (zxnu_config); row heights and the
+    header (which inherits the view font) follow by themselves. A plain
+    wheel keeps scrolling exactly as before — only Ctrl+wheel is consumed.
+    ``persist(pt)`` fires after each applied change so the host can store
+    the size; the restore half is zxnu_config.apply_tree_font_pt. Returns
+    the installed filter (parented to the tree; keep-alive is automatic).
+
+    Bound on all four explorer panes: the SD Card tab's local/image trees
+    (wired at the SdCardExplorerPane construction seam in zxnu_main) and
+    the Remote Explorer's local/Next trees (wired in zxnu_nextsync_pane).
+    """
+    filt = _TreeFontZoomFilter(tree, persist)
+    tree.viewport().installEventFilter(filt)
+    hdr = tree.header()
+    if hdr is not None:
+        hdr.viewport().installEventFilter(filt)
+    return filt
 
 
 class CompactButton(QPushButton):
@@ -493,18 +553,31 @@ def _re_is_osp(payload):
             payload[1:1 + len(RE_OSP_MARK)] == RE_OSP_MARK)
 
 
-def _re_is_fail_block(data):
-    """True if ``data`` is the framed 1-byte 'F' status block a dotN pushes when a
-    put fails (couldn't create the file, or the transfer gave up).
+def _re_fail_block_payload(data):
+    """The verified payload of a framed 'F' status block, else None.
 
-    Framing is [0x00 0x06]['F'][cs0][cs1][pktno]; the checksum of 'F' is 0x46/0x46.
-    Older dots don't send this - they just stop pulling - so callers keep the
-    "abandoned upload" fallback as well.
+    A dotN pushes the classic 1-byte b"F" when a put fails (couldn't create
+    the file, or the transfer gave up); ZXNextRemote can mark WHY with a
+    suffix — b"FOSP" when its OS protection refused the write — so the
+    controller can say more than "upload failed". Framing is
+    [len_hi len_lo][payload][cs0][cs1][pktno] with len = payload + 5; like
+    the byte-exact matcher this replaces, trailing bytes after the frame are
+    tolerated (TCP coalescing). Older dots send nothing at all - they just
+    stop pulling - so callers keep the "abandoned upload" fallback as well.
     """
-    if len(data) < 6 or data[0] != 0x00 or data[1] != 0x06 or data[2:3] != b'F':
-        return False
-    c0, c1 = _re_checksums(b'F')
-    return data[3] == c0 and data[4] == c1
+    if len(data) < 6 or data[0] != 0x00:
+        return None
+    total = (data[0] << 8) | data[1]
+    if total < 6 or len(data) < total or data[2:3] != b'F':
+        return None
+    payload = bytes(data[2:total - 3])
+    c0, c1 = _re_checksums(payload)
+    return payload if (data[total - 3] == c0 and data[total - 2] == c1) else None
+
+
+def _re_is_fail_block(data):
+    """True if ``data`` is a framed 'F' status block (classic or marked)."""
+    return _re_fail_block_payload(data) is not None
 
 
 def _re_sendpacket(conn, payload, pktno):
@@ -725,13 +798,23 @@ def _re_session(sid, conn, addr, my_q, sig, cmd_queue, stop_event, shared,
             last_packet = b''
             pending = None   # ("put", remote, bridge_reply|None) awaiting completion
 
-            def _put_finish(ok):
+            def _put_finish(ok, osp=False):
                 # Resolve the pending put: to its bridge reply when it has
                 # one, to the UI signal otherwise (reads `pending` live).
+                # ``osp`` marks ZXNextRemote's OS-protection refusal (the
+                # marked 'F'+OSP status block): the bridge caller gets the
+                # same 401 + explanation every other blocked write gets, the
+                # UI the os_protected toast instead of a generic failure.
                 if pending[2] is not None:
-                    pending[2].put({'ok': bool(ok)} if ok else
-                                   {'ok': False,
-                                    'error': 'put failed on the Next'})
+                    if osp:
+                        pending[2].put({'ok': False, 'error': RE_OSP_ERROR,
+                                        'http': 401})
+                    else:
+                        pending[2].put({'ok': bool(ok)} if ok else
+                                       {'ok': False,
+                                        'error': 'put failed on the Next'})
+                elif osp:
+                    sig.os_protected.emit("put", pending[1])
                 else:
                     sig.put_done.emit(bool(ok), pending[1])
             # rmtree walk state: sub-commands the worker generates for itself
@@ -795,14 +878,17 @@ def _re_session(sid, conn, addr, my_q, sig, cmd_queue, stop_event, shared,
                 # A put in flight is served by the Next pulling the bytes with
                 # "Get"/"Gee" (or asking to resend with "Retry"/"Restart"). A newer
                 # dotN instead pushes an explicit 'F' status block when the put
-                # fails (couldn't create the file, or the transfer gave up); ack it
-                # so the dot's send_block_rt doesn't burn its retries, and report
-                # the failure. Ack even with no pending put (a rare late 'F' after
-                # the last byte already counted) so the dot isn't left retrying.
-                if _re_is_fail_block(data):
+                # fails (couldn't create the file, or the transfer gave up) —
+                # ZXNextRemote marks an OS-protection refusal as 'F'+OSP so the
+                # failure toast can say WHY. Ack it so the dot's send_block_rt
+                # doesn't burn its retries, and report the failure. Ack even with
+                # no pending put (a rare late 'F' after the last byte already
+                # counted) so the dot isn't left retrying.
+                fail_payload = _re_fail_block_payload(data)
+                if fail_payload is not None:
                     _re_sendpacket(conn, b"Ok", 0)
                     if pending and pending[0] == "put":
-                        _put_finish(False)
+                        _put_finish(False, osp=_re_is_osp(fail_payload))
                         pending = None
                         put_data = b''
                         put_ofs = 0


### PR DESCRIPTION
Three changes riding one branch:

**Remote Explorer idle panel** — the disconnected host/IP guidance now sits on its own animated 8-bit starfield backdrop (`IdleStarfieldOverlay`: chunky parallax pixel stars, twinkle, occasional comets; timer stops while the pane is hidden) instead of a transparent QLabel colliding with the disabled tree underneath. Text back at the normal 10pt, and the worked example now ends with *or a ZX Next Remote listener.*

**Ctrl + mouse-wheel font zoom** on all four explorer trees (SD Card local/image, Remote Explorer local/Next) — shared `bind_tree_font_zoom`, ±1pt per notch clamped 6–28pt, plain wheel untouched; sizes persist per pane and restore like the column widths.

**OS-protection upload refusals named** — both listen servers (`zxnu_workers` + `nextsync5`) parse ZX Next Remote 0.9.45's marked `'F'+OSP` put refusal: 🛡 "Remote OS protection" toast instead of the anonymous "Upload failed", and the same 401 os-protected bridge answer every other blocked write draws. Classic bare-'F' dotN path untouched and regression-covered.

Full suite green (22 files) incl. new coverage: starfield overlay, font zoom, protected-put in both servers' protocol tests (UI + bridge flavours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)