### PR TITLE
9.5.24-9.5.25: Disconnect button, and connected Nexts as side tabs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.24"
+version = "9.5.25"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.5.23"
+version = "9.5.24"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -1351,8 +1351,12 @@ def test_compact_buttons_fit_translated_labels():
     w, _calls = make_widget()
     compact = w.findChildren(rex.CompactButton)
     labels = sorted(b.text() for b in compact)
+    # Disconnect (9.5.24) joined the Next bar as a CompactButton for the
+    # same reason the others are: its label is translated, and a hard
+    # setMaximumWidth truncates the longer languages.
     check("both bars' Up/Refresh (+ Drive) are CompactButtons",
-          labels == ["+ Drive", "Refresh", "Refresh", "Up", "Up"], str(labels))
+          labels == ["+ Drive", "Disconnect", "Refresh", "Refresh",
+                     "Up", "Up"], str(labels))
     for button in compact:
         if button.text() != "Up":
             continue
@@ -1468,6 +1472,39 @@ def test_font_zoom():
     check("wheel-down clamps at the minimum",
           w.next_view.font().pointSize() == TREE_FONT_MIN_PT
           and saved[-1] == TREE_FONT_MIN_PT)
+
+
+def test_disconnect_button():
+    """The Disconnect button (9.5.24) is the bridge's /forceexit on the
+    pane: it asks the DRIVEN Next to leave listen mode and end its
+    application, sending the MARKED quit a plain server stop must never
+    send. Enabled only while connected, confirmed before it fires."""
+    w, calls = make_widget(local_start_dir=tdir("disc_root"))
+    check("disabled while disconnected", not w.btn_disconnect.isEnabled())
+    check("it sits between the machine name and the drive",
+          w.btn_disconnect is not None)
+    connect_widget(w, calls)
+    check("enabled once a Next is connected", w.btn_disconnect.isEnabled())
+
+    # Cancelling must send nothing at all.
+    FakeMsg.answer = QMessageBox.Cancel
+    w._disconnect_peer()
+    check("a cancelled confirm queues nothing", drain(calls) == [])
+
+    FakeMsg.answer = QMessageBox.Yes
+    w._disconnect_peer()
+    check("confirmed: the MARKED quit goes out, alone",
+          drain(calls) == [("quit_app",)])
+    check("and it is logged for the console",
+          logged(calls, "leave listen mode and exit"))
+
+    # A dropped link disables it again, so it can never fire into nothing.
+    w.on_disconnected()
+    check("disabled again after a disconnect",
+          not w.btn_disconnect.isEnabled())
+    FakeMsg.answer = QMessageBox.Yes
+    w._disconnect_peer()
+    check("and the action itself refuses while offline", drain(calls) == [])
 
 
 def test_os_protection_stops_and_explains():
@@ -1662,6 +1699,7 @@ def main():
         test_select_all_skips_updir()
         test_os_protection_stops_and_explains()
         test_font_zoom()
+        test_disconnect_button()
     finally:
         shutil.rmtree(TMP, ignore_errors=True)
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")

--- a/tests/test_remote_explorer_widget.py
+++ b/tests/test_remote_explorer_widget.py
@@ -1474,6 +1474,45 @@ def test_font_zoom():
           and saved[-1] == TREE_FONT_MIN_PT)
 
 
+def test_session_strip():
+    """The session strip (9.5.25): one vertical tab per connected Next
+    down the Next pane's outer edge, shown only when there are two or
+    more to choose between. A tab shows the machine's NAME when the user
+    gave its address one, the bare address otherwise, and clicking it is
+    the combo pick it stands for - same request, same guards."""
+    names = {"10.0.0.7": "N-GO"}
+    w, calls = make_widget(local_start_dir=tdir("strip_root"),
+                           machine_name_for=names.get)
+
+    w.on_peers((1, [(1, "10.0.0.5")]))
+    check("hidden with a single Next (nothing to switch between)",
+          not w.next_session_strip.isVisible() and not w._session_tabs)
+
+    w.on_peers((1, [(1, "10.0.0.5"), (2, "10.0.0.7")]))
+    connect_widget(w, calls)
+    check("a tab per machine once two are on the line",
+          len(w._session_tabs) == 2)
+    check("named machines show the NAME, unnamed the address",
+          [t._text for t in w._session_tabs] == ["10.0.0.5", "N-GO"])
+    check("the driven machine's tab is the lit one",
+          [t._active for t in w._session_tabs] == [True, False])
+
+    # Clicking the other tab must make the same request the combo makes.
+    w._session_tabs[1]._on_click()
+    check("a tab click asks the worker to hand the baton over",
+          ("select_next", 2) in drain(calls))
+
+    # Naming a machine has to reach the tabs, not just the combo.
+    names["10.0.0.5"] = "Attic Next"
+    w._rebuild_session_strip()
+    check("a new name reaches the tab", w._session_tabs[0]._text == "Attic Next")
+
+    # Down to one machine: nothing left to choose, so the strip goes away.
+    w.on_peers((2, [(2, "10.0.0.7")]))
+    check("the strip retires when only one Next remains",
+          not w.next_session_strip.isVisible() and not w._session_tabs)
+
+
 def test_disconnect_button():
     """The Disconnect button (9.5.24) is the bridge's /forceexit on the
     pane: it asks the DRIVEN Next to leave listen mode and end its
@@ -1700,6 +1739,7 @@ def main():
         test_os_protection_stops_and_explains()
         test_font_zoom()
         test_disconnect_button()
+        test_session_strip()
     finally:
         shutil.rmtree(TMP, ignore_errors=True)
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")

--- a/tests/test_ui_offscreen.py
+++ b/tests/test_ui_offscreen.py
@@ -1212,7 +1212,13 @@ def inspect_phase11():
     # The navigation buttons (Up / Refresh / + Drive) and the transfer arrows.
     labels = sorted(b.text() for b in re_widget.findChildren(CompactButton))
     check("both navigation bars' buttons rendered",
-          labels == ["+ Drive", "Refresh", "Refresh", "Up", "Up"], str(labels))
+          labels == ["+ Drive", "Disconnect", "Refresh", "Refresh",
+                     "Up", "Up"], str(labels))
+    # Disconnect (9.5.24) sits in the Next bar between the machine's name
+    # and its drive, and is dead until a Next is actually connected.
+    check("Disconnect is present but disabled while offline",
+          re_widget.btn_disconnect.isVisible()
+          and not re_widget.btn_disconnect.isEnabled())
     check("the transfer arrow buttons rendered",
           re_widget.btn_to_next.isVisible() and re_widget.btn_to_local.isVisible())
     check("the Remote Explorer server-control button is shown",

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.24"
+ZX_NEXT_UNITE_VERSION = "9.5.25"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.5.23"
+ZX_NEXT_UNITE_VERSION = "9.5.24"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -376,6 +376,10 @@ CATALOGS = {
         "Delete SyncIgnore File": "Eliminar archivo SyncIgnore",
         "Delete SyncPoint File": "Eliminar archivo SyncPoint",
         "Disconnect": "Desconectar",
+        "Tell this Next to leave listen mode and exit? ZX Next Remote closes its application; a '.sync5' dot returns to BASIC. The server keeps listening, so it can connect again.":
+            "¿Pedir a este Next que salga del modo escucha y se cierre? ZX Next Remote cierra su aplicación; un punto '.sync5' vuelve a BASIC. El servidor sigue escuchando, así que puede volver a conectarse.",
+        "Asked the Next to leave listen mode and exit.":
+            "Se ha pedido al Next que salga del modo escucha y se cierre.",
         "Download File": "Descargar archivo",
         "Download NextZXOS Image": "Descargar imagen NextZXOS",
         "Download and install HDF Monkey": "Descargar e instalar HDF Monkey",
@@ -1484,6 +1488,10 @@ CATALOGS = {
         "Delete SyncIgnore File": "Eliminar ficheiro SyncIgnore",
         "Delete SyncPoint File": "Eliminar ficheiro SyncPoint",
         "Disconnect": "Desligar",
+        "Tell this Next to leave listen mode and exit? ZX Next Remote closes its application; a '.sync5' dot returns to BASIC. The server keeps listening, so it can connect again.":
+            "Pedir a este Next para sair do modo de escuta e terminar? O ZX Next Remote fecha a sua aplicação; um ponto '.sync5' volta ao BASIC. O servidor continua à escuta, por isso pode ligar-se de novo.",
+        "Asked the Next to leave listen mode and exit.":
+            "Pedido ao Next para sair do modo de escuta e terminar.",
         "Download File": "Transferir ficheiro",
         "Download NextZXOS Image": "Transferir imagem NextZXOS",
         "Download and install HDF Monkey": "Transferir e instalar o HDF Monkey",
@@ -2590,6 +2598,10 @@ CATALOGS = {
         "Delete SyncIgnore File": "Usuń plik SyncIgnore",
         "Delete SyncPoint File": "Usuń plik SyncPoint",
         "Disconnect": "Rozłącz",
+        "Tell this Next to leave listen mode and exit? ZX Next Remote closes its application; a '.sync5' dot returns to BASIC. The server keeps listening, so it can connect again.":
+            "Poprosić tego Nexta o wyjście z trybu nasłuchu i zakończenie? ZX Next Remote zamyka swoją aplikację; kropka '.sync5' wraca do BASIC-a. Serwer nadal nasłuchuje, więc można połączyć się ponownie.",
+        "Asked the Next to leave listen mode and exit.":
+            "Poproszono Nexta o wyjście z trybu nasłuchu i zakończenie.",
         "Download File": "Pobierz plik",
         "Download NextZXOS Image": "Pobierz obraz NextZXOS",
         "Download and install HDF Monkey": "Pobierz i zainstaluj HDF Monkey",
@@ -3698,6 +3710,10 @@ CATALOGS = {
         "Delete SyncIgnore File": "Удалить файл SyncIgnore",
         "Delete SyncPoint File": "Удалить файл SyncPoint",
         "Disconnect": "Отключить",
+        "Tell this Next to leave listen mode and exit? ZX Next Remote closes its application; a '.sync5' dot returns to BASIC. The server keeps listening, so it can connect again.":
+            "Попросить этот Next выйти из режима прослушивания и завершить работу? ZX Next Remote закроет своё приложение; точка '.sync5' вернётся в BASIC. Сервер продолжает слушать, поэтому можно подключиться снова.",
+        "Asked the Next to leave listen mode and exit.":
+            "Next-у отправлен запрос выйти из режима прослушивания и завершить работу.",
         "Download File": "Скачать файл",
         "Download NextZXOS Image": "Скачать образ NextZXOS",
         "Download and install HDF Monkey": "Скачать и установить HDF Monkey",
@@ -4805,6 +4821,10 @@ CATALOGS = {
         "Delete SyncIgnore File": "Smazat soubor SyncIgnore",
         "Delete SyncPoint File": "Smazat soubor SyncPoint",
         "Disconnect": "Odpojit",
+        "Tell this Next to leave listen mode and exit? ZX Next Remote closes its application; a '.sync5' dot returns to BASIC. The server keeps listening, so it can connect again.":
+            "Požádat tento Next, aby opustil režim naslouchání a skončil? ZX Next Remote zavře svou aplikaci; tečka '.sync5' se vrátí do BASICu. Server dál naslouchá, takže se lze připojit znovu.",
+        "Asked the Next to leave listen mode and exit.":
+            "Next byl požádán, aby opustil režim naslouchání a skončil.",
         "Download File": "Stáhnout soubor",
         "Download NextZXOS Image": "Stáhnout obraz NextZXOS",
         "Download and install HDF Monkey": "Stáhnout a nainstalovat HDF Monkey",
@@ -5914,6 +5934,10 @@ CATALOGS = {
         "Delete SyncIgnore File": "Supprimer le fichier SyncIgnore",
         "Delete SyncPoint File": "Supprimer le fichier SyncPoint",
         "Disconnect": "Déconnecter",
+        "Tell this Next to leave listen mode and exit? ZX Next Remote closes its application; a '.sync5' dot returns to BASIC. The server keeps listening, so it can connect again.":
+            "Demander à ce Next de quitter le mode écoute et de se fermer ? ZX Next Remote ferme son application ; un point '.sync5' revient au BASIC. Le serveur continue d'écouter, il peut donc se reconnecter.",
+        "Asked the Next to leave listen mode and exit.":
+            "Demande envoyée au Next : quitter le mode écoute et se fermer.",
         "Download File": "Télécharger le fichier",
         "Download NextZXOS Image": "Télécharger l'image NextZXOS",
         "Download and install HDF Monkey": "Télécharger et installer HDF Monkey",

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -23,11 +23,11 @@ from zxnu_http_bridge import session_label   # stdlib-only at import
 from zxnu_i18n import ui_tr_now
 
 from PySide6.QtCore import (
-    Qt, QDir, QEvent, QModelIndex, QMimeData, QUrl, QSize, QTimer,
+    Qt, QDir, QEvent, QModelIndex, QMimeData, QRect, QUrl, QSize, QTimer,
 )
 from PySide6.QtGui import (
-    QColor, QDrag, QKeySequence, QPainter, QStandardItem,
-    QStandardItemModel,
+    QColor, QDrag, QFontMetrics, QKeySequence, QPainter, QPalette,
+    QStandardItem, QStandardItemModel,
 )
 from PySide6.QtWidgets import (
     QAbstractItemView, QComboBox, QFileSystemModel, QGridLayout, QHBoxLayout,
@@ -258,6 +258,79 @@ def _norm_remote_dir(p):
     if not p.startswith("/"):
         p = "/" + p
     return posixpath.normpath(p)
+
+
+class SessionTab(QWidget):
+    """One connected Next as a vertical tab down the side of the Next pane.
+
+    The machine combo tells you which machine you drive, but switching
+    through it costs a click, a read and a second click. With two or more
+    Nexts on the line the roster is small and fixed, so it can simply BE
+    on screen: one tab per machine, piled top-down, the driven one lit.
+    Clicking a tab is the combo pick it stands for — same request, same
+    guards (RemoteExplorerWidget._request_machine).
+
+    Text runs bottom-to-top like every side tab (IDE tabs, browser
+    sidebars): a horizontal label wide enough for "10.0.0.7 #1 - N-GO"
+    would eat ~140px of the listing, and the listing is the point of the
+    pane. Colours come from the PALETTE rather than the app's hardcoded
+    chrome so the tab follows whatever theme is live.
+    """
+
+    W = 26                       # strip width; the text is what is tall
+    _PAD = 10                    # end padding, both ends of the label
+
+    def __init__(self, text, active, on_click, parent=None):
+        super().__init__(parent)
+        self._text = text or ""
+        self._active = bool(active)
+        self._on_click = on_click
+        self.setCursor(Qt.PointingHandCursor)
+        self.setToolTip(self._text)
+        fm = QFontMetrics(self.font())
+        want = fm.horizontalAdvance(self._text) + self._PAD * 2
+        # Capped so one long name cannot push the others off a short pane;
+        # the full text is always in the tooltip.
+        self.setFixedSize(self.W, max(56, min(200, want)))
+
+    def set_active(self, active):
+        active = bool(active)
+        if active != self._active:
+            self._active = active
+            self.update()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton and self._on_click is not None:
+            self._on_click()
+        else:
+            super().mousePressEvent(event)
+
+    def paintEvent(self, _event):
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        pal = self.palette()
+        if self._active:
+            bg = pal.color(QPalette.ColorRole.Highlight)
+            fg = pal.color(QPalette.ColorRole.HighlightedText)
+        else:
+            bg = pal.color(QPalette.ColorRole.Button).darker(115)
+            fg = pal.color(QPalette.ColorRole.ButtonText)
+        p.setPen(Qt.NoPen)
+        p.setBrush(bg)
+        # Rounded on the OUTER edge only would need a path; a plain
+        # rounded rect reads as a tab well enough and costs one call.
+        p.drawRoundedRect(self.rect().adjusted(0, 0, -1, -1), 6, 6)
+        # Bottom-to-top: put the origin at the bottom-left and turn left,
+        # which makes the drawing rect (height x width).
+        p.translate(0, self.height())
+        p.rotate(-90)
+        p.setPen(fg)
+        box = QRect(self._PAD, 0, self.height() - self._PAD * 2, self.W)
+        text = QFontMetrics(self.font()).elidedText(
+            self._text, Qt.TextElideMode.ElideRight, box.width())
+        p.drawText(box, int(Qt.AlignmentFlag.AlignVCenter
+                            | Qt.AlignmentFlag.AlignLeft), text)
+        p.end()
 
 
 class IdleStarfieldOverlay(QWidget):
@@ -861,11 +934,30 @@ class RemoteExplorerWidget(QWidget):
         next_bar.addWidget(self.next_drive_add)
         next_bar.addWidget(self.next_path_label, 1)
 
+        # The session strip (9.5.25): one SessionTab per connected Next,
+        # down the pane's outer edge, shown only when there are at least
+        # TWO machines — with one there is nothing to switch between and
+        # the combo already names it. Rebuilt from the roster, so it is
+        # always the same truth the combo shows.
+        self.next_session_strip = QWidget(self)
+        self._session_strip_box = QVBoxLayout(self.next_session_strip)
+        self._session_strip_box.setContentsMargins(3, 0, 0, 0)
+        self._session_strip_box.setSpacing(4)
+        self._session_strip_box.addStretch(1)   # tabs pile from the TOP
+        self.next_session_strip.setVisible(False)
+        self._session_tabs = []
+
+        next_tree_row = QHBoxLayout()
+        next_tree_row.setContentsMargins(0, 0, 0, 0)
+        next_tree_row.setSpacing(0)
+        next_tree_row.addWidget(self.next_view, 1)
+        next_tree_row.addWidget(self.next_session_strip, 0)
+
         next_box = QVBoxLayout()
         next_box.setContentsMargins(0, 0, 0, 0)
         next_box.setSpacing(2)
         next_box.addLayout(next_bar)
-        next_box.addWidget(self.next_view)
+        next_box.addLayout(next_tree_row)
 
         # Under the tree, mirroring the local pane's sync-root row: the Next
         # path box (type a folder, ENTER lists it) with the New Folder /
@@ -1470,10 +1562,40 @@ class RemoteExplorerWidget(QWidget):
             self.next_machine_name_btn.setVisible(len(plist) >= 1)
         finally:
             self._peer_guard = False
+        self._rebuild_session_strip()
         if active is not None and prev is not None and active != prev:
             # The baton moved: this pane now drives a DIFFERENT machine.
             self._set_connected(False)     # drop the old card's listing
             self.on_connected()            # drives + listing of the new one
+
+    def _rebuild_session_strip(self):
+        """Repaint the side tabs from the roster we hold.
+
+        Called wherever the roster or a NAME changes, so the strip can
+        never disagree with the combo — they are two renderings of one
+        list. Tabs are rebuilt rather than patched: the roster is at most
+        four entries (SESS_MAX), and a machine leaving mid-list would make
+        an in-place update the harder thing to get right.
+        """
+        for tab in self._session_tabs:
+            self._session_strip_box.removeWidget(tab)
+            tab.setParent(None)
+            tab.deleteLater()
+        self._session_tabs = []
+        show = len(self._peer_map) >= 2
+        self.next_session_strip.setVisible(show)
+        if not show:
+            return
+        for i, (sid, addr) in enumerate(self._peer_map):
+            # The NAME if the user gave this address one, else the plain
+            # address — the tab is for recognising a machine at a glance,
+            # so the friendly name earns the space when it exists.
+            label = (self._machine_name_for(addr) or "").strip() or str(addr)
+            tab = SessionTab(label, sid == self._peer_active,
+                             (lambda s=sid: self._request_machine(s)),
+                             self.next_session_strip)
+            self._session_strip_box.insertWidget(i, tab)
+            self._session_tabs.append(tab)
 
     def _machine_label(self, sid, addr):
         """One combo entry: "addr #sid", plus " - Name" when the host
@@ -1549,6 +1671,10 @@ class RemoteExplorerWidget(QWidget):
                     self.next_machine_combo.setItemText(
                         i, self._machine_label(_s, _addr))
                     break
+        # The side tabs show the NAME when there is one, so a naming has
+        # to reach them too - otherwise the tab would still read the bare
+        # address the user just replaced.
+        self._rebuild_session_strip()
 
     def _on_machine_pick(self, index):
         """User picked a Next in the machine combo: hand the baton over.
@@ -1558,7 +1684,12 @@ class RemoteExplorerWidget(QWidget):
         queued belong to the machine they were built for)."""
         if self._peer_guard:
             return
-        sid = self.next_machine_combo.itemData(index)
+        self._request_machine(self.next_machine_combo.itemData(index))
+
+    def _request_machine(self, sid):
+        """Ask the worker to hand the baton to `sid` — the one path both
+        switchers take, so the combo and the session strip can never grow
+        different rules about when a switch is allowed."""
         if sid is None or sid == self._peer_active:
             return
         if self._op_active or self._precheck is not None:

--- a/zxnu_remote_explorer.py
+++ b/zxnu_remote_explorer.py
@@ -834,12 +834,29 @@ class RemoteExplorerWidget(QWidget):
             "the name.")
         self.next_machine_name_btn.setVisible(False)
         self.next_machine_name_btn.clicked.connect(self._on_machine_name_edit)
+        # Disconnect (9.5.24): the HTTP bridge's /forceexit as a button —
+        # tell the Next this pane drives to leave listen mode AND end its
+        # application. Sits between the machine's name and its drive
+        # because that is the row that identifies the machine: everything
+        # left of it says WHICH Next, everything right of it says what is
+        # on it. Enabled only while connected (see _set_connected), and
+        # never a broadcast — the marked quit reaches the driven seat
+        # alone, so other connected Nexts keep their place.
+        self.btn_disconnect = CompactButton("Disconnect", self, floor=72)
+        self.btn_disconnect.setToolTip(
+            "Tell the Next shown here to leave listen mode and exit its "
+            "application (the HTTP bridge's /forceexit). The server keeps "
+            "listening, so the same machine — or another — can connect "
+            "again straight away.")
+        self.btn_disconnect.setEnabled(False)
+        self.btn_disconnect.clicked.connect(self._disconnect_peer)
         next_bar = QHBoxLayout()
         next_bar.setContentsMargins(0, 0, 0, 0)
         next_bar.addWidget(next_up)
         next_bar.addWidget(refresh)
         next_bar.addWidget(self.next_machine_combo)
         next_bar.addWidget(self.next_machine_name_btn)
+        next_bar.addWidget(self.btn_disconnect)
         next_bar.addWidget(self.next_drive_combo)
         next_bar.addWidget(self.next_drive_add)
         next_bar.addWidget(self.next_path_label, 1)
@@ -1335,7 +1352,7 @@ class RemoteExplorerWidget(QWidget):
         self._connected = on
         for w in (self.btn_to_next, self.btn_to_local, self.btn_new_folder,
                   self.btn_rename, self.btn_delete, self.next_view,
-                  self.next_path_edit):
+                  self.next_path_edit, self.btn_disconnect):
             w.setEnabled(on)
         if not on:
             self.next_model.removeRows(0, self.next_model.rowCount())
@@ -1465,6 +1482,38 @@ class RemoteExplorerWidget(QWidget):
         combo, GET /sessions and ZXNextRemote's title line can never
         drift apart."""
         return session_label(sid, addr, self._machine_name_for(addr) or "")
+
+    def _disconnect_peer(self):
+        """The Disconnect button: ask the driven Next to leave listen mode
+        and end its application — the bridge's /forceexit, on a button.
+
+        Sends the MARKED quit ('Q' + the exit marker, zxnu_workers): a bare
+        quit is what a server SHUTTING DOWN sends, and the far side must be
+        able to tell the two apart or stopping our own server would kill the
+        operator's app. Fire-and-forget rather than a tracked operation —
+        the command's whole point is that the peer stops answering, so there
+        is no completion to wait for; the worker's disconnect signal repaints
+        the pane when the link drops.
+        """
+        if not self._connected:
+            return
+        machine = (self.next_machine_combo.currentText().strip()
+                   if self.next_machine_combo.isVisible() else "")
+        if not machine:
+            _addr = self._active_addr()
+            machine = str(_addr) if _addr else ""
+        if QMessageBox.question(
+                self, ui_tr_now("Disconnect"),
+                ui_tr_now("Tell this Next to leave listen mode and exit? "
+                          "ZX Next Remote closes its application; a "
+                          "'.sync5' dot returns to BASIC. The server keeps "
+                          "listening, so it can connect again.")
+                + (f"\n\n{machine}" if machine else ""),
+                QMessageBox.Yes | QMessageBox.Cancel,
+                QMessageBox.Cancel) != QMessageBox.Yes:
+            return
+        self._enqueue(("quit_app",))
+        self._log(ui_tr_now("Asked the Next to leave listen mode and exit."))
 
     def _on_machine_name_edit(self):
         """The ✎ button: name (or rename) the machine the combo currently


### PR DESCRIPTION
Two Remote Explorer features, both from using the multi-Next flow.

### 9.5.24 — a Disconnect button

Unite could tell a Next to leave listen mode and exit only through the HTTP bridge's `/forceexit`; there was no way to do it from the Remote Explorer itself. Now there is a button, and it sits on the seam that row already has — between the machine's name and its drive letter, so everything left of it says **which** Next and everything right of it says **what is on it**.

It sends the **marked** quit (ZXNR 0.9.47's `'Q'`+`'X'`), never the bare one: a bare quit is what a server *shutting down* sends, and conflating the two would kill the operator's app every time the server stopped. Not a broadcast either — the marked quit reaches the driven seat alone, so other connected Nexts keep their place. Fire-and-forget rather than a tracked operation, because the command's whole point is that the peer stops answering; the worker's disconnect signal repaints the pane. Confirmed before it fires, naming the machine, and enabled only while connected.

### 9.5.25 — connected Nexts as side tabs

The machine combo tells you which Next you drive, but switching through it costs a click, a read and a second click. The roster is small and fixed (four seats), so it can simply **be on screen**: one vertical tab per connected Next down the Next pane's outer edge, piled from the top, the driven one lit. Clicking a tab is the combo pick it stands for.

A tab shows the **name** the user gave that address, falling back to the bare address — recognising a machine at a glance is the point, so the friendly name earns the space. Naming through the ✎ button reaches the tabs too. Shown only with **two or more** machines: with one there is nothing to switch between and the combo already names it. Text runs bottom-to-top like every side tab, because a horizontal label wide enough for `10.0.0.7 #1 - N-GO` would eat ~140px of the listing — and the listing is the point of the pane. Colours come from the palette, so a tab follows whatever theme is live.

Both switchers now go through one `_request_machine`, so the combo and the strip can never grow different rules about when a switch is allowed (mid-operation it is still refused, and the combo snaps back).

### Verified

Full suite green (22 files). New coverage: eight checks on the strip (visibility gate both ways, name-vs-address labelling, the lit tab, a click making the same request as the combo, a rename reaching the tabs) and six on Disconnect (enablement follows the connection, a cancelled confirm queues nothing, the marked quit goes out alone, the action refuses while offline). Both navigation-bar tripwires updated for the new CompactButton; confirm + log text translated into all six languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)