### PR TITLE
test_esp_emu: fix the Linux-only CLOSED failure (fixture hung up without a FIN)

### DIFF
--- a/tests/test_esp_emu.py
+++ b/tests/test_esp_emu.py
@@ -370,8 +370,24 @@ class FakeUpstream:
         self.conn.sendall(data)
 
     def close_client(self):
+        """Hang up so the PEER actually sees it.
+
+        shutdown() before close(), and it matters: close() alone races the
+        reader thread blocked in recv() on the same socket. On Windows
+        closesocket() aborts that recv and the peer gets a reset, but on
+        Linux the blocked recv keeps the socket alive, NO FIN is sent, and
+        the peer never learns we hung up - which is exactly how the
+        "remote close is announced as CLOSED" check passed locally and
+        failed on CI. shutdown() sends the FIN immediately and wakes the
+        reader on both platforms.
+        """
         if self.conn is not None:
+            try:
+                self.conn.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass                      # already gone: close() still runs
             self.conn.close()
+            self._thread.join(timeout=2)
 
     def close(self):
         try:
@@ -397,7 +413,7 @@ class FakeMame:
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
-                chunk = self.sock.recv(4096)
+                chunk = self.sock.recv(65536)
                 if not chunk:
                     break
                 got += chunk
@@ -626,8 +642,14 @@ def test_server_backpressure():
 
     def push():
         # sendall blocks as TCP pushes the pressure back - exactly the
-        # point; it completes as the reader drains.
-        upstream.send(payload)
+        # point; it completes as the reader drains. Guarded: the teardown
+        # at the end of the test can close this socket while it is still
+        # blocked, and an unhandled raise in a daemon thread only sprays
+        # stderr.
+        try:
+            upstream.send(payload)
+        except OSError:
+            pass
     pusher = threading.Thread(target=push, daemon=True)
     pusher.start()
 


### PR DESCRIPTION
## The failure

`v9.5.28`'s CI went red on Linux (3.10 and 3.13) with a single check:

```
FAIL the remote close is announced as CLOSED
test_esp_emu.py                 FAIL
```

The release workflow gates on the suite, so it aborted — which is why no `v9.5.28` release was ever built.

## Root cause: the fixture, not espemu

`FakeUpstream.close_client()` called `conn.close()` while the fixture's **own reader thread was blocked in `recv()` on that same socket**.

- **Windows**: `closesocket()` aborts the pending recv and the peer sees a reset → espemu reports `CLOSED` → green locally.
- **Linux**: the blocked `recv` keeps the socket alive, **no FIN is sent**, and espemu never learns the peer hung up — *correctly*, because it hadn't. The assertion then timed out.

espemu's behaviour is right on both platforms; only the test pretended to disconnect.

## The fix

`shutdown(SHUT_RDWR)` before `close()` — it sends the FIN immediately and wakes blocked readers on both platforms — then joins the reader so the hang-up is fully settled before the assertion looks for it. I audited every other `close()` in the file; this was the only one with a reader blocked on it.

Also hardened the newest test against a slower runner: `collect()` drains in 64 KB reads rather than 4 KB (the 200 KB backpressure check needed ~5 rounds), and the pusher thread swallows the `OSError` it gets when teardown closes the socket under its blocking `sendall`.

## Tests

Full local suite green; `test_esp_emu.py` 91 checks, run repeatedly. **This one waits for CI green before any tag is moved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)