### PR TITLE
ci: stop superseded flatpak builds piling up

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -26,6 +26,26 @@ on:
       - "flatpak/**"
       - ".github/workflows/flatpak.yml"
 
+# A newer push to the same branch supersedes an in-flight run: the bundle
+# takes ~10 minutes and only the newest commit's result is interesting.
+#
+# Two things this guard must NOT do, both specific to this workflow (test.yml
+# has neither problem - it never runs on tags, and never on `create`):
+#
+#   * cancel a v* TAG build. That run attaches the bundle to the tag's draft
+#     release, so killing it costs a release asset.
+#   * let the `create` event cancel the `push` event. Pushing a NEW branch
+#     fires both, with the same github.ref, in no guaranteed order - so a
+#     shared group would let the create run (which the job's `if` then skips)
+#     cancel the real build and leave the branch with no flatpak run at all.
+#
+# Both are handled by keying the group on the EVENT as well as the ref, and
+# only ever cancelling pushes: a push run can then only supersede another
+# push run on the same branch, which is exactly the pile-up being cleaned up.
+concurrency:
+  group: flatpak-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
   flatpak:
     name: Build Flatpak bundle


### PR DESCRIPTION
`test.yml` has had a concurrency guard for a while; `flatpak.yml` never did.
Every push to a branch touching `flatpak/**` left its predecessor grinding
through a ~10 minute bundle build nobody would look at — three were alive at
once during the 9.6.1 docs work (#308) and had to be cancelled by hand.

```yaml
concurrency:
  group: flatpak-${{ github.event_name }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'push' }}
```

## Why not just copy test.yml's guard

`test.yml` runs on `push`/`pull_request` only. This workflow also runs on
`create` for `v*` tags, which brings two hazards a plain
`group: flatpak-${{ github.ref }}` + `cancel-in-progress: true` would walk
straight into:

1. **A tag build must never be cancelled.** That run attaches the bundle to
   the tag's draft release, so killing it costs a release asset.
2. **`create` must not cancel `push`.** Pushing a *new* branch fires both
   events with the same `github.ref`, in no guaranteed order. If `create`
   lands second it would cancel the real push build and then skip itself via
   the job's existing `if` — leaving that branch with **no flatpak run at
   all**, silently. Strictly worse than the pile-up being fixed.

Keying the group on the **event** as well as the ref, and only cancelling
pushes, handles both: a push run can only ever supersede another push run on
the same branch. Tag and `workflow_dispatch` runs are never cancelled, even if
the same tag is re-pushed.

Validated by parsing the workflow (`yaml.safe_load`) — triggers and the job's
`if` are untouched. Since the file sits in its own `paths` trigger, merging
this fires a flatpak run, so the guard is exercised on the way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
