### PR TITLE
docs: advertise the PowerShell module, and point at the SampleNex demo

### DIFF
--- a/PowerShell/PowerShellHelperClass.md
+++ b/PowerShell/PowerShellHelperClass.md
@@ -20,6 +20,12 @@ $oneFile    = $mySession.Get($remoteList[0])             # fetch the first file
 $remote.Close()                      # disconnect this client (NOT a /forceexit)
 ```
 
+> **Want to see it working before reading any of this?** Clone
+> **[SampleNex](https://github.com/jclauzel/SampleNex)** — a tiny z88dk ZX
+> Spectrum Next app wired to this module end to end, where `Ctrl+Shift+B`
+> in VS Code builds it, pushes it to your Next, verifies it and runs it.
+> It is the worked example for everything below.
+
 It runs on **Windows PowerShell 5.1** (the stock PowerShell of Windows
 10/11 — the module's compatibility floor, no 6/7-only syntax anywhere) and
 on **PowerShell 7+** (`pwsh`), which is what macOS and Linux users run.
@@ -287,6 +293,10 @@ verified · `5` timed out waiting for a Next.
 
 # VS Code: build → push to hardware in one click
 
+A complete, working project using exactly this setup is
+**[SampleNex](https://github.com/jclauzel/SampleNex)** — clone it and press
+`Ctrl+Shift+B`. To wire up your *own* project instead, read on.
+
 The sample lives in [`PowerShell/vscode-sample/`](vscode-sample/) — copy
 `tasks.json` into your project's `.vscode/` folder (or merge the tasks into
 yours) and adjust three things: the path to `PS-Send-ToNext.ps1`, your
@@ -395,3 +405,13 @@ justification — keep the pattern if you extend the code:
 | `PowerShell/PowerShellHelperClass.md` | this document |
 | `PowerShell/vscode-sample/tasks.json` | ready-to-copy VS Code tasks |
 | `tests/test_powershell_module.py` / `.ps1` | the module's test suite (runs under 5.1 AND 7) |
+
+## See also
+
+* **[SampleNex](https://github.com/jclauzel/SampleNex)** — the demo project: a
+  z88dk `.nex` app, a build script and the VS Code tasks, assembled and
+  hardware-tested.
+* [`nextsync/sync/server/HTTP_BRIDGE.md`](../nextsync/sync/server/HTTP_BRIDGE.md)
+  — the wire contract this module speaks.
+* [`extra/README.md`](../extra/README.md) — the Next-side `autoexec` loop
+  and the original `Send-ToNext.ps1`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ emulator launch buttons below:
   built-in `.http` dot command. Enable it in the Settings tab (the port —
   80 by default — is set in the box next to the toggle). See the
   [HTTP bridge documentation](nextsync/sync/server/HTTP_BRIDGE.md).
+- ⭐ **PowerShell module (`ZxNextRemote`)** — drive a connected Next's SD card
+  from a script or a prompt, with no HTTP call in sight: list the seated
+  machines, `Ls`/`Get`/`Put`/`Ren`/`Rcpy`, and `Verify` an upload against a
+  checksum read back **off the Next**. Runs on Windows PowerShell 5.1 and
+  PowerShell 7 (macOS/Linux included), with typed errors that tell the
+  bridge's two different 401s apart — a wrong bearer token vs a write the
+  remote machine's OS protection refused. It powers `PS-Send-ToNext.ps1`, a
+  **build → push → verify → run-on-hardware loop bound to `Ctrl+Shift+B`**
+  in VS Code. See the
+  [PowerShell helper guide](PowerShell/PowerShellHelperClass.md), and
+  [SampleNex](https://github.com/jclauzel/SampleNex) for a ready-made demo
+  project you can clone and push to your Next in one key.
 - **Online libraries** — search and download from GetIt, ZXDB/ZXInfo, zxArt and
   (optionally) itch.io.
 - 🎁 **Starter pack** — one click on the GetIt tab fills your SD image with
@@ -131,6 +143,19 @@ the **[Wiki](https://github.com/jclauzel/ZX-Next-Unite/wiki)**:
   [Alien Floyd's](https://github.com/jclauzel/ZX-Next-Unite/wiki/Alien-Floyds-tab) ·
   [Settings](https://github.com/jclauzel/ZX-Next-Unite/wiki/Settings-tab) ·
   [Help](https://github.com/jclauzel/ZX-Next-Unite/wiki/Help-tab)
+
+### PowerShell automation
+
+- 🧰 **[PowerShell helper guide](PowerShell/PowerShellHelperClass.md)** — the
+  `ZxNextRemote` module: install/uninstall, the class and error reference,
+  the bearer-token pattern, `PS-Send-ToNext.ps1`, and the VS Code
+  integration (`PowerShell/vscode-sample/tasks.json`).
+- 🎮 **[SampleNex](https://github.com/jclauzel/SampleNex)** — a tiny z88dk ZX
+  Spectrum Next app wired to all of the above, ready to clone. It prints
+  `Hello Dev Builders <n>!` with a number that increments on every build, so
+  one glance at the TV proves the bytes running are the ones you just
+  compiled. `Ctrl+Shift+B` builds it, pushes it, verifies it and runs it on
+  real hardware.
 
 ## License
 

--- a/extra/README.md
+++ b/extra/README.md
@@ -12,7 +12,7 @@ Odds and ends that support the project but are not part of the app.
 | `detectenvironnement.bas` / `.txt` | NextBASIC environment-detection helper and its notes |
 | `Send-ToNext.ps1` | Push a build to a real Next over Unite's NextSync HTTP bridge, verified end-to-end (see below) |
 | `ZxNextRemote/` | PowerShell module (classes + cmdlets, PS 5.1 and 7): a typed client for the NextSync HTTP bridge - sessions, ls/get/put/ren/rcpy..., bridge-scoped bearer token, and typed errors that tell the two 401s apart (token vs OS protection). Docs: `PowerShell/PowerShellHelperClass.md`; tests: `tests/test_powershell_module.py` |
-| `PS-Send-ToNext.ps1` | `Send-ToNext.ps1` rebuilt on that module - same cfg/exit codes, plus `-autoexec:On/Off/Deploy` to manage the Next-side loop file remotely and `-AndSend` to combine it with a push. VS Code one-click sample: `PowerShell/vscode-sample/` |
+| `PS-Send-ToNext.ps1` | `Send-ToNext.ps1` rebuilt on that module - same cfg/exit codes, plus `-autoexec:On/Off/Deploy` to manage the Next-side loop file remotely and `-AndSend` to combine it with a push. VS Code one-click sample: `PowerShell/vscode-sample/`; a ready-made demo project: [SampleNex](https://github.com/jclauzel/SampleNex) |
 | `autoexec.bas` / `.txt` | The Next-side loop `Send-ToNext.ps1` pushes into: listen, receive, run, repeat — in either ZX Next Remote flavour. Drop `autoexec.bas` into `/nextzxos/` on the card as-is |
 
 ## Regenerating the README/wiki tour GIF
@@ -204,6 +204,30 @@ A `tasks.json` entry that fails the task on anything but a verified send:
   "problemMatcher": []
 }
 ```
+
+### A ready-made demo project: SampleNex
+
+Rather than wiring a project up from scratch to try this, clone
+**[SampleNex](https://github.com/jclauzel/SampleNex)** — a deliberately tiny z88dk
+ZX Spectrum Next app that exists purely to demo this integration, already
+assembled and confirmed working on real hardware:
+
+* a `build.ps1` that finds z88dk, bumps a build counter and compiles a
+  `.nex` (modelled on this project's sibling build script),
+* a `.vscode/tasks.json` where **`Ctrl+Shift+B`** runs *build → push →
+  verify → run on the Next*, plus tasks for the three `-autoexec` actions,
+* `tools/` carrying the vendored trio, so the repo is self-contained.
+
+The app prints `Hello Dev Builders <n>!` where `n` increments on **every**
+build — so the number on the TV is proof the Next is running the build you
+just made, not a stale copy on the SD card. It ends with a soft reset,
+which hands the machine back to the `autoexec` loop and re-arms the
+Listener for the next push.
+
+Vendoring into your own project means copying **three** things from here —
+`PS-Send-ToNext.ps1`, the `ZxNextRemote/` module folder (imported relative
+to the script) and `autoexec.bas` (what `-autoexec:Deploy` sends, looked up
+beside the script). SampleNex's README documents refreshing them.
 
 ### Editing the loop
 


### PR DESCRIPTION
The `ZxNextRemote` module landed in #311, but nothing outside `PowerShell/` mentioned it and there was no worked example to send anyone to. There is one now — **[SampleNex](https://github.com/jclauzel/SampleNex)** — so this links it from the three places a reader actually starts.

| File | What was added |
|---|---|
| `README.md` | a **Features** bullet for the module (what it does, both shells, the two distinct 401s, the `Ctrl+Shift+B` loop it powers) + a **PowerShell automation** entry under Documentation with both links |
| `extra/README.md` | a section on the demo project beside the push-script material, restating the three-part vendoring recipe it follows |
| `PowerShell/PowerShellHelperClass.md` | a see-it-working pointer at the top, a line in the VS Code section noting the sample project already does exactly this, and a **See also** block |

Docs only — no code touched. Every added link was checked: the repo answers HTTP 200 and all four relative targets exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)