### PR TITLE
ZXInfo API: move to v5 (magazines to v4), 9.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.6.3"
+version = "9.6.4"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_api_parsers.py
+++ b/tests/test_api_parsers.py
@@ -542,6 +542,58 @@ for _mod in ("zxnu_config.py", "zxnu_workers.py", "zxnu_api.py"):
     _src = open(os.path.join(REPO, _mod), encoding="utf-8").read()
     check(f"{_mod} carries the catch-all __all__", _CATCH_ALL in _src)
 
+# --------------------------------------------------------------------------
+# ZXInfo API v5 tripwires (9.6.x).
+#
+# The v3 endpoints are being retired. The migration is easy to REGRESS
+# silently, because v5 answers an unknown path with HTTP 200 and the body
+# "Hello World! api-v5 catch all ..." rather than a 404 -- so a wrong path
+# does not raise, does not 404, and does not look wrong in a log. It just
+# returns a string where JSON was expected.
+#
+# Two of the traps return valid JSON and so survive even a "did it parse"
+# check: v5 silently DROPS the query= search parameter and the author=/
+# publisher= filters, answering with the unfiltered index. The only tell is
+# that the result set is wrong, which no offline test can see. Hence source
+# tripwires: they cannot prove the API still behaves, but they can stop a
+# refactor from quietly reintroducing a spelling we know is dead.
+# --------------------------------------------------------------------------
+from zxnu_config import ZXDB_BASE_URL, ZXDB_MAGAZINES_BASE_URL  # noqa: E402
+
+check("ZXDB base URL is v5", ZXDB_BASE_URL.rstrip("/").endswith("/v5"),
+      ZXDB_BASE_URL)
+# Magazines never reached v5: /v5/magazines/{name} is a catch-all and the
+# documents live in a separate index, so no /entries route reaches them.
+check("ZXDB magazines base URL is v4",
+      ZXDB_MAGAZINES_BASE_URL.rstrip("/").endswith("/v4"),
+      ZXDB_MAGAZINES_BASE_URL)
+
+_pane_src = open(os.path.join(REPO, "zxnu_zxdb_pane.py"), encoding="utf-8").read()
+_api_src2 = open(os.path.join(REPO, "zxnu_api.py"), encoding="utf-8").read()
+
+# v3 spelled entries "games". Every one of these is a catch-all on v5.
+for _dead in ('f"/games/', '"/games/', "/authors/{qname}/games",
+              "/publishers/{qname}/games"):
+    check(f"no dead v3 path {_dead!r} in the ZXDB pane", _dead not in _pane_src)
+
+# The search TERM must be a path segment. As ?query= it is dropped and the
+# call returns the whole index with a 200.
+check("search term goes in the path, not ?query=",
+      "/search/titles/" in _pane_src and 'params["query"]' not in _pane_src)
+# Matched against CODE, not prose: the v3->v5 map in zxdb_fetch_json's
+# docstring names the dead spellings on purpose, and a bare substring ban
+# would fail on the documentation that explains why they are dead.
+_api_code = chr(10).join(l for l in _api_src2.splitlines()
+                        if "zxdb_fetch_json(" in l or 'f"/search' in l)
+check("the publisher lookup uses the v5 search path too",
+      "/search/titles/" in _api_src2
+      and "mode=tit" not in _api_code and "query=" not in _api_code)
+
+# The v5 replacements are actually present.
+for _live in ("/entries/", "/entries/byauthor/", "/entries/bypublisher/",
+              "/entries/morelikethis/", "/entries/byletter/", "/entries/random/"):
+    check(f"v5 path {_live!r} is used", _live in _pane_src)
+
 print()
 if FAIL:
     print(f"RESULT: {len(FAIL)} FAILURE(S)")

--- a/zxnu_api.py
+++ b/zxnu_api.py
@@ -1,5 +1,5 @@
 """Online catalogue API layer for ZX-Next-Unite: GetIt (zxnext.uk),
-ZXDB (api.zxinfo.dk/v3) and zxART (zxart.ee).
+ZXDB (api.zxinfo.dk/v5, magazines on v4) and zxART (zxart.ee).
 
 Extracted verbatim from zx-next-unite.py (strangler refactor, sitting #2):
 the shared HTTP retry helpers, the per-service fetchers, response parsers,
@@ -461,13 +461,52 @@ def zxart_entry_website_url(entry) -> str:
     return ""
 
 
-def zxdb_fetch_json(path: str, timeout: int = 15, _retries: int = 3, _backoff: float = 1.5):
+def zxdb_fetch_json(path: str, timeout: int = 15, _retries: int = 3, _backoff: float = 1.5,
+                    base: str = ""):
     """GET JSON from the ZXInfo API. *path* must include any query string.
     Identifies the client per API policy via a custom User-Agent.
     Retries up to *_retries* times on transient server errors (5xx / network)
-    with exponential backoff starting at *_backoff* seconds."""
+    with exponential backoff starting at *_backoff* seconds.
+
+    *base* overrides ZXDB_BASE_URL - used only for magazines, which live on
+    v4 (see zxnu_config).
+
+    THE v3 -> v5 MAP, every line verified against the live API in August 2026
+    by comparing RESULT SETS, because v5 answers an unknown path with HTTP
+    200 and a plain-text "api-v5 catch all" body rather than a 404:
+
+        /games/{id}                 -> /entries/{id}
+        /games/morelikethis/{id}    -> /entries/morelikethis/{id}
+        /games/byletter/{letter}    -> /entries/byletter/{letter}
+        /games/random/{n}           -> /entries/random/{n}
+        /authors/{name}/games       -> /entries/byauthor/{name}
+        /publishers/{name}/games    -> /entries/bypublisher/{name}
+        /magazines/{name}           -> NO v5 ROUTE; use v4 (base= above)
+        /search?query=TERM&mode=tit -> /search/titles/TERM
+
+    TWO TRAPS THAT LOOK LIKE SUCCESS. Both return valid JSON with no
+    catch-all string, so neither is caught by checking the status or the
+    shape - only by comparing what comes back:
+
+      1. v5 /search DROPS the query= parameter. /v5/search?query=jetpac
+         returns the same 10000-hit unfiltered page as the same URL with
+         query deleted; v3 returned 15 hits led by Jetpac. The search term
+         belongs in the PATH now. The query STRING still works for browsing
+         (contenttype, sort, size, offset are all honoured), which is why
+         the "latest games" call below is unchanged.
+      2. v5 ignores author=/publisher= as search parameters the same way -
+         they filter nothing. Use the byauthor/bypublisher paths.
+
+    Also changed: mode= is the response SHAPE in v5 (full/compact/tiny),
+    not the search scope. v3's mode=tit is accepted and silently ignored.
+
+    Not a change, verified: the ENVELOPE is identical. hits.total is still
+    {value, relation}, and a recursive key diff of the same entry through
+    both versions gives 76 shared paths and none unique to either - so the
+    parsers below need nothing. Result ORDER does differ on the multi-hit
+    routes (v5 applies a default sort where v3 returned relevance order)."""
     import time as _time
-    url = ZXDB_BASE_URL + path
+    url = (base or ZXDB_BASE_URL) + path
     last_exc = None
     for attempt in range(_retries):
         try:
@@ -535,7 +574,8 @@ def zxdb_parse_search(payload) -> tuple:
         return entries, total, page, total_pages, page_size
 
     # Pagination metadata (may appear under different keys)
-    # ZXInfo v3 uses ES envelope: hits.total.value (or hits.total as int)
+    # ZXInfo uses the raw ES envelope: hits.total.value (or hits.total as
+    # int). Unchanged between v3 and v5 - verified by a recursive key diff.
     _hits_meta = payload.get("hits")
     if isinstance(_hits_meta, dict):
         _hits_total = _hits_meta.get("total")
@@ -1170,7 +1210,7 @@ def _zxart_resolve_publishers_via_zxdb(title: str, year: str = "") -> str:
     API to recover a human-readable publisher name when zxArt only exposes
     an opaque numeric publisher id.
 
-    Strategy: search ZXDB by title (mode=tit) and return the publishers of
+    Strategy: search ZXDB by title (/search/titles/) and return the publishers of
     the best hit. If *year* is provided, prefer hits whose
     ``originalYearOfRelease`` / ``yearOfRelease`` matches. Falls back to
     release-level publishers when the top-level record has none. Results
@@ -1189,7 +1229,10 @@ def _zxart_resolve_publishers_via_zxdb(title: str, year: str = "") -> str:
     name = ""
     try:
         q = urllib.parse.quote(t)
-        payload = zxdb_fetch_json(f"/search?query={q}&mode=tit&size=10")
+        # v5: the term is a PATH segment. As a query parameter it is
+        # silently dropped and the call returns the unfiltered index.
+        payload = zxdb_fetch_json(
+            f"/search/titles/{urllib.parse.quote(q)}?mode=compact&size=10")
         hits = ((payload or {}).get("hits") or {}).get("hits") or []
         # Prefer year-matched hits when a year is provided.
         def _pubs_from_hit(hit):

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
 
-ZX_NEXT_UNITE_VERSION = "9.6.3"
+ZX_NEXT_UNITE_VERSION = "9.6.4"
 # Version of the bundled NextSync .sync5 dotN command (nextsync/sync/server/
 # dot/syncdev, also attached to GitHub releases as the "sync5" asset). MUST be
 # kept in sync with the banner in nextsync/sync/z88dk/nextsync.c ("NextSync
@@ -175,7 +175,20 @@ GETIT_STARTER_PACK_IMAGE_DIR = "/games/StarterPack"
 # Minimum number of characters required before a keyword search is accepted.
 SEARCH_MIN_CHARS = 3
 
-ZXDB_BASE_URL = "https://api.zxinfo.dk/v3"
+# ZXInfo moved to v5 and is retiring v3 (the API's author gave notice in
+# August 2026). The rename is not cosmetic: v3's "games" became "entries",
+# and v5 answers an UNKNOWN PATH WITH HTTP 200 and the plain-text body
+# "Hello World! api-v5 catch all ...". So a wrong path does not 404 - it
+# succeeds and returns a string where JSON was expected. Every mapping in
+# this app was verified against the live API by comparing RESULT SETS, not
+# status codes; see zxdb_fetch_json for the v3 -> v5 table.
+ZXDB_BASE_URL = "https://api.zxinfo.dk/v5"
+# Magazines never made it to v5 - /v5/magazines/{name} is a catch-all, and
+# the documents live in a separate Elasticsearch index from entries, so no
+# /entries route reaches them. v4 carries them, byte-identical to v3
+# (same _index, _id, _score and issue list), and is what zxinfo.dk's own
+# frontend uses. One endpoint, one base URL, kept apart so it is obvious.
+ZXDB_MAGAZINES_BASE_URL = "https://api.zxinfo.dk/v4"
 ZXDB_USER_AGENT = f"ZX-Next-Unite/{ZX_NEXT_UNITE_VERSION}"
 ZXDB_PAGE_SIZE = 20
 

--- a/zxnu_zxdb_pane.py
+++ b/zxnu_zxdb_pane.py
@@ -1,6 +1,6 @@
-"""zxnu_zxdb_pane.py — ZXDB (ZXInfo API v3) gallery pane builder.
+"""zxnu_zxdb_pane.py — ZXDB (ZXInfo API v5) gallery pane builder.
 
-Strangler extraction from MainWindow.__init__: the ~3k-line ZXDB (ZXInfo API v3) UI
+Strangler extraction from MainWindow.__init__: the ~3k-line ZXDB (ZXInfo API v5) UI
 construction blob (widgets + navigation + search/detail/download closures) now
 lives here as build_zxdb_pane(host, ...). The operation-layer wiring that still
 lives in MainWindow (tab spinners, cross-search dispatch, hdfmonkey transfers,
@@ -76,7 +76,7 @@ def build_zxdb_pane(
     _right_disk_content,
 ):
     # -----------------------------------------------------------------------
-    # ZXDB UI construction (ZXInfo API v3)
+    # ZXDB UI construction (ZXInfo API v5)
     # -----------------------------------------------------------------------
 
     host.zxdb_form = QFormLayout()
@@ -288,7 +288,7 @@ def build_zxdb_pane(
         if not eid:
             return
         def _fn():
-            payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+            payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
             detail  = zxdb_parse_game_detail(payload)
             shots = detail.get("screenshots") or []
             if not shots and detail.get("screenshot_url"):
@@ -424,7 +424,7 @@ def build_zxdb_pane(
                 return
             zxdb_set_status(f"Loading {eid}\u2026")
             def _fn():
-                payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                 return zxdb_parse_game_detail(payload)
             def _on_ok(detail, _dr=dest_root, _pa=post_action):
                 zxdb_populate_detail(detail)
@@ -443,7 +443,7 @@ def build_zxdb_pane(
                 return
             zxdb_set_status(f"Loading {eid}\u2026")
             def _fn_dl():
-                payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                 return zxdb_parse_game_detail(payload)
             def _on_ok_dl(detail):
                 zxdb_populate_detail(detail)
@@ -462,7 +462,7 @@ def build_zxdb_pane(
                 return
             zxdb_set_status(f"Loading {eid}\u2026")
             def _fn_sd():
-                payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                 return zxdb_parse_game_detail(payload)
             def _on_ok_sd(detail):
                 zxdb_populate_detail(detail)
@@ -482,7 +482,7 @@ def build_zxdb_pane(
             zxdb_set_status(f"Finding titles similar to '{title}'\u2026")
             def _fn_mlt():
                 payload = zxdb_fetch_json(
-                    f"/games/morelikethis/{urllib.parse.quote(eid)}"
+                    f"/entries/morelikethis/{urllib.parse.quote(eid)}"
                     f"?mode=compact&size={ZXDB_PAGE_SIZE}"
                 )
                 entries, total, _pg, total_pages, _ps = zxdb_parse_search(payload)
@@ -1005,9 +1005,17 @@ def build_zxdb_pane(
                 "sort":   "rel_desc",
                 "contenttype": "SOFTWARE",
             }
+            # v5 SPLITS these. A search TERM is a path segment -- as a
+            # query parameter it is silently dropped and the unfiltered
+            # index comes back with a 200. A bare browse (no term) still
+            # uses the query string, where sort/contenttype/size/offset
+            # are all honoured. /search/titles/ is the closest match to
+            # v3's mode=tit; /search/ alone searches wider.
             if query:
-                params["query"] = query
-            path = f"/search?{urllib.parse.urlencode(params)}"
+                path = (f"/search/titles/{urllib.parse.quote(query)}"
+                        f"?{urllib.parse.urlencode(params)}")
+            else:
+                path = f"/search?{urllib.parse.urlencode(params)}"
 
             def _fn():
                 payload = zxdb_fetch_json(path)
@@ -1024,7 +1032,7 @@ def build_zxdb_pane(
                 "mode":   "compact",
                 "contenttype": "SOFTWARE",
             }
-            path = f"/games/byletter/{urllib.parse.quote(letter)}?{urllib.parse.urlencode(params)}"
+            path = f"/entries/byletter/{urllib.parse.quote(letter)}?{urllib.parse.urlencode(params)}"
 
             def _fn():
                 payload = zxdb_fetch_json(path)
@@ -1039,7 +1047,8 @@ def build_zxdb_pane(
                 mag_path = f"/magazines/{urllib.parse.quote(query)}"
 
                 def _fn():
-                    payload = zxdb_fetch_json(mag_path)
+                    payload = zxdb_fetch_json(mag_path,
+                                              base=ZXDB_MAGAZINES_BASE_URL)
                     # /magazines/{name} returns a single ES hit: {_id, _source, …}
                     # Wrap it so _zxdb_parse_magazine_list can handle it uniformly.
                     if isinstance(payload, dict) and "_source" in payload:
@@ -1061,18 +1070,21 @@ def build_zxdb_pane(
                 list_path = f"/magazines/?{urllib.parse.urlencode(params)}"
 
                 def _fn():
-                    payload = zxdb_fetch_json(list_path)
+                    payload = zxdb_fetch_json(list_path,
+                                              base=ZXDB_MAGAZINES_BASE_URL)
                     entries = _zxdb_parse_magazine_list(payload)
                     total = _zxdb_extract_es_total(payload) or len(entries)
                     total_pages = max(1, (total + ZXDB_PAGE_SIZE - 1) // ZXDB_PAGE_SIZE) if total else 1
                     return ("magazines", entries, total, page, total_pages)
 
         elif mode == "author":
-            # ZXInfo exposes both /authors/{name}/games and /publishers/{name}/games.
+            # ZXInfo v5 exposes both /entries/byauthor/{name} and
+            # /entries/bypublisher/{name} (v3 spelled these
+            # /authors/{name}/games and /publishers/{name}/games).
             # Many UI users type a publisher/label name (e.g. 'Ultimate'), so we
             # try authors first and fall back to publishers when authors yields
             # no hits — this matches the working URL the user supplied:
-            #   /publishers/{name}/games?mode=compact&...
+            #   /entries/bypublisher/{name}?mode=compact&...
             params = {
                 "size":   str(ZXDB_PAGE_SIZE),
                 "offset": str(offset),
@@ -1084,11 +1096,11 @@ def build_zxdb_pane(
 
             def _fn():
                 used = "authors"
-                payload = zxdb_fetch_json(f"/authors/{qname}/games?{qs}")
+                payload = zxdb_fetch_json(f"/entries/byauthor/{qname}?{qs}")
                 entries, total, _pg, total_pages, _ps = zxdb_parse_search(payload)
                 if not entries:
                     used = "publishers"
-                    payload = zxdb_fetch_json(f"/publishers/{qname}/games?{qs}")
+                    payload = zxdb_fetch_json(f"/entries/bypublisher/{qname}?{qs}")
                     entries, total, _pg, total_pages, _ps = zxdb_parse_search(payload)
                 for e in entries:
                     e["_kind"] = "game"
@@ -1149,7 +1161,7 @@ def build_zxdb_pane(
         _start_tab_spinner(ZX_NEXT_UNITE_TAB_TITLE_ZXDB)
 
         def _fn():
-            payload = zxdb_fetch_json(f"/games/random/{ZXDB_PAGE_SIZE}")
+            payload = zxdb_fetch_json(f"/entries/random/{ZXDB_PAGE_SIZE}")
             # /games/random returns an ES envelope: { hits: { hits: [...] } }
             entries = []
             if isinstance(payload, list):
@@ -1477,7 +1489,7 @@ def build_zxdb_pane(
                     "mode":        "compact",
                     "contenttype": "SOFTWARE",
                 }
-                path = f"/games/byletter/{urllib.parse.quote(letter)}?{urllib.parse.urlencode(params)}"
+                path = f"/entries/byletter/{urllib.parse.quote(letter)}?{urllib.parse.urlencode(params)}"
                 try:
                     payload = zxdb_fetch_json(path)
                     entries, page_total, _pg, _tp, _ps = zxdb_parse_search(payload)
@@ -1633,7 +1645,7 @@ def build_zxdb_pane(
         _zxdb_reset_preview()
 
         def _fn():
-            payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+            payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
             return zxdb_parse_game_detail(payload)
 
         def _on_ok(detail):
@@ -1671,7 +1683,8 @@ def build_zxdb_pane(
         def _fn():
             # /magazines/{name} returns a single ES hit whose _source contains
             # the full issues array (with id, files, cover_image per issue).
-            return zxdb_fetch_json(f"/magazines/{urllib.parse.quote(name)}")
+            return zxdb_fetch_json(f"/magazines/{urllib.parse.quote(name)}",
+                                   base=ZXDB_MAGAZINES_BASE_URL)
 
         def _on_ok(payload):
             if host._zxdb_selected_title != name:
@@ -1965,7 +1978,7 @@ def build_zxdb_pane(
                 return
             zxdb_set_status(f"Loading {eid}\u2026")
             def _fn():
-                payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                 return zxdb_parse_game_detail(payload)
             def _on_ok(detail):
                 zxdb_populate_detail(detail)
@@ -1986,7 +1999,7 @@ def build_zxdb_pane(
                 return
             zxdb_set_status(f"Loading {eid}\u2026")
             def _fn():
-                payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                 return zxdb_parse_game_detail(payload)
             def _on_ok(detail):
                 zxdb_populate_detail(detail)
@@ -2009,7 +2022,7 @@ def build_zxdb_pane(
                 return
             zxdb_set_status(f"Loading {eid}\u2026")
             def _fn():
-                payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                 return zxdb_parse_game_detail(payload)
             def _on_ok(detail):
                 zxdb_populate_detail(detail)
@@ -2048,7 +2061,7 @@ def build_zxdb_pane(
         def _fn():
             if kind == "magazine":
                 return ("magazine", {}, [])
-            payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+            payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
             detail  = zxdb_parse_game_detail(payload)
             shots   = detail.get("screenshots") or []
             if not shots and detail.get("screenshot_url"):
@@ -2164,7 +2177,8 @@ def build_zxdb_pane(
                 # Issues not loaded yet — load then open dialog
                 zxdb_set_status(f"Loading issues for '{mag_name}'…")
                 def _fn_dbl():
-                    payload = zxdb_fetch_json(f"/magazines/{urllib.parse.quote(mag_name)}")
+                    payload = zxdb_fetch_json(f"/magazines/{urllib.parse.quote(mag_name)}",
+                                              base=ZXDB_MAGAZINES_BASE_URL)
                     src = payload.get("_source", payload) if isinstance(payload, dict) else {}
                     return src.get("issues") or []
                 def _on_ok_dbl(issues):
@@ -2671,7 +2685,8 @@ def build_zxdb_pane(
                 else:
                     zxdb_set_status(f"Loading issues for '{mag_name}'…")
                     def _fn_all():
-                        payload = zxdb_fetch_json(f"/magazines/{urllib.parse.quote(mag_name)}")
+                        payload = zxdb_fetch_json(f"/magazines/{urllib.parse.quote(mag_name)}",
+                                              base=ZXDB_MAGAZINES_BASE_URL)
                         src = payload.get("_source", payload) if isinstance(payload, dict) else {}
                         return src.get("issues") or []
                     def _on_ok_all(issues):
@@ -2686,7 +2701,8 @@ def build_zxdb_pane(
                 zxdb_set_status(f"Fetching magazine '{mag_name}'…")
 
                 def _fn_mag():
-                    payload = zxdb_fetch_json(f"/magazines/{urllib.parse.quote(mag_name)}")
+                    payload = zxdb_fetch_json(f"/magazines/{urllib.parse.quote(mag_name)}",
+                                              base=ZXDB_MAGAZINES_BASE_URL)
                     if isinstance(payload, dict) and "_source" in payload:
                         wrapped = {"hits": {"hits": [payload], "total": {"value": 1}}}
                     elif isinstance(payload, list):
@@ -2718,7 +2734,8 @@ def build_zxdb_pane(
                 def _fn_issue():
                     return zxdb_fetch_json(
                         f"/magazines/{urllib.parse.quote(mag_name)}"
-                        f"/issues/{urllib.parse.quote(issue_id)}"
+                        f"/issues/{urllib.parse.quote(issue_id)}",
+                        base=ZXDB_MAGAZINES_BASE_URL,
                     )
 
                 def _on_ok_issue(payload):
@@ -2821,7 +2838,7 @@ def build_zxdb_pane(
                     return
                 zxdb_set_status(f"Loading {eid}…")
                 def _fn():
-                    payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                    payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                     return zxdb_parse_game_detail(payload)
                 def _on_ok(detail, _dr=dest_root, _pa=post_action):
                     zxdb_populate_detail(detail)
@@ -2849,7 +2866,7 @@ def build_zxdb_pane(
                 zxdb_set_status(f"Loading {eid}…")
 
                 def _fn():
-                    payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                    payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                     return zxdb_parse_game_detail(payload)
 
                 def _on_ok(detail):
@@ -2877,7 +2894,7 @@ def build_zxdb_pane(
                         return
                     zxdb_set_status(f"Loading {eid}…")
                     def _fn_sd():
-                        payload = zxdb_fetch_json(f"/games/{urllib.parse.quote(eid)}")
+                        payload = zxdb_fetch_json(f"/entries/{urllib.parse.quote(eid)}")
                         return zxdb_parse_game_detail(payload)
                     def _on_ok_sd(detail):
                         zxdb_populate_detail(detail)
@@ -2901,7 +2918,7 @@ def build_zxdb_pane(
 
                 def _fn_mlt():
                     payload = zxdb_fetch_json(
-                        f"/games/morelikethis/{urllib.parse.quote(eid)}"
+                        f"/entries/morelikethis/{urllib.parse.quote(eid)}"
                         f"?mode=compact&size={ZXDB_PAGE_SIZE}"
                     )
                     entries, total, _pg, total_pages, _ps = zxdb_parse_search(payload)


### PR DESCRIPTION
The API's author gave notice that the v3 endpoints are going away. This moves every ZXDB call off them.

### The migration is not a base-URL swap

v5 answers an **unknown path with HTTP 200** and the plain-text body:

```
Hello World! api-v5 catch all - read more about this API here <link>: /games/0044183
```

Not a 404. Flipping `ZXDB_BASE_URL` alone would have left every call "succeeding" while returning that string where JSON was expected. Every mapping below was checked against the live API by comparing **result sets**, not status codes.

| v3 | v5 |
|---|---|
| `/games/{id}` | `/entries/{id}` |
| `/games/morelikethis/{id}` | `/entries/morelikethis/{id}` |
| `/games/byletter/{letter}` | `/entries/byletter/{letter}` |
| `/games/random/{n}` | `/entries/random/{n}` |
| `/authors/{name}/games` | `/entries/byauthor/{name}` |
| `/publishers/{name}/games` | `/entries/bypublisher/{name}` |
| `/search?query=TERM&mode=tit` | `/search/titles/TERM` |
| `/magazines/{name}` | **no v5 route** → v4 |

### Two traps that look exactly like success

Valid JSON, no catch-all string — so neither is caught by checking the status or the shape:

**1. v5 drops the `query=` search parameter.**
```
v3 ?query=jetpac         → total=15     Jetpac | Jetpac 2 | JetPac
v5 ?query=jetpac         → total=10000  "Astros": Planisferio | …
v5 with no query at all  → total=10000  "Astros": Planisferio | …   ← identical
v5 /search/titles/jetpac → total=12     Jetpac | Jetpac 2 | JetPac
```
The term is a path segment now. The query **string** still works for *browsing* — `contenttype`, `sort`, `size`, `offset` are all honoured — so the "latest games" call, which carries no term, is deliberately unchanged.

**2. v5 ignores `author=` and `publisher=` the same way.** `?author=Matthew%20Smith` returns the identical first three titles as the query without it. Hence the `byauthor`/`bypublisher` **paths**, which do filter — 7 and 18 hits against an index that saturates at 10000, matching v3's counts exactly.

### Magazines have no v5 route

`/v5/magazines/{name}` is a catch-all, and the documents live in a separate Elasticsearch index from entries, so no `/entries` path reaches them. v4 carries them byte-identically to v3 (same `_index`, `_id`, `_score`, same 117 issues for *Crash*) and is what zxinfo.dk's own frontend uses — so they move to a second base URL rather than being left on the version that is going away.

Also: `mode=` is the response **shape** in v5 (full/compact/tiny), not the search scope, so v3's `mode=tit` is gone — it was accepted and silently ignored.

### Not changed, and verified rather than assumed

The response **envelope**. `hits.total` is still `{value, relation}`, and a recursive key diff of the same entry through both versions gives 76 shared paths and none unique to either — so `zxdb_parse_search` and `zxdb_parse_game_detail` need nothing.

Result **order** does differ on the multi-hit routes (v5 applies a default sort where v3 returned relevance order). Cosmetic here, but it would matter to anything asserting a first row.

---

**Tested:** all ten migrated paths fetched live, returning real JSON with plausible counts. `test_api_parsers`, `test_pane_imports`, `test_i18n`, `test_network`, `test_data_root` all pass.

Source tripwires added to `tests/test_api_parsers.py` so a later refactor cannot quietly reintroduce a dead spelling. They cannot prove the API still behaves, and say so — but they caught a leftover `mode=tit` in this very change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)