### PR TITLE
Flatpak metainfo: record the 9.6.4 .. 9.7.1 releases

### DIFF
--- a/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
+++ b/flatpak/io.github.jclauzel.ZXNextUnite.metainfo.xml
@@ -50,6 +50,10 @@
     <color type="primary" scheme_preference="dark">#1c1c60</color>
   </branding>
   <releases>
+    <release version="9.7.1" date="2026-09-03"/>
+    <release version="9.7.0" date="2026-08-31"/>
+    <release version="9.6.5" date="2026-08-30"/>
+    <release version="9.6.4" date="2026-08-29"/>
     <release version="9.6.3" date="2026-08-28"/>
     <release version="9.6.2" date="2026-08-28"/>
     <release version="9.6.1" date="2026-08-27"/>


### PR DESCRIPTION
The AppStream `<releases>` list stopped at 9.6.3 — the 9.6.4, 9.6.5, 9.7.0 and today's 9.7.1 bumps touched only `pyproject.toml` and `zxnu_config.py`, so the shipped v9.7.1 `.flatpak` carries a metainfo whose newest release is 9.6.3, and a software center renders that as the latest. `flatpak/README.md` step 5 says to keep the list current (the 9.6.1–9.6.3 bumps did); nothing in CI regenerates or validates it, so it only moves by hand.

Four one-line `<release>` entries, XML validated, zero runtime risk. Found by today's adversarial review of the day's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)