### PR TITLE
itch.io build order: a dotted version's last digit is not an extension

### DIFF
--- a/tests/test_api_parsers.py
+++ b/tests/test_api_parsers.py
@@ -653,6 +653,44 @@ check(f"dotN binary: carries the 'NextSync {ZX_NEXT_UNITE_DOTN_VERSION}' "
       sync5_blob_has_banner(_dot_blob, ZX_NEXT_UNITE_DOTN_VERSION),
       f"{len(_dot_blob)} bytes read")
 
+# ---- itch.io build-name ordering --------------------------------------------
+# cspect_version_key's extension strip used os.path.splitext, which on a DOTTED
+# version took the last component for an extension: zxnextremote-1.0.7 keyed as
+# zxnextremote-1.0, so every ZX Next Remote patch level tied. The update sender
+# then pushed whichever install folder it listed first, and the startup check
+# compared an upload name that kept its digit against a folder that had lost
+# it. CSpect's underscore names never hit it. Pins for both shapes.
+import tempfile  # noqa: E402
+from zxnu_config import (cspect_version_key, cspect_version_newer,  # noqa: E402
+                         find_installed_zxnextremote_version)
+
+check("build order: zxnextremote-1.0.7 is newer than 1.0.3",
+      cspect_version_newer("zxnextremote-1.0.7", "zxnextremote-1.0.3"))
+check("build order: 1.0.3 is not newer than 1.0.7",
+      not cspect_version_newer("zxnextremote-1.0.3", "zxnextremote-1.0.7"))
+check("build order: 1.0.10 is newer than 1.0.7 (numeric, not lexical)",
+      cspect_version_newer("zxnextremote-1.0.10", "zxnextremote-1.0.7"))
+check("build order: a .zip upload keys equal to its extracted folder",
+      cspect_version_key("zxnextremote-1.0.7.zip")
+      == cspect_version_key("zxnextremote-1.0.7"))
+check("build order: an identical version is not 'newer' (no spurious update)",
+      not cspect_version_newer("zxnextremote-1.0.7.zip", "zxnextremote-1.0.7"))
+check("build order: CSpect underscore names unchanged (3_1_10 > 3_1_4)",
+      cspect_version_newer("CSpect3_1_10_0", "CSpect3_1_4_0"))
+check("build order: a CSpect .zip vs its folder still tie",
+      not cspect_version_newer("CSpect3_1_4_0.zip", "CSpect3_1_4_0"))
+with tempfile.TemporaryDirectory() as _td:
+    _files = os.path.join(_td, "downloads", "itchio", "jclauzel",
+                          "zxnextremote", "files")
+    for _v in ("zxnextremote-1.0.3", "zxnextremote-1.0.10",
+               "zxnextremote-1.0.7"):
+        os.makedirs(os.path.join(_files, _v))
+    open(os.path.join(_files, "zxnextremote-1.0.10.zip"), "wb").close()
+    _name, _path = find_installed_zxnextremote_version(_td)
+    check("installed ZXNR: the highest dotted FOLDER wins (1.0.10), not the "
+          "first listed and not the .zip", _name == "zxnextremote-1.0.10",
+          str(_name))
+
 print()
 if FAIL:
     print(f"RESULT: {len(FAIL)} FAILURE(S)")

--- a/zxnu_config.py
+++ b/zxnu_config.py
@@ -2239,9 +2239,26 @@ def cspect_version_key(name):
     (``CSpect3_1_4_0.zip``) — otherwise the trailing ``.zip`` token would make an
     identical version compare as *newer* and trigger a spurious update. Digit
     runs compare as ints, other runs as lower-case text."""
-    stem = os.path.splitext(os.path.basename(name or ""))[0]
+    stem = _version_stem(name)
     return [int(tok) if tok.isdigit() else tok.lower()
             for tok in re.split(r"(\d+)", stem)]
+
+
+def _version_stem(name):
+    """The build name with a real archive extension stripped and nothing else.
+
+    ``os.path.splitext`` is the wrong tool here: on a DOTTED version it takes
+    the last component for an extension, so ``zxnextremote-1.0.7`` became
+    ``zxnextremote-1.0`` and every patch level of ZX Next Remote (1.0.3, 1.0.7,
+    1.0.10) collapsed onto one key — the update sender then pushed whichever
+    install folder it listed first, and the startup check compared an itch.io
+    upload name that had kept its patch digit (its ``.zip`` really is an
+    extension) against an install folder that had lost it. Only a suffix that
+    is not purely numeric is an extension (``.zip``, ``.7z``); ``.7`` is a
+    version component. CSpect's underscore names never hit this."""
+    base = os.path.basename(name or "")
+    root, ext = os.path.splitext(base)
+    return root if ext and not ext[1:].isdigit() else base
 
 
 def cspect_version_newer(candidate_name, installed_name):
@@ -2257,8 +2274,8 @@ def cspect_version_newer(candidate_name, installed_name):
     try:
         return ck > ik
     except TypeError:
-        a = os.path.splitext(os.path.basename(candidate_name or ""))[0].lower()
-        b = os.path.splitext(os.path.basename(installed_name or ""))[0].lower()
+        a = _version_stem(candidate_name).lower()
+        b = _version_stem(installed_name).lower()
         return a > b
 
 


### PR DESCRIPTION
`cspect_version_key` stripped a "file extension" with `os.path.splitext`, which on a **dotted** version takes the last component: `zxnextremote-1.0.7` keyed as `zxnextremote-1.0`, so every ZX Next Remote patch level (1.0.3, 1.0.7, 1.0.10) collapsed onto one key.

Consequences: `find_installed_zxnextremote_version` kept whichever install folder it listed first — the remote update sender would push the **old** `.nex` after a newer download — and the startup check compared an itch.io upload name that kept its digit (its `.zip` really is an extension) against an install folder that had lost it. CSpect's underscore names never hit it, which is how it hid.

Fix: only a non-numeric suffix is an extension (`.zip`, `.7z`); `.7` is a version component. Found rehearsing the upgrade with ZXNextRemote's new `ZipZXNR.ps1 -Deploy`, which plants a fake 1.0.7 download beside the real 1.0.3 — the app kept picking 1.0.3.

Eight regression pins in `test_api_parsers.py` cover both naming shapes (dotted and underscore), zip-equals-folder (no spurious update), and the folder-over-zip pick. Full suite 25/25 PASS. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)