### PR TITLE
tests: a bridge with no /crc route; i18n: the dead .sync5 dialog key goes

### DIFF
--- a/tests/test_powershell_module.ps1
+++ b/tests/test_powershell_module.ps1
@@ -19,6 +19,7 @@ param(
     [Parameter(Mandatory)] [int]$TokenPort,
     [Parameter(Mandatory)] [int]$OspPort,
     [Parameter(Mandatory)] [int]$DeadPort,
+    [Parameter(Mandatory)] [int]$OldBridgePort,
     [Parameter(Mandatory)] [string]$Token,
     [Parameter(Mandatory)] [string]$TmpDir
 )
@@ -184,6 +185,29 @@ Check 'old listener: the fallback still catches a difference' `
 Check 'old listener: Verify of a missing file throws' `
     ((Get-ThrownReason { $s2.Verify($data, '/no-such.bin') }) -eq 'NextRefused')
 [void]$s2.Rm('/old.bin')
+
+# A BRIDGE that predates the /crc route (ZX-Next-Unite < 9.7.2): Flask's
+# plain 404 - HttpError, status 404 - is not a verdict about the file, so
+# Verify() must fall through to /sum exactly as 1.0.0 did, while the strict
+# Crc() lets the 404 out (it is not a NextRefused).
+$obCon = New-ZxNextRemoteConnection -IpAddress 127.0.0.1 -Port $OldBridgePort
+$ob = (New-ZxNextRemote $obCon).ManageSession()
+[void]$ob.Put($data, '/old-bridge.bin')
+$obStatus = 0
+try { [void]$ob.Crc('/old-bridge.bin') } catch {
+    $sp = $_.Exception.PSObject.Properties['StatusCode']
+    if ($sp) { $obStatus = [int]$sp.Value }
+}
+Check 'pre-/crc bridge: Crc -> HttpError with status 404 (no such route)' `
+    ((Get-ThrownReason { $ob.Crc('/old-bridge.bin') }) -eq 'HttpError' -and $obStatus -eq 404) $obStatus
+Check 'pre-/crc bridge: VerifyCrc lets the 404 out too (strict)' `
+    ((Get-ThrownReason { $ob.VerifyCrc($data, '/old-bridge.bin') }) -eq 'HttpError')
+Check 'pre-/crc bridge: Verify falls back to /sum -> true (the 1.0.0 verdict)' `
+    ($ob.Verify($data, '/old-bridge.bin'))
+Check 'pre-/crc bridge: the fallback still catches a difference' `
+    (-not $ob.Verify([byte[]](1..100), '/old-bridge.bin'))
+Check 'pre-/crc bridge: Verify of a missing file throws (fails both ways)' `
+    ((Get-ThrownReason { $ob.Verify($data, '/no-such.bin') }) -eq 'NextRefused')
 
 [System.IO.File]::WriteAllBytes($push, [byte[]](1..100))
 Check 'Verify: false once the local file differs' `

--- a/tests/test_powershell_module.py
+++ b/tests/test_powershell_module.py
@@ -17,6 +17,11 @@ Six bridges:
   BROKEN - one seat whose /crc fails to open the file it just accepted
            (the OTHER meaning of that 502; PS-Send must not blame the
            listener's age, and /sum still settles the verdict).
+  PRECRC - not a NextSyncHttpBridge at all but a Flask app shaped like a
+           ZX-Next-Unite bridge from before 9.7.2: /put and /sum with the
+           real routes' JSON and NO /crc route, so Flask's own 404 is what
+           the module's Verify() must swallow on its way to the /sum
+           fallback (the strict Crc() surfaces it as HttpError 404).
   (dead) - a port nothing listens on (BridgeUnreachable).
 
 The PS driver (test_powershell_module.ps1) runs under EVERY PowerShell
@@ -33,6 +38,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import zlib
 
@@ -47,6 +53,7 @@ OSP_PORT = 18592
 DEAD_PORT = 18593
 OLD_PORT = 18594          # one seat whose listener predates the crc op
 BROKEN_PORT = 18595       # one seat whose /crc cannot open the file it holds
+OLDBRIDGE_PORT = 18596    # a BRIDGE that predates the /crc route (Unite < 9.7.2)
 TOKEN = "t0ken-t0ken-t0ken"
 
 ok = True
@@ -255,6 +262,54 @@ class SingleSeatAdapter:
         return self.seat.run(op, a1, a2, body=body)
 
 
+class PreCrcBridge:
+    """A bridge from before the /crc route existed (ZX-Next-Unite < 9.7.2),
+    as a bare Flask app rather than a NextSyncHttpBridge (which always
+    registers /crc): /status, /put and /sum answer with the real routes'
+    JSON shapes, everything else - /crc included - gets Flask's genuine
+    404 page. The module's Verify() must treat that 404 as "no crc here"
+    and fall back to /sum; its strict Crc() must surface it as HttpError."""
+
+    def __init__(self, port):
+        from flask import Flask, jsonify, request
+        from werkzeug.serving import make_server
+        self.files = {}
+        app = Flask("pre-crc-bridge")
+
+        @app.route("/status")
+        def _status():
+            return jsonify({"ok": True, "listening": True, "connected": True,
+                            "current": "C", "drives": ["C"], "partitions": 1,
+                            "inflight": 0})
+
+        @app.route("/put", methods=["POST", "PUT"])
+        def _put():
+            p = request.args.get("path", "")
+            self.files[p] = request.get_data()
+            return jsonify({"ok": True, "path": p, "bytes": len(self.files[p])})
+
+        @app.route("/sum")
+        def _sum():
+            p = request.args.get("path", "")
+            data = self.files.get(p)
+            if data is None:
+                return jsonify({"ok": False, "error": f"no such file {p}",
+                                "status": 502}), 502
+            return jsonify({"ok": True, "path": p, "bytes": len(data),
+                            "sum16": sum(data) & 0xFFFF})
+
+        self.port = port
+        self._server = make_server("127.0.0.1", port, app, threaded=True)
+        self._thread = threading.Thread(target=self._server.serve_forever,
+                                        daemon=True)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._server.shutdown()
+
+
 class OspAdapter:
     """The OTHER 401: reads work, writes are os-protected. Plus one verb per
     remaining classification - rmtree 501, ren 503, free('slow') hangs."""
@@ -320,6 +375,9 @@ def main():
     for b in bridges:
         okd, err = b.start()
         check(f"bridge on {b.port} started", okd, err)
+    precrc = PreCrcBridge(OLDBRIDGE_PORT)
+    precrc.start()
+    check(f"pre-/crc bridge on {OLDBRIDGE_PORT} started", precrc._thread.is_alive())
 
     tmp = tempfile.mkdtemp(prefix="zxnr-psmod-")
     try:
@@ -330,6 +388,7 @@ def main():
                 "-ModulePath", module,
                 "-PlainPort", str(PLAIN_PORT), "-TokenPort", str(TOKEN_PORT),
                 "-OspPort", str(OSP_PORT), "-DeadPort", str(DEAD_PORT),
+                "-OldBridgePort", str(OLDBRIDGE_PORT),
                 "-Token", TOKEN, "-TmpDir", tmp])
             sys.stdout.write(r.stdout)
             if r.stderr.strip():
@@ -472,6 +531,7 @@ def main():
     finally:
         for b in bridges:
             b.stop()
+        precrc.stop()
         shutil.rmtree(tmp, ignore_errors=True)
 
     print("\nRESULT:", "ALL PASS" if ok else "FAILURES")

--- a/zxnu_i18n.py
+++ b/zxnu_i18n.py
@@ -447,19 +447,6 @@ CATALOGS = {
             "Todavía localizando el .sync5 a enviar — un momento.",
         "Could not obtain the .sync5 build to send: {reason}":
             "No se pudo obtener el .sync5 a enviar: {reason}",
-        ("Update .sync5 on {machine}: v{old} → v{new}.\n\nThe new dot is "
-         "staged on the Next's SD card, read back and verified, then "
-         "swapped in; the previous dot is kept as sync5.bak (renaming it "
-         "back to sync5 is the one-step recovery). The session ends when "
-         "the update completes — run {command} on the Next again "
-         "afterwards.\n\nTarget directory on the Next:"):
-            ("Actualizar .sync5 en {machine}: v{old} → v{new}.\n\nEl nuevo "
-             "dot se prepara en la tarjeta SD del Next, se relee y "
-             "verifica, y después se sustituye; el dot anterior se "
-             "conserva como sync5.bak (renombrarlo de nuevo a sync5 es la "
-             "recuperación en un paso). La sesión termina cuando la "
-             "actualización se completa — ejecuta {command} de nuevo en "
-             "el Next después.\n\nDirectorio de destino en el Next:"),
         ("Push the new .sync5 (v{new}) to {machine}?\n\nThis machine's "
          "version is unknown (an older dot, or an old ZX Next Remote "
          "build — the two cannot be told apart), and the swap itself "
@@ -1728,19 +1715,6 @@ CATALOGS = {
             "Ainda a localizar o .sync5 a enviar — um momento.",
         "Could not obtain the .sync5 build to send: {reason}":
             "Não foi possível obter o .sync5 a enviar: {reason}",
-        ("Update .sync5 on {machine}: v{old} → v{new}.\n\nThe new dot is "
-         "staged on the Next's SD card, read back and verified, then "
-         "swapped in; the previous dot is kept as sync5.bak (renaming it "
-         "back to sync5 is the one-step recovery). The session ends when "
-         "the update completes — run {command} on the Next again "
-         "afterwards.\n\nTarget directory on the Next:"):
-            ("Atualizar o .sync5 em {machine}: v{old} → v{new}.\n\nO novo "
-             "dot é preparado no cartão SD do Next, relido e verificado, "
-             "e depois substituído; o dot anterior fica guardado como "
-             "sync5.bak (renomeá-lo de volta para sync5 é a recuperação "
-             "num passo). A sessão termina quando a atualização se "
-             "completa — executa {command} de novo no Next "
-             "depois.\n\nDiretório de destino no Next:"),
         ("Push the new .sync5 (v{new}) to {machine}?\n\nThis machine's "
          "version is unknown (an older dot, or an old ZX Next Remote "
          "build — the two cannot be told apart), and the swap itself "
@@ -3007,20 +2981,6 @@ CATALOGS = {
             "Wciąż trwa szukanie pliku .sync5 do wysłania — chwileczkę.",
         "Could not obtain the .sync5 build to send: {reason}":
             "Nie udało się uzyskać pliku .sync5 do wysłania: {reason}",
-        ("Update .sync5 on {machine}: v{old} → v{new}.\n\nThe new dot is "
-         "staged on the Next's SD card, read back and verified, then "
-         "swapped in; the previous dot is kept as sync5.bak (renaming it "
-         "back to sync5 is the one-step recovery). The session ends when "
-         "the update completes — run {command} on the Next again "
-         "afterwards.\n\nTarget directory on the Next:"):
-            ("Aktualizacja .sync5 na {machine}: v{old} → v{new}.\n\nNowe "
-             "polecenie dot jest przygotowywane na karcie SD Nexta, "
-             "odczytywane z powrotem i weryfikowane, a następnie "
-             "podmieniane; poprzednie polecenie dot zostaje zachowane "
-             "jako sync5.bak (zmiana jego nazwy z powrotem na sync5 to "
-             "odzyskanie w jednym kroku). Sesja kończy się po zakończeniu "
-             "aktualizacji — uruchom potem {command} na Nexcie "
-             "ponownie.\n\nKatalog docelowy na Nexcie:"),
         ("Push the new .sync5 (v{new}) to {machine}?\n\nThis machine's "
          "version is unknown (an older dot, or an old ZX Next Remote "
          "build — the two cannot be told apart), and the swap itself "
@@ -4288,19 +4248,6 @@ CATALOGS = {
             "Сборка .sync5 для отправки ещё ищется — минутку.",
         "Could not obtain the .sync5 build to send: {reason}":
             "Не удалось получить файл .sync5 для отправки: {reason}",
-        ("Update .sync5 on {machine}: v{old} → v{new}.\n\nThe new dot is "
-         "staged on the Next's SD card, read back and verified, then "
-         "swapped in; the previous dot is kept as sync5.bak (renaming it "
-         "back to sync5 is the one-step recovery). The session ends when "
-         "the update completes — run {command} on the Next again "
-         "afterwards.\n\nTarget directory on the Next:"):
-            ("Обновление .sync5 на {machine}: v{old} → v{new}.\n\nНовая "
-             "dot-команда записывается на SD-карту Next, считывается "
-             "обратно и проверяется, затем подменяется; прежняя "
-             "dot-команда сохраняется как sync5.bak (переименование "
-             "обратно в sync5 — восстановление в один шаг). Сессия "
-             "завершится по окончании обновления — после этого снова "
-             "запустите {command} на Next.\n\nЦелевой каталог на Next:"),
         ("Push the new .sync5 (v{new}) to {machine}?\n\nThis machine's "
          "version is unknown (an older dot, or an old ZX Next Remote "
          "build — the two cannot be told apart), and the swap itself "
@@ -5567,19 +5514,6 @@ CATALOGS = {
             "Soubor .sync5 k odeslání se stále hledá — okamžik.",
         "Could not obtain the .sync5 build to send: {reason}":
             "Nepodařilo se získat soubor .sync5 k odeslání: {reason}",
-        ("Update .sync5 on {machine}: v{old} → v{new}.\n\nThe new dot is "
-         "staged on the Next's SD card, read back and verified, then "
-         "swapped in; the previous dot is kept as sync5.bak (renaming it "
-         "back to sync5 is the one-step recovery). The session ends when "
-         "the update completes — run {command} on the Next again "
-         "afterwards.\n\nTarget directory on the Next:"):
-            ("Aktualizace .sync5 na {machine}: v{old} → v{new}.\n\nNový "
-             "dot příkaz se nahraje na SD kartu Nextu, načte zpět a "
-             "ověří, a poté vymění; předchozí dot příkaz zůstane uložen "
-             "jako sync5.bak (jeho přejmenování zpět na sync5 je obnova "
-             "jedním krokem). Relace skončí po dokončení aktualizace — "
-             "poté znovu spusťte {command} na Nextu.\n\nCílový adresář "
-             "na Nextu:"),
         ("Push the new .sync5 (v{new}) to {machine}?\n\nThis machine's "
          "version is unknown (an older dot, or an old ZX Next Remote "
          "build — the two cannot be told apart), and the swap itself "
@@ -6846,20 +6780,6 @@ CATALOGS = {
             "Toujours en train de localiser le .sync5 à envoyer — un instant.",
         "Could not obtain the .sync5 build to send: {reason}":
             "Impossible d'obtenir le .sync5 à envoyer : {reason}",
-        ("Update .sync5 on {machine}: v{old} → v{new}.\n\nThe new dot is "
-         "staged on the Next's SD card, read back and verified, then "
-         "swapped in; the previous dot is kept as sync5.bak (renaming it "
-         "back to sync5 is the one-step recovery). The session ends when "
-         "the update completes — run {command} on the Next again "
-         "afterwards.\n\nTarget directory on the Next:"):
-            ("Mise à jour de .sync5 sur {machine} : v{old} → "
-             "v{new}.\n\nLa nouvelle commande dot est déposée sur la "
-             "carte SD du Next, relue et vérifiée, puis mise en place ; "
-             "la commande dot précédente est conservée sous le nom "
-             "sync5.bak (la renommer en sync5 est la récupération en une "
-             "étape). La session se termine quand la mise à jour est "
-             "finie — relancez ensuite {command} sur le "
-             "Next.\n\nRépertoire cible sur le Next :"),
         ("Push the new .sync5 (v{new}) to {machine}?\n\nThis machine's "
          "version is unknown (an older dot, or an old ZX Next Remote "
          "build — the two cannot be told apart), and the swap itself "


### PR DESCRIPTION
## What

Two loose ends from #326:

- **The `Verify()` fallback for a bridge that predates `/crc` is now tested.** Every `NextSyncHttpBridge` registers `/crc`, so `tests/test_powershell_module.py` stands up a bare Flask app shaped like a ZX-Next-Unite bridge from before 9.7.2 (`/status`, `/put`, `/sum` with the real routes' JSON, nothing else). The driver pins, under Windows PowerShell 5.1 and pwsh 7, that `Crc()`/`VerifyCrc()` surface Flask's genuine 404 as `HttpError` (status 404) while `Verify()` falls through to the `/sum` verdict exactly as 1.0.0 did, still catches a difference, and still throws for a missing file.
- **The dead `.sync5` update dialog key is gone from all six catalogs.** Nothing has rendered "Update .sync5 on {machine}: … Target directory on the Next:" since 9.7.2 removed the `.sync5` target prompt; the tripwire only requires every live string to be translated, so nothing else moves.

No version bump: tests and a catalog cleanup only. 9.7.5 stays the untagged version on main.

## Testing

- `tests/test_powershell_module.py`: the new pre-`/crc` bridge checks pass under both shells — **ALL PASS**.
- `tests/test_i18n.py`, `tests/test_nextsync_verify_crc.py` — **ALL PASS** after the removal.
- `python tests/run_all.py`: all suites green; `ruff check .` and PSScriptAnalyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
