### PR TITLE
wizard: the health probe's late emit no longer tracebacks at exit

### DIFF
--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -439,7 +439,8 @@ wiz._dismiss()
 # ── Health check (wizard menu links row) ─────────────────────────────────
 host._hdfmonkey_binary_found = lambda: False
 wiz._health_ip = "192.168.1.50"          # probe result already cached
-wiz.show_health()
+wiz._health_ip_pending = True            # ...and no probe thread: keeps the
+wiz.show_health()                        # test offline and its exit quiet
 txt = "\n".join(wiz.bubble._pages)
 check("health check lists all six items",
       all(wc.wizard_tr(k, "en") in txt

--- a/zxnu_wizard.py
+++ b/zxnu_wizard.py
@@ -1011,7 +1011,16 @@ class WizardManager(QObject):
                     ip = detect_local_ipv4()[3]
                 except Exception:
                     ip = None
-                sig.emit(ip or "")
+                # The emit can race application shutdown: the wizard (and
+                # the window that owns it) may be gone by the time a slow
+                # DNS resolve returns, and PySide then raises "Signal
+                # source has been deleted" out of this daemon thread —
+                # nothing is left to update, so swallow it (the same rule
+                # getit_run_in_thread applies to its own late emits).
+                try:
+                    sig.emit(ip or "")
+                except RuntimeError:
+                    pass
 
             threading.Thread(target=_probe, daemon=True).start()
 


### PR DESCRIPTION
`show_health()` resolves the local IP on a daemon thread and emits the result to the wizard. When the process ends first (the test suite's interpreter exit), the wizard is already gone and PySide raises "Signal source has been deleted" out of the thread — two tracebacks after the suite's RESULT line, exit code untouched. The emit now swallows that `RuntimeError` (the rule `getit_run_in_thread` already applies to its late emits), and the wizard test marks the probe pending before `show_health()` so no thread starts at all: offline and quiet. Five consecutive runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
