### PR TITLE
9.7.17: bump pyproject.toml alongside ZX_NEXT_UNITE_VERSION

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "zx-next-unite"
 # MUST match ZX_NEXT_UNITE_VERSION in zxnu_config.py — the release workflow
 # gates on it (same rule as the git tag).
-version = "9.7.16"
+version = "9.7.17"
 description = "GUI toolbox for the ZX Spectrum Next: SD-card/HDF image explorer, NextSync Wi-Fi file sync + Remote Explorer & HTTP bridge, and built-in software browsing via GetIt, ZXDB and zxArt"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`149adeea` bumped `zxnu_config.py` to 9.7.17 but left `pyproject.toml` at 9.7.16, so pushing `v9.7.17` failed `release.yml`'s *Verify the tag matches ZX_NEXT_UNITE_VERSION and pyproject.toml* step and no release was created.

Both are bumped in the same commit for every prior release (see `1e7f5b16`, `0571614f`); this restores that. The tag will be moved to the merge commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)